### PR TITLE
See #524. Added support for methodchain setting in prettydiff.

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -1254,11 +1254,11 @@ Add a space before an anonymous function's parens, ie. function () (Supported by
 
 **Type**: `boolean`
 
-**Supported Beautifiers**:  [`JS Beautify`](#js-beautify) 
+**Supported Beautifiers**:  [`JS Beautify`](#js-beautify)  [`Pretty Diff`](#pretty-diff) 
 
 **Description**:
 
-Break chained method calls across subsequent lines (Supported by JS Beautify)
+Break chained method calls across subsequent lines (Supported by JS Beautify, Pretty Diff)
 
 **Example `.jsbeautifyrc` Configuration**
 
@@ -2007,7 +2007,7 @@ Disable C Beautification
 
 **Type**: `string`
 
-**Enum**:  `Uncrustify` 
+**Enum**:  `Uncrustify`  `clang-format` 
 
 **Description**:
 
@@ -2117,7 +2117,7 @@ Disable C++ Beautification
 
 **Type**: `string`
 
-**Enum**:  `Uncrustify` 
+**Enum**:  `Uncrustify`  `clang-format` 
 
 **Description**:
 
@@ -3162,7 +3162,7 @@ Disable Objective-C Beautification
 
 **Type**: `string`
 
-**Enum**:  `Uncrustify` 
+**Enum**:  `Uncrustify`  `clang-format` 
 
 **Description**:
 
@@ -3437,7 +3437,7 @@ Disable Python Beautification
 
 **Type**: `string`
 
-**Enum**:  `autopep8` 
+**Enum**:  `autopep8`  `yapf` 
 
 **Description**:
 
@@ -5224,11 +5224,11 @@ Add a space before an anonymous function's parens, ie. function () (Supported by
 
 **Type**: `boolean`
 
-**Supported Beautifiers**:  [`JS Beautify`](#js-beautify) 
+**Supported Beautifiers**:  [`JS Beautify`](#js-beautify)  [`Pretty Diff`](#pretty-diff) 
 
 **Description**:
 
-Break chained method calls across subsequent lines (Supported by JS Beautify)
+Break chained method calls across subsequent lines (Supported by JS Beautify, Pretty Diff)
 
 **Example `.jsbeautifyrc` Configuration**
 
@@ -5889,6 +5889,30 @@ Add a space before an anonymous function's parens, ie. function () (Supported by
 {
     "js": {
         "space_after_anon_function": false
+    }
+}
+```
+
+####  [JavaScript - Break chained methods](#javascript---break-chained-methods) 
+
+**Namespace**: `js`
+
+**Key**: `break_chained_methods`
+
+**Type**: `boolean`
+
+**Supported Beautifiers**:  [`JS Beautify`](#js-beautify)  [`Pretty Diff`](#pretty-diff) 
+
+**Description**:
+
+Break chained method calls across subsequent lines (Supported by JS Beautify, Pretty Diff)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "js": {
+        "break_chained_methods": false
     }
 }
 ```

--- a/examples/simple-jsbeautifyrc/jsx/expected/test.jsx
+++ b/examples/simple-jsbeautifyrc/jsx/expected/test.jsx
@@ -1,10 +1,7 @@
 var Mist = React.createClass({
   renderList: function() {
-    return this
-      .props
-      .items
-      .map(function(item) {
-        return <ListItem item={return <tag>{item}</tag>} key={item.id}/>;
-      });
+    return this.props.items.map(function(item) {
+      return <ListItem item={return <tag>{item}</tag>} key={item.id}/>;
+    });
   }
 });

--- a/src/beautifiers/prettydiff.coffee
+++ b/src/beautifiers/prettydiff.coffee
@@ -29,6 +29,10 @@ module.exports = class PrettyDiff extends Beautifier
       space: "space_after_anon_function"
       noleadzero: "no_lead_zero"
       endcomma: "end_with_comma"
+      methodchain: ['break_chained_methods', (break_chained_methods) ->
+        if (break_chained_methods is true ) then \
+          false else true
+      ]
     # Apply language-specific options
     CSV: true
     ERB: true


### PR DESCRIPTION
This is to help address #524 and #591. It looks like the docs were a bit out of date when I ran coffee /docs, so there's some extra `clang-format` support noted in there that's unrelated to this change.