### PR TITLE
bug/perltidy

### DIFF
--- a/src/beautifiers/perltidy.coffee
+++ b/src/beautifiers/perltidy.coffee
@@ -23,7 +23,7 @@ module.exports = class PerlTidy extends Beautifier
       '--standard-output'
       '--standard-error-output'
       '--quiet'
-      "--profile=#{options.perltidy_profile}" if options.perltidy_profile?
+      "--profile=#{options.perltidy_profile}" if options.perltidy_profile?.length
       @tempFile("input", text)
       ], help: {
       link: "http://perltidy.sourceforge.net/"

--- a/src/beautify.coffee
+++ b/src/beautify.coffee
@@ -368,7 +368,7 @@ debug = () ->
     addInfo('Final Options', "\n" +
     "Final combined options that are used\n" +
     "```json\n#{JSON.stringify(finalOptions, undefined, 4)}\n```")
-    
+
     addInfo('Package Settings', "\n" +
     "The raw package settings options\n" +
     "```json\n#{JSON.stringify(atom.config.get('atom-beautify'), undefined, 4)}\n```")
@@ -430,8 +430,15 @@ handleSaveEvent = ->
         beautifyFilePath(filePath, ->
           buffer.reload()
           logger.verbose('restore editor positions', posArray,origScrollTop)
-          setCursors(editor, posArray)
-          editor.setScrollTop(origScrollTop)
+          # Let the scrollTop setting run after all the save related stuff is run,
+          # otherwise setScrollTop is not working, probably because the cursor
+          # addition happens asynchronously
+          setTimeout ( ->
+            setCursors(editor, posArray)
+            editor.setScrollTop(origScrollTop)
+            # console.log "setScrollTop"
+            return
+          ), 0
         )
       )
     plugin.subscribe disposable
@@ -445,4 +452,3 @@ plugin.activate = ->
   atom.commands.add "atom-workspace", "atom-beautify:help-debug-editor", debug
   atom.commands.add ".tree-view .file .name", "atom-beautify:beautify-file", beautifyFile
   atom.commands.add ".tree-view .directory .name", "atom-beautify:beautify-directory", beautifyDirectory
-


### PR DESCRIPTION
should cover #479 by not passing the --profile option when an empty string is passed as its argument.