### PR TITLE
Add two beautifiers: clang-format and yapf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# dev
+- Add [clang-format](http://clang.llvm.org/docs/ClangFormat.html) beautifier for C/C++/Obj-C languages.
+- Add [yapf](http://github.com/google/yapf) beautifier for Python.
+
 # v0.29.0
 - Closes [#447](https://github.com/Glavin001/atom-beautify/issues/447). Improved Handlebars language support
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
     {
       "name": "Clemens Damke",
       "url": "https://github.com/Cortys"
+    },
+    {
+      "name": "Zhang YANG",
+      "url": "https://github.com/ProgramFan"
     }
   ],
   "engines": {

--- a/src/beautifiers/clang-format.coffee
+++ b/src/beautifiers/clang-format.coffee
@@ -65,8 +65,8 @@ module.exports = class ClangFormat extends Beautifier
         @dumpToFile(dumpFile, text)
         ["--style=file"]
         ], help: {
-        link: "https://clang.llvm.org/docs/ClangFormat.html"
-        }).finally( =>
+          link: "https://clang.llvm.org/docs/ClangFormat.html"
+        }).finally( ->
           fs.unlink(dumpFile)
         )
     )

--- a/src/beautifiers/clang-format.coffee
+++ b/src/beautifiers/clang-format.coffee
@@ -12,9 +12,9 @@ module.exports = class ClangFormat extends Beautifier
   name: "clang-format"
 
   options: {
-    "C++": true
-    "C": true
-    "Objective-C": true
+    "C++": false
+    "C": false
+    "Objective-C": false
   }
 
   ###

--- a/src/beautifiers/clang-format.coffee
+++ b/src/beautifiers/clang-format.coffee
@@ -1,0 +1,60 @@
+###
+Requires clang-format (https://clang.llvm.org)
+###
+
+"use strict"
+Beautifier = require('./beautifier')
+path = require('path')
+fs = require('fs')
+
+module.exports = class ClangFormat extends Beautifier
+
+  name: "clang-format"
+
+  options: {
+    "C++": true
+    "C": true
+    "Objective-C": true
+  }
+
+  ###
+    Dump contents to a given file
+  ###
+  dumpToFile: (name = "atom-beautify-dump", contents = "") ->
+    return new Promise((resolve, reject) =>
+      fs.open(name, "w", (err, fd) =>
+        @debug('dumpToFile', name, err, fd)
+        return reject(err) if err
+        fs.write(fd, contents, (err) ->
+          return reject(err) if err
+          fs.close(fd, (err) ->
+            return reject(err) if err
+            resolve(name)
+          )
+        )
+      )
+    )
+
+  beautify: (text, language, options) ->
+    return new @Promise((resolve, reject) ->
+      editor = atom.workspace.getActiveTextEditor()
+      if editor?
+        fullPath = editor.getPath()
+        currDir = path.dirname(fullPath)
+        currFile = path.basename(fullPath)
+        dumpFile = path.join(currDir, ".atom-beautify.#{currFile}")
+        resolve dumpFile
+      else
+        reject(new Error("No active editor found!"))
+    )
+    .then((dumpFile) =>
+      # console.log("clang-format", dumpFile)
+      @run("clang-format", [
+        @dumpToFile(dumpFile, text)
+        ["--style=file"]
+        ], help: {
+        link: "https://clang.llvm.org/docs/ClangFormat.html"
+      }).then( =>
+        fs.unlinkSync(dumpFile)
+      )
+    )

--- a/src/beautifiers/clang-format.coffee
+++ b/src/beautifiers/clang-format.coffee
@@ -61,7 +61,7 @@ module.exports = class ClangFormat extends Beautifier
     )
     .then((dumpFile) =>
       # console.log("clang-format", dumpFile)
-      @run("clang-format", [
+      return @run("clang-format", [
         @dumpToFile(dumpFile, text)
         ["--style=file"]
         ], help: {

--- a/src/beautifiers/index.coffee
+++ b/src/beautifiers/index.coffee
@@ -37,6 +37,7 @@ module.exports = class Beautifiers extends EventEmitter
     'autopep8'
     'coffee-formatter'
     'coffee-fmt'
+    'clang-format'
     'htmlbeautifier'
     'csscomb'
     'gherkin'
@@ -54,6 +55,7 @@ module.exports = class Beautifiers extends EventEmitter
     'sqlformat'
     'tidy-markdown'
     'typescript-formatter'
+    'yapf'
   ]
 
   ###

--- a/src/beautifiers/yapf.coffee
+++ b/src/beautifiers/yapf.coffee
@@ -21,5 +21,5 @@ module.exports = class Yapf extends Beautifier
       ["--style=pep8"]
       @tempFile("input", text)
       ], help: {
-      link: "https://github.com/google/yapf"
+        link: "https://github.com/google/yapf"
       })

--- a/src/beautifiers/yapf.coffee
+++ b/src/beautifiers/yapf.coffee
@@ -1,0 +1,25 @@
+###
+Requires https://github.com/google/yapf
+###
+
+"use strict"
+Beautifier = require('./beautifier')
+
+module.exports = class Yapf extends Beautifier
+
+  name: "yapf"
+
+  # I decide to support no options since yapf is configured using its
+  # own configure file.
+  options: {
+    Python: false
+  }
+
+  beautify: (text, language, options) ->
+    # console.log('yapf', options, text, language)
+    @run("yapf", [
+      ["--style=pep8"]
+      @tempFile("input", text)
+      ], help: {
+      link: "https://github.com/google/yapf"
+      })


### PR DESCRIPTION
clang-format is a semantics-aware C/C++/Objective-C beautifier from clang compiler tool. It produces correct code even for very complicated sources. So this can be an alternative to uncrusify for C/C++/Obj-C.

yapf (Yet Another Python Formatter) is a python formatter using the same format algorithm as clang-format. It's said to produce better looking pep8-conforming code than autopep8. So someone might want it.

This pull request implements two beautifiers for the above code formatters. I have tested it with my own code base and it works fine.