### PR TITLE
Travis: cache stack builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ cache:
     - directories:
         - node_modules
         - $HOME/.atom
+        - $HOME/.stack
 
 before_install:
   # Update Homebrew


### PR DESCRIPTION
In https://github.com/Glavin001/atom-beautify/pull/629 I added a stack build to Travis. This PR will cache the `~/.stack` dir and greatly speed up subsequent runs.