### PR TITLE
Add Optional Path for Rubocop

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -1766,6 +1766,30 @@ Indentation size/length (Supported by Rubocop, Ruby Beautify)
 }
 ```
 
+####  [Ruby - Rubocop Path](#ruby---rubocop-path) 
+
+**Namespace**: `ruby`
+
+**Key**: `rubocop_path`
+
+**Type**: `string`
+
+**Supported Beautifiers**:  [`Rubocop`](#rubocop) 
+
+**Description**:
+
+Path to the `rubocop` CLI executable (Supported by Rubocop)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "ruby": {
+        "rubocop_path": ""
+    }
+}
+```
+
 ####  [Ruby - Indent char](#ruby---indent-char) 
 
 **Namespace**: `ruby`
@@ -6443,6 +6467,30 @@ Indentation size/length (Supported by Rubocop, Ruby Beautify)
 {
     "ruby": {
         "indent_size": 4
+    }
+}
+```
+
+####  [Ruby - Rubocop Path](#ruby---rubocop-path) 
+
+**Namespace**: `ruby`
+
+**Key**: `rubocop_path`
+
+**Type**: `string`
+
+**Supported Beautifiers**:  [`Rubocop`](#rubocop) 
+
+**Description**:
+
+Path to the `rubocop` CLI executable (Supported by Rubocop)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "ruby": {
+        "rubocop_path": ""
     }
 }
 ```

--- a/src/beautifiers/beautifier.coffee
+++ b/src/beautifiers/beautifier.coffee
@@ -20,27 +20,27 @@ module.exports = class Beautifier
 
   ###
   Supported Options
-
+  
   Enable options for supported languages.
   - <string:language>:<boolean:all_options_enabled>
   - <string:language>:<string:option_key>:<boolean:enabled>
   - <string:language>:<string:option_key>:<string:rename>
   - <string:language>:<string:option_key>:<function:transform>
   - <string:language>:<string:option_key>:<array:mapper>
-
+  
   ###
   options: {}
 
   ###
   Supported languages by this Beautifier
-
+  
   Extracted from the keys of the `options` field.
   ###
   languages: null
 
   ###
   Beautify text
-
+  
   Override this method in subclasses
   ###
   beautify: null
@@ -87,7 +87,7 @@ module.exports = class Beautifier
 
   ###
   Get Shell Environment variables
-
+  
   Special thank you to @ioquatix
   See https://github.com/ioquatix/script-runner/blob/v1.5.0/lib/script-runner.coffee#L45-L63
   ###
@@ -139,7 +139,7 @@ module.exports = class Beautifier
 
   ###
   Like the unix which utility.
-
+  
   Finds the first instance of a specified executable in the PATH environment variable.
   Does not cache the results,
   so hash -r is not needed when the PATH changes.
@@ -165,7 +165,7 @@ module.exports = class Beautifier
 
   ###
   Add help to error.description
-
+  
   Note: error.description is not officially used in JavaScript,
   however it is used internally for Atom Beautify when displaying errors.
   ###
@@ -256,8 +256,8 @@ module.exports = class Beautifier
               # If return code is not 0 then error occured
               if not ignoreReturnCode and returnCode isnt 0
                 err = new Error(stderr)
-                windowsProgramNotFoundMsg = 'is not recognized as an \
-                internal or external command'#, operable program or batch file.'
+                windowsProgramNotFoundMsg = "is not recognized as an \
+                internal or external command" # operable program or batch file
                 @verbose(stderr, windowsProgramNotFoundMsg)
                 if @isWindows and returnCode is 1 and \
                 stderr.indexOf(windowsProgramNotFoundMsg) isnt -1
@@ -346,5 +346,3 @@ module.exports = class Beautifier
     @verbose("Options for #{@name}:", @options)
     # Set supported languages
     @languages = _.keys(@options)
-
-

--- a/src/beautifiers/rubocop.coffee
+++ b/src/beautifiers/rubocop.coffee
@@ -11,42 +11,42 @@ module.exports = class Rubocop extends Beautifier
   options: {
     Ruby:
       indent_size: true
+      rubocop_path: true
   }
 
   beautify: (text, language, options) ->
-
-    fs = require 'fs'
-
-    configFile = path.join(atom.project.getPaths()[0], ".rubocop.yml")
-
-    if fs.existsSync(configFile)
-      @debug("rubocop", config, fs.readFileSync(configFile, 'utf8'))
-    else
-      yaml = require("yaml-front-matter")
-      # Generate config file
-      config = {
-        "Style/IndentationWidth":
-          "Width": options.indent_size
-      }
-
-      configFile = @tempFile("rubocop-config", yaml.safeDump(config))
-      @debug("rubocop", config, configFile)
-
     @Promise.all([
       @which(options.rubocop_path) if options.rubocop_path
       @which('rubocop')
     ]).then((paths) =>
-      @debug('php-cs-fixer paths', paths)
+      @debug('rubocop paths', paths)
       _ = require 'lodash'
       path = require 'path'
       # Get first valid, absolute path
       rubocopPath = _.find(paths, (p) -> p and path.isAbsolute(p) )
       @verbose('rubocopPath', rubocopPath)
       @debug('rubocopPath', rubocopPath, paths)
+
+      configFile = path.join(atom.project.getPaths()[0], ".rubocop.yml")
+
+      fs = require 'fs'
+
+      if fs.existsSync(configFile)
+        @debug("rubocop", config, fs.readFileSync(configFile, 'utf8'))
+      else
+        yaml = require("yaml-front-matter")
+        # Generate config file
+        config = {
+          "Style/IndentationWidth":
+            "Width": options.indent_size
+        }
+
+        configFile = @tempFile("rubocop-config", yaml.safeDump(config))
+        @debug("rubocop", config, configFile)
+
       # Check if PHP-CS-Fixer path was found
       if rubocopPath?
-        @run("rubocop", [
-          rubocopPath
+        @run(rubocopPath, [
           "--auto-correct"
           "--config", configFile
           tempFile = @tempFile("temp", text)
@@ -63,3 +63,4 @@ module.exports = class Rubocop extends Beautifier
           .then(=>
             @readFile(tempFile)
           )
+)

--- a/src/beautifiers/rubocop.coffee
+++ b/src/beautifiers/rubocop.coffee
@@ -15,7 +15,6 @@ module.exports = class Rubocop extends Beautifier
 
   beautify: (text, language, options) ->
 
-    path = require 'path'
     fs = require 'fs'
 
     configFile = path.join(atom.project.getPaths()[0], ".rubocop.yml")
@@ -33,11 +32,34 @@ module.exports = class Rubocop extends Beautifier
       configFile = @tempFile("rubocop-config", yaml.safeDump(config))
       @debug("rubocop", config, configFile)
 
-    @run("rubocop", [
-      "--auto-correct"
-      "--config", configFile
-      tempFile = @tempFile("temp", text)
-      ], {ignoreReturnCode: true})
-      .then(=>
-        @readFile(tempFile)
-      )
+    @Promise.all([
+      @which(options.rubocop_path) if options.rubocop_path
+      @which('rubocop')
+    ]).then((paths) =>
+      @debug('php-cs-fixer paths', paths)
+      _ = require 'lodash'
+      path = require 'path'
+      # Get first valid, absolute path
+      rubocopPath = _.find(paths, (p) -> p and path.isAbsolute(p) )
+      @verbose('rubocopPath', rubocopPath)
+      @debug('rubocopPath', rubocopPath, paths)
+      # Check if PHP-CS-Fixer path was found
+      if rubocopPath?
+        @run("rubocop", [
+          rubocopPath
+          "--auto-correct"
+          "--config", configFile
+          tempFile = @tempFile("temp", text)
+          ], {ignoreReturnCode: true})
+          .then(=>
+            @readFile(tempFile)
+          )
+      else
+        @run("rubocop", [
+          "--auto-correct"
+          "--config", configFile
+          tempFile = @tempFile("temp", text)
+          ], {ignoreReturnCode: true})
+          .then(=>
+            @readFile(tempFile)
+          )

--- a/src/languages/ruby.coffee
+++ b/src/languages/ruby.coffee
@@ -32,6 +32,11 @@ module.exports = {
       default: defaultIndentSize
       minimum: 0
       description: "Indentation size/length"
+    rubocop_path:
+      title: "Rubocop Path"
+      type: 'string'
+      default: ""
+      description: "Path to the `rubocop` CLI executable"
     indent_char:
       type: 'string'
       default: defaultIndentChar


### PR DESCRIPTION
add option to specify the path for rubocop in the settings.
The relative beautifier now retrieve the path similarly to how the php-cs-fixer one does.

I tested it and is working correctly on my system.