### PR TITLE
Enable typescript-formatter defaults.

### DIFF
--- a/examples/simple-jsbeautifyrc/typescript/expected/test.ts
+++ b/examples/simple-jsbeautifyrc/typescript/expected/test.ts
@@ -1,8 +1,8 @@
 module TestModule {
-	export class A {
-		constructor(private a: string) {
-		}
-	}
-	export class B extends A {
-	}
+  export class A {
+    constructor(private a: string) {
+    }
+  }
+  export class B extends A {
+  }
 };

--- a/examples/simple-jsbeautifyrc/typescript/expected/test2.ts
+++ b/examples/simple-jsbeautifyrc/typescript/expected/test2.ts
@@ -1,56 +1,56 @@
 module XYZ {
   interface I {
-		x: number,
+    x: number,
    y,
-	z
+  z
 }
 
-var zZz={
-	a: 123,
-	b: 456
+var zZz = {
+  a: 123,
+  b: 456
 };
 
 enum En {
-	AB,
-	CD
+  AB,
+  CD
 }
 
-var y=3;
+var y = 3;
 
-switch(y {
-	case X:
-		console.log("x");
-		break;
-	default:
-		console.log("y");
+switch (y {
+  case X:
+    console.log("x");
+    break;
+  default:
+    console.log("y");
 }
 
-if(x===3) {
-	if(y===4) {
-		console.log("hey");
-	}
-	console.log("x");
-	x=y.hey
-	.b
-	.c
-	.d;
+if (x === 3) {
+  if (y === 4) {
+    console.log("hey");
+  }
+  console.log("x");
+  x = y.hey
+  .b
+  .c
+  .d;
 
 
-	export class X {
-		private x: number;
+  export class X {
+    private x: number;
 
-		constructor() {
-			console.log("hi");
-		}
+    constructor() {
+      console.log("hi");
+    }
 
-		public mem() {
-			console.log("yes");
-		}
-	}
+    public mem() {
+      console.log("yes");
+    }
+  }
 
-	function xyz() {
-		function mem() {
-			console.log("yes");
-		}
-	}
+  function xyz() {
+    function mem() {
+      console.log("yes");
+    }
+  }
 }

--- a/src/beautifiers/typescript-formatter.coffee
+++ b/src/beautifiers/typescript-formatter.coffee
@@ -11,8 +11,9 @@ module.exports = class TypeScriptFormatter extends Beautifier
         return new @Promise((resolve, reject) =>
 
             format = require("typescript-formatter/lib/formatter")
+            formatterUtils = require("typescript-formatter/lib/utils")
 
-            opts = {}
+            opts = formatterUtils.createDefaultFormatCodeOptions()
             opts.TabSize = options.tab_width or options.indent_size
             opts.IndentSize = options.indent_size
             opts.IndentStyle = 'space'


### PR DESCRIPTION
These defaults were in place until 25e2a754d58. Without them, there is an unfortunate lack of whitespace (IMO).