### PR TITLE
Fix support for editorconfig with indent style = 'tab'

### DIFF
--- a/lib/beautify.coffee
+++ b/lib/beautify.coffee
@@ -253,7 +253,7 @@ beautify = ->
       editorConfigOptions.indent_char = "\t"
       editorConfigOptions.indent_with_tabs = true
       if (editorConfigOptions.tab_width)
-          editorConfigOptions.indent_size = config.tab_width
+          editorConfigOptions.indent_size = editorConfigOptions.tab_width
 
     # Get all options in configuration files from this directory upwards to root
     projectOptions = []


### PR DESCRIPTION
When running atom-beautify with editorconfig and indent style 'tab', it crashes with "cannot access attribute of undefined". See lib/beautify.coffee, line 256.

Replace non-existant config with editorConfigOptions and it works fine.
