### PR TITLE
updating selectors to the new atom API

### DIFF
--- a/menus/atom-beautify.cson
+++ b/menus/atom-beautify.cson
@@ -1,6 +1,6 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
 'context-menu':
-  '.workspace .editor:not(.mini)':
+  'atom-workspace atom-text-editor:not(.mini)':
     'Enable atom-beautify': 'beautify:beautify-editor'
   '.tree-view .file > .name':
     'Beautify File': 'beautify:beautify-file'


### PR DESCRIPTION
atom-beautify
  menus/atom-beautify.cson
    Use the `atom-workspace` tag instead of the `workspace` class.
    Use the `atom-text-editor` tag instead of the `editor` class.