### PR TITLE
Updates context-menu to use new api

### DIFF
--- a/menus/atom-beautify.cson
+++ b/menus/atom-beautify.cson
@@ -1,12 +1,15 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
 'context-menu':
-  'atom-workspace atom-text-editor:not(.mini)':
-    'Beautify editor contents': 'beautify:beautify-editor'
-    'Debug Atom Beautify': 'beautify:help-debug-editor'
-  '.tree-view .file > .name':
-    'Beautify File': 'beautify:beautify-file'
-#  '.tree-view .directory > .header > .name':
-#    'Beautify Directory': 'beautify:beautify-directory'
+  'atom-workspace atom-text-editor:not(.mini)': [
+    {label: 'Beautify editor contents', command: 'beautify:beautify-editor'}
+    {label: 'Debug Atom Beautify', command: 'beautify:help-debug-editor'}
+  ]
+  '.tree-view .file > .name': [
+    {label: 'Beautify File', command: 'beautify:beautify-file'}
+  ]
+#  '.tree-view .directory > .header > .name': [
+#    {label: 'Beautify Directory', command: 'beautify:beautify-directory'}
+#  ]
 
 'menu': [
   {


### PR DESCRIPTION
This removes the warning "ContextMenuManager::add has changed to take a single object as its argument. Please see https://atom.io/docs/api/latest/ContextMenuManager for more info." which is one of the messages described in #267 