### PR TITLE
Can configure a fallback for unsupported language

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
     {
       "name": "Clemens Damke",
       "url": "https://github.com/Cortys"
+    },
+    {
+      "name": "Chris Bigelow",
+      "url": "https://github.com/seebigs"
     }
   ],
   "engines": {

--- a/src/beautifiers/index.coffee
+++ b/src/beautifiers/index.coffee
@@ -325,6 +325,12 @@ module.exports = class Beautifiers extends EventEmitter
         languages = @languages.getLanguages({grammar, extension: fileExtension})
         logger.verbose(languages, grammar, fileExtension)
 
+        # use fallback if configured
+        unsupportedLanguageFallback = atom.config.get("atom-beautify.unsupportedLanguageFallback")
+        if languages.length < 1 && unsupportedLanguageFallback.charAt(0) != '-'
+          languages = [require('../languages/' + unsupportedLanguageFallback)]
+          logger.verbose('Unsupported Language, fallback to:', unsupportedLanguageFallback)
+
         # Check if unsupported language
         if languages.length < 1
           unsupportedGrammar = true

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -1,3 +1,9 @@
+Languages = require('./languages/')
+
+langFallbackDefault = '- none (do not format) -'
+langFallbacks = new Languages().languageNames
+langFallbacks.unshift(langFallbackDefault)
+
 module.exports = {
   analytics :
     type : 'boolean'
@@ -28,4 +34,9 @@ module.exports = {
     type : 'boolean'
     default : false
     description : "Do not show any/all errors when they occur"
+  unsupportedLanguageFallback :
+    type : 'string'
+    default : langFallbackDefault
+    description : "Format any Unsupported Languages as the language you specify here"
+    enum : langFallbacks
 }


### PR DESCRIPTION
I often like to paste content into a new, unsaved window and beautify it. Unfortunately, this causes Atom Beautify to throw an error. I suggest an improvement that allows users to configure a fallback for any unsupported language type.

https://gist.github.com/seebigs/ff0fc0c71d6d9ea8a9e2