### PR TITLE
Properly dispose of event subscriptions

### DIFF
--- a/src/beautify.coffee
+++ b/src/beautify.coffee
@@ -4,6 +4,7 @@ pkg = require('../package.json')
 
 # Dependencies
 plugin = module.exports
+{CompositeDisposable} = require 'atom'
 _ = require("lodash")
 Beautifiers = require("./beautifiers")
 beautifier = new Beautifiers()
@@ -447,9 +448,13 @@ handleSaveEvent = ->
 Subscriber.extend plugin
 plugin.config = _.merge(require('./config.coffee'), defaultLanguageOptions)
 plugin.activate = ->
-  handleSaveEvent()
+  @subscriptions = new CompositeDisposable
+  @subscriptions.add handleSaveEvent()
   plugin.subscribe atom.config.observe("atom-beautify.beautifyOnSave", handleSaveEvent)
-  atom.commands.add "atom-workspace", "atom-beautify:beautify-editor", beautify
-  atom.commands.add "atom-workspace", "atom-beautify:help-debug-editor", debug
-  atom.commands.add ".tree-view .file .name", "atom-beautify:beautify-file", beautifyFile
-  atom.commands.add ".tree-view .directory .name", "atom-beautify:beautify-directory", beautifyDirectory
+  @subscriptions.add atom.commands.add "atom-workspace", "atom-beautify:beautify-editor", beautify
+  @subscriptions.add atom.commands.add "atom-workspace", "atom-beautify:help-debug-editor", debug
+  @subscriptions.add atom.commands.add ".tree-view .file .name", "atom-beautify:beautify-file", beautifyFile
+  @subscriptions.add atom.commands.add ".tree-view .directory .name", "atom-beautify:beautify-directory", beautifyDirectory
+
+plugin.deactivate = ->
+  @subscriptions.dispose()

--- a/src/beautify.coffee
+++ b/src/beautify.coffee
@@ -450,7 +450,7 @@ plugin.config = _.merge(require('./config.coffee'), defaultLanguageOptions)
 plugin.activate = ->
   @subscriptions = new CompositeDisposable
   @subscriptions.add handleSaveEvent()
-  plugin.subscribe atom.config.observe("atom-beautify.beautifyOnSave", handleSaveEvent)
+  @subscriptions.add plugin.subscribe atom.config.observe("atom-beautify.beautifyOnSave", handleSaveEvent)
   @subscriptions.add atom.commands.add "atom-workspace", "atom-beautify:beautify-editor", beautify
   @subscriptions.add atom.commands.add "atom-workspace", "atom-beautify:help-debug-editor", debug
   @subscriptions.add atom.commands.add ".tree-view .file .name", "atom-beautify:beautify-file", beautifyFile


### PR DESCRIPTION
This PR updates atom-beautify so that it properly disposes of all its subscriptions by adding [a standard `deactivate` for clean-up](https://atom.io/docs/v1.0.4/hacking-atom-package-word-count#source-code). This should prevent memory leaks when updating the package, allow it to report updates successfully (see https://github.com/atom/settings-view/issues/532), and avoid potential issues with commands not working immediately after an update.