### PR TITLE
added import sorting using isort + small yapf fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ before_install:
   # Python language support
   - brew install python
   - pip install --upgrade autopep8
+  - pip install --upgrade isort
   # SQL language support
   - pip install --upgrade sqlparse
   # Java, C, C++, C#, Objective-C, D, Pawn, Vala

--- a/examples/nested-jsbeautifyrc/.jsbeautifyrc
+++ b/examples/nested-jsbeautifyrc/.jsbeautifyrc
@@ -33,6 +33,7 @@
     indent_with_tabs: false
   python:
     indent_size: 2
+    sort_imports: true
     #max_line_length: 79
     #ignore:
     #  - "E24"

--- a/examples/nested-jsbeautifyrc/python/expected/test_isort.py
+++ b/examples/nested-jsbeautifyrc/python/expected/test_isort.py
@@ -1,0 +1,5 @@
+import os
+import sys
+from pprint import pprint
+
+from scrapy import FormRequest, Request

--- a/examples/nested-jsbeautifyrc/python/original/test_isort.py
+++ b/examples/nested-jsbeautifyrc/python/original/test_isort.py
@@ -1,0 +1,4 @@
+from scrapy import Request, FormRequest
+import sys
+import os
+from pprint import pprint

--- a/src/beautifiers/autopep8.coffee
+++ b/src/beautifiers/autopep8.coffee
@@ -15,10 +15,24 @@ module.exports = class Autopep8 extends Beautifier
 
   beautify: (text, language, options) ->
     @run("autopep8", [
-      @tempFile("input", text)
+      tempFile = @tempFile("input", text)
+      "-i"
       ["--max-line-length", "#{options.max_line_length}"] if options.max_line_length?
       ["--indent-size","#{options.indent_size}"] if options.indent_size?
       ["--ignore","#{options.ignore.join(',')}"] if options.ignore?
       ], help: {
         link: "https://github.com/hhatto/autopep8"
       })
+      .then(=>
+        if options.sort_imports
+          @run("isort",
+            [tempFile],
+            help: {
+              link: "https://github.com/timothycrosley/isort"
+          })
+          .then(=>
+            @readFile(tempFile)
+          )
+        else
+          @readFile(tempFile)
+      )

--- a/src/beautifiers/yapf.coffee
+++ b/src/beautifiers/yapf.coffee
@@ -15,8 +15,22 @@ module.exports = class Yapf extends Beautifier
 
   beautify: (text, language, options) ->
     @run("yapf", [
+      "-i"
       ["--style=pep8"]
-      @tempFile("input", text)
+      tempFile = @tempFile("input", text)
       ], help: {
         link: "https://github.com/google/yapf"
-      })
+      }, ignoreReturnCode: true)
+      .then(=>
+        if options.sort_imports
+          @run("isort",
+            [tempFile],
+            help: {
+              link: "https://github.com/timothycrosley/isort"
+          })
+          .then(=>
+            @readFile(tempFile)
+          )
+        else
+          @readFile(tempFile)
+      )

--- a/src/languages/python.coffee
+++ b/src/languages/python.coffee
@@ -41,5 +41,9 @@ module.exports = {
       items:
         type: 'string'
       description: "do not fix these errors/warnings"
+    sort_imports:
+      type: 'boolean'
+      default: false
+      description: "sort imports (requires isort installed)"
 
 }


### PR DESCRIPTION
isort is a very useful tool that orders imports. I added the feature to both python formatters.

+ added a ignoreReturnCode: true to yapf run command to fix the empty error I was getting.