### PR TITLE
add language scopes to atom language config gets

### DIFF
--- a/src/languages/css.coffee
+++ b/src/languages/css.coffee
@@ -1,6 +1,7 @@
 # Get Atom defaults
-tabLength = atom?.config.get('editor.tabLength') ? 4
-softTabs = atom?.config.get('editor.softTabs') ? true
+scope = ['source.css']
+tabLength = atom?.config.get('editor.tabLength', scope: scope) ? 4
+softTabs = atom?.config.get('editor.softTabs', scope: scope) ? true
 defaultIndentSize = (if softTabs then tabLength else 1)
 defaultIndentChar = (if softTabs then " " else "\t")
 defaultIndentWithTabs = not softTabs

--- a/src/languages/html.coffee
+++ b/src/languages/html.coffee
@@ -1,6 +1,7 @@
 # Get Atom defaults
-tabLength = atom?.config.get('editor.tabLength') ? 4
-softTabs = atom?.config.get('editor.softTabs') ? true
+scope = ['text.html']
+tabLength = atom?.config.get('editor.tabLength', scope: scope) ? 4
+softTabs = atom?.config.get('editor.softTabs', scope: scope) ? true
 defaultIndentSize = (if softTabs then tabLength else 1)
 defaultIndentChar = (if softTabs then " " else "\t")
 defaultIndentWithTabs = not softTabs

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -1,6 +1,7 @@
 # Get Atom defaults
-tabLength = atom?.config.get('editor.tabLength') ? 4
-softTabs = atom?.config.get('editor.softTabs') ? true
+scope = ['source.js']
+tabLength = atom?.config.get('editor.tabLength', scope: scope) ? 4
+softTabs = atom?.config.get('editor.softTabs', scope: scope) ? true
 defaultIndentSize = (if softTabs then tabLength else 1)
 defaultIndentChar = (if softTabs then " " else "\t")
 defaultIndentWithTabs = not softTabs
@@ -27,7 +28,7 @@ module.exports = {
   defaultBeautifier: "JS Beautify"
 
   ###
-  
+
   ###
   options:
     # JavaScript

--- a/src/languages/python.coffee
+++ b/src/languages/python.coffee
@@ -1,6 +1,7 @@
 # Get Atom defaults
-tabLength = atom?.config.get('editor.tabLength') ? 4
-softTabs = atom?.config.get('editor.softTabs') ? true
+scope = ['source.python']
+tabLength = atom?.config.get('editor.tabLength', scope: scope) ? 4
+softTabs = atom?.config.get('editor.softTabs', scope: scope) ? true
 defaultIndentSize = (if softTabs then tabLength else 1)
 defaultIndentChar = (if softTabs then " " else "\t")
 defaultIndentWithTabs = not softTabs

--- a/src/languages/ruby.coffee
+++ b/src/languages/ruby.coffee
@@ -1,6 +1,7 @@
 # Get Atom defaults
-tabLength = atom?.config.get('editor.tabLength') ? 4
-softTabs = atom?.config.get('editor.softTabs') ? true
+scope = ['source.ruby']
+tabLength = atom?.config.get('editor.tabLength', scope: scope) ? 4
+softTabs = atom?.config.get('editor.softTabs', scope: scope) ? true
 defaultIndentSize = (if softTabs then tabLength else 1)
 defaultIndentChar = (if softTabs then " " else "\t")
 defaultIndentWithTabs = not softTabs

--- a/src/languages/sql.coffee
+++ b/src/languages/sql.coffee
@@ -1,6 +1,7 @@
 # Get Atom defaults
-tabLength = atom?.config.get('editor.tabLength') ? 4
-softTabs = atom?.config.get('editor.softTabs') ? true
+scope = ['source.sql']
+tabLength = atom?.config.get('editor.tabLength', scope: scope) ? 4
+softTabs = atom?.config.get('editor.softTabs', scope: scope) ? true
 defaultIndentSize = (if softTabs then tabLength else 1)
 defaultIndentChar = (if softTabs then " " else "\t")
 defaultIndentWithTabs = not softTabs


### PR DESCRIPTION
Atom's config is not fully supported at the moment. Config like the following is currently ignored:

```cson
"*":
  welcome:
    showOnStartup: false
  linter:
    lintOnChange: false
    clearOnChange: true
  core: {}
".shell.source":
  editor:
    tabLength: 4
".python.source":
  editor:
    tabLength: 4
".java.source":
  editor:
    tabLength: 4
".gfm.source":
  editor:
    showInvisibles: false
    softWrap: true
    tabLength: 4
```

atom-beautify currently ignores the language specific tabLength and other settings and uses the default tabLength of 2 in this case. This commit fixes that issue by specifying the scope in the language files.