### PR TITLE
disable beautification of specific languages

### DIFF
--- a/lib/beautify.coffee
+++ b/lib/beautify.coffee
@@ -318,6 +318,7 @@ plugin.configDefaults = _.merge(
   beautifyEntireFileOnSave: true
   muteUnsupportedLanguageErrors: false
   muteAllErrors: false
+  disabledLanguages: []
 , defaultLanguageOptions)
 plugin.activate = ->
   handleSaveEvent()

--- a/lib/language-options.coffee
+++ b/lib/language-options.coffee
@@ -155,6 +155,8 @@ module.exports =
     # Beautify!
     unsupportedGrammar = false
     options = undefined
+    if atom.config.get("atom-beautify.disabledLanguages").indexOf(grammar) > - 1
+      return
     switch grammar
       # Treat JSON as JavaScript, because it will support comments.
       # And Glavin001 has tested JSON beauifying with beautifyJS.


### PR DESCRIPTION
Created option to disable beautification of specific languages.  This is
useful when a particular language formatter is broken, but you still
want beautifyEntireFileOnSave for other languages.

Closes https://github.com/Glavin001/atom-beautify/issues/118
