### PR TITLE
Add extra_liners option from js-beautify in Settings View

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -916,6 +916,36 @@ End output with newline (Supported by JS Beautify)
 }
 ```
 
+####  [HTML - Extra liners](#html---extra-liners) 
+
+**Namespace**: `html`
+
+**Key**: `extra_liners`
+
+**Default**: `head,body,/html`
+
+**Type**: `array`
+
+**Supported Beautifiers**:  [`JS Beautify`](#js-beautify) 
+
+**Description**:
+
+List of tags (defaults to [head,body,/html] that should have an extra newline before them. (Supported by JS Beautify)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "html": {
+        "extra_liners": [
+            "head",
+            "body",
+            "/html"
+        ]
+    }
+}
+```
+
 ####  [Java - Config Path](#java---config-path) 
 
 **Namespace**: `java`
@@ -4852,6 +4882,36 @@ End output with newline (Supported by JS Beautify)
 {
     "html": {
         "end_with_newline": false
+    }
+}
+```
+
+####  [HTML - Extra liners](#html---extra-liners) 
+
+**Namespace**: `html`
+
+**Key**: `extra_liners`
+
+**Default**: `head,body,/html`
+
+**Type**: `array`
+
+**Supported Beautifiers**:  [`JS Beautify`](#js-beautify) 
+
+**Description**:
+
+List of tags (defaults to [head,body,/html] that should have an extra newline before them. (Supported by JS Beautify)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "html": {
+        "extra_liners": [
+            "head",
+            "body",
+            "/html"
+        ]
     }
 }
 ```

--- a/src/languages/html.coffee
+++ b/src/languages/html.coffee
@@ -82,5 +82,11 @@ module.exports = {
       type: 'boolean'
       default: false
       description: "End output with newline"
+    extra_liners:
+      type: 'array'
+      default: ['head', 'body', '/html']
+      items:
+        type: 'string'
+      description: "List of tags (defaults to [head,body,/html] that should have an extra newline before them."
 
 }


### PR DESCRIPTION
Hi !

This PR add a "HTML - Extra liners" field in Settings View. 
See extra_liners option for HTML docs here : https://github.com/beautify-web/js-beautify#css--html

This option is already supported by atom-beautify but you need to edit your config file manually.
