### PR TITLE
Fixing faux possessive 'it is' -> 'its', and some small language fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Or Settings/Preferences ➔ Packages ➔ Search for `atom-beautify`
 
 Open the [Command Palette](https://github.com/atom/command-palette), and type `Beautify`.
 
-It will only beautify selected text, if a selection is found - if not, the whole file will be beautified.
+It will only beautify selected text if a selection is found -- if not, the whole file will be beautified.
 
 ### Shortcut
 
@@ -86,10 +86,9 @@ For example:
 
 ### Package Options
 
-Each language and all of their respective beautifier's options
-are fully documented in Atom Beautify Package Settings Panel.
-There are much too many to document them all here.
-Here are a few key options that you may use:
+Each language and its beautifier's options are fully documented in the Atom
+Beautify package settings panel. There are far too many to document them all
+here. Here are a few key options that you may use:
 
 - `beautifyOnSave`  (Default *false*)
 You can also choose to beautify on every file save.
@@ -108,14 +107,11 @@ Do not show the *Atom Beautify Error Messages* panel
 for any of the errors occurring while beautifying.
 
 - `analytics`  (Default *true*)
-There is [Segment.io](https://segment.io/),
-which forwards the data to [Google Analytics](http://www.google.com/analytics/),
-to track what languages
-are being used the most and other stats.
-Everything is anonymized and no personal information,
-such as source code, is sent.
-See https://github.com/Glavin001/atom-beautify/issues/47
-for more details.
+There is [Segment.io](https://segment.io/) which forwards data to [Google
+Analytics](http://www.google.com/analytics/) to track what languages are being
+used the most, as well as other stats. Everything is anonymized and no personal
+information, such as source code, is sent.
+See https://github.com/Glavin001/atom-beautify/issues/47 for more details.
 
 ## Configuration
 
@@ -126,13 +122,13 @@ Edit your `.jsbeautifyrc` file in any of the following locations:
 - Same directory as current file
 - Project root  
 `atom-beautify` will recursively look up from the current file's directory to find `.jsbeautifyrc`.
-- Your User's Home directory
+- Your user's home directory
 
 **Note**: *Comments are supported in `.jsbeautifyrc` thanks to [strip-json-comments](https://github.com/sindresorhus/strip-json-comments).*
 
-See examples of both way inside [`examples/`](https://github.com/donaldpipowitch/atom-beautify/tree/master/examples)
+See examples of both ways inside [`examples/`](https://github.com/donaldpipowitch/atom-beautify/tree/master/examples)
 
-Option table is available at the [js-beautify repo](https://github.com/beautify-web/js-beautify#options).
+An option table is available at the [js-beautify repo](https://github.com/beautify-web/js-beautify#options).
 
 ### Simple
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
     {
       "name": "Filipe Silva",
       "url": "https://github.com/filipesilva"
+    },
+    {
+      "name": "Ramón Cahenzli",
+      "url": "https://github.com/psy-q"
     }
   ],
   "engines": {

--- a/src/beautifiers/index.coffee
+++ b/src/beautifiers/index.coffee
@@ -29,7 +29,7 @@ module.exports = class Beautifiers
     ###
       List of beautifier names
 
-      To register a beautifier add it's name here
+      To register a beautifier add its name here
     ###
     beautifierNames : [
         'uncrustify'
@@ -470,7 +470,7 @@ module.exports = class Beautifiers
                         title = "Atom Beautify could not find a supported beautifier for this file"
                         detail = """
                                  Atom Beautify could not determine a supported beautifier to handle this file with grammar \"#{grammar}\" and extension \"#{fileExtension}\". \
-                                 If you would like to request support for this file and it's language, please create an issue for Atom Beautify at #{repoBugsUrl}
+                                 If you would like to request support for this file and its language, please create an issue for Atom Beautify at #{repoBugsUrl}
                                  """
 
                         atom?.notifications.addWarning(title, {
@@ -638,7 +638,7 @@ module.exports = class Beautifiers
         userHome = @getUserHome()
 
 
-        # FAKEFILENAME forces `path` to treat as file path and it's parent directory
+        # FAKEFILENAME forces `path` to treat as file path and its parent directory
         # is the userHome. See implementation of findConfig
         # and how path.dirname(DIRECTORY) returns the parent directory of DIRECTORY
         homeOptions = @getConfig(path.join(userHome, "FAKEFILENAME"), false)


### PR DESCRIPTION
Just spotted that in a notification about a missing beautifier, so I thought I'd correct it.