### PR TITLE
Fix missing space in "tomarkup"

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -407,7 +407,7 @@ Determines whether comments should be indented. (Supported by Pretty Diff)
 
 **Description**:
 
-if indentation should be forcefully applied tomarkup even if it disruptively adds unintended whitespace to the documents rendered output (Supported by Pretty Diff)
+if indentation should be forcefully applied to markup even if it disruptively adds unintended whitespace to the documents rendered output (Supported by Pretty Diff)
 
 **Example `.jsbeautifyrc` Configuration**
 
@@ -5706,7 +5706,7 @@ Determines whether comments should be indented. (Supported by Pretty Diff)
 
 **Description**:
 
-if indentation should be forcefully applied tomarkup even if it disruptively adds unintended whitespace to the documents rendered output (Supported by Pretty Diff)
+if indentation should be forcefully applied to  markup even if it disruptively adds unintended whitespace to the documents rendered output (Supported by Pretty Diff)
 
 **Example `.jsbeautifyrc` Configuration**
 

--- a/src/languages/css.coffee
+++ b/src/languages/css.coffee
@@ -64,7 +64,7 @@ module.exports = {
     force_indentation:
       type: 'boolean'
       default: false
-      description: "if indentation should be forcefully applied to\
+      description: "if indentation should be forcefully applied to \
                 markup even if it disruptively adds unintended whitespace \
                 to the documents rendered output"
     convert_quotes:


### PR DESCRIPTION
<img width="519" alt="screen shot 2015-11-10 at 14 08 00" src="https://cloud.githubusercontent.com/assets/2098462/11063089/79095f64-87b4-11e5-90bc-9b596ba49e18.png">
