### PR TITLE
Add support for Elm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,3 +59,6 @@ before_install:
   - brew install haskell-stack
   - stack setup
   - stack install stylish-haskell
+  # Elm
+  - curl -L -o /tmp/elm-format.tgz
+  - tar xvzf -C /usr/local/bin /tmp/elm-format.tgz

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,5 +60,5 @@ before_install:
   - stack setup
   - stack install stylish-haskell
   # Elm
-  - curl -L -o /tmp/elm-format.tgz
+  - curl -L -o /tmp/elm-format.tgz https://github.com/avh4/elm-format/releases/download/0.1-alpha2/elm-format-0.1-alpha2-mac-x64.tgz
   - tar xvzf -C /usr/local/bin /tmp/elm-format.tgz

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,4 +61,4 @@ before_install:
   - stack install stylish-haskell
   # Elm
   - curl -L -o /tmp/elm-format.tgz https://github.com/avh4/elm-format/releases/download/0.1-alpha2/elm-format-0.1-alpha2-mac-x64.tgz
-  - tar xvzf -C /usr/local/bin /tmp/elm-format.tgz
+  - tar xvzf /tmp/elm-format.tgz -C /usr/local/bin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # dev
+- Add [elm-format](https://github.com/avh4/elm-format) beautifier for the Elm language.
 - Add [clang-format](http://clang.llvm.org/docs/ClangFormat.html) beautifier for C/C++/Obj-C languages.
 - Add [yapf](http://github.com/google/yapf) beautifier for Python.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Or Settings/Preferences ➔ Packages ➔ Search for `atom-beautify`
 - [x] [TypeScript](https://github.com/Glavin001/atom-beautify/issues/49)
 - [x] [Haskell](https://github.com/Glavin001/atom-beautify/issues/628)
   - Requires [stylish-haskell](https://github.com/jaspervdj/stylish-haskell)
+- [x] [Elm]()
+  - Requires [Elm-Format](https://github.com/avh4/elm-format)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Or Settings/Preferences ➔ Packages ➔ Search for `atom-beautify`
 - [x] [TypeScript](https://github.com/Glavin001/atom-beautify/issues/49)
 - [x] [Haskell](https://github.com/Glavin001/atom-beautify/issues/628)
   - Requires [stylish-haskell](https://github.com/jaspervdj/stylish-haskell)
-- [x] [Elm]()
+- [x] [Elm](https://github.com/Glavin001/atom-beautify/pull/700)
   - Requires [Elm-Format](https://github.com/avh4/elm-format)
 
 ## Usage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -115,7 +115,7 @@ build_script:
 
   - cd %APPVEYOR_BUILD_FOLDER%
   # Install languages to Atom
-  - apm install language-marko language-html-swig language-svg
+  - apm install language-marko language-html-swig language-svg language-elm
   # Show current PATH
   - echo %PATH%
   # Run tests on package

--- a/docs/options.md
+++ b/docs/options.md
@@ -2467,6 +2467,61 @@ Automatically beautify EJS files on save
 2. Go into *Packages* and search for "*Atom Beautify*" package.
 3. Find the option "*Language Config - EJS - Beautify On Save*" and change it to your desired configuration.
 
+####  [Language Config - Elm - Disable Beautifying Language](#language-config---elm---disable-beautifying-language) 
+
+**Important**: This option is only configurable from within Atom Beautify's setting panel.
+
+**Type**: `boolean`
+
+**Description**:
+
+Disable Elm Beautification
+
+**How to Configure**
+
+1. You can open the [Settings View](https://github.com/atom/settings-view) by navigating to
+*Edit > Preferences (Linux)*, *Atom > Preferences (OS X)*, or *File > Preferences (Windows)*.
+2. Go into *Packages* and search for "*Atom Beautify*" package.
+3. Find the option "*Language Config - Elm - Disable Beautifying Language*" and change it to your desired configuration.
+
+####  [Language Config - Elm - Default Beautifier](#language-config---elm---default-beautifier) 
+
+**Important**: This option is only configurable from within Atom Beautify's setting panel.
+
+**Default**: `elm-format`
+
+**Type**: `string`
+
+**Enum**:  `elm-format` 
+
+**Description**:
+
+Default Beautifier to be used for Elm
+
+**How to Configure**
+
+1. You can open the [Settings View](https://github.com/atom/settings-view) by navigating to
+*Edit > Preferences (Linux)*, *Atom > Preferences (OS X)*, or *File > Preferences (Windows)*.
+2. Go into *Packages* and search for "*Atom Beautify*" package.
+3. Find the option "*Language Config - Elm - Default Beautifier*" and change it to your desired configuration.
+
+####  [Language Config - Elm - Beautify On Save](#language-config---elm---beautify-on-save) 
+
+**Important**: This option is only configurable from within Atom Beautify's setting panel.
+
+**Type**: `boolean`
+
+**Description**:
+
+Automatically beautify Elm files on save
+
+**How to Configure**
+
+1. You can open the [Settings View](https://github.com/atom/settings-view) by navigating to
+*Edit > Preferences (Linux)*, *Atom > Preferences (OS X)*, or *File > Preferences (Windows)*.
+2. Go into *Packages* and search for "*Atom Beautify*" package.
+3. Find the option "*Language Config - Elm - Beautify On Save*" and change it to your desired configuration.
+
 ####  [Language Config - ERB - Disable Beautifying Language](#language-config---erb---disable-beautifying-language) 
 
 **Important**: This option is only configurable from within Atom Beautify's setting panel.

--- a/examples/nested-jsbeautifyrc/elm/expected/test.elm
+++ b/examples/nested-jsbeautifyrc/elm/expected/test.elm
@@ -1,0 +1,9 @@
+module Main (..) where
+
+
+addThings x y =
+    x + y
+
+
+main =
+    addThings 4 5

--- a/examples/nested-jsbeautifyrc/elm/original/test.elm
+++ b/examples/nested-jsbeautifyrc/elm/original/test.elm
@@ -1,0 +1,3 @@
+addThings x y = x + y
+
+main = addThings 4 5

--- a/package.json
+++ b/package.json
@@ -160,7 +160,8 @@
     "marko",
     "go",
     "golang",
-    "svg"
+    "svg",
+    "elm"
   ],
   "devDependencies": {
     "coffee-script": "^1.9.3",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,10 @@
     {
       "name": "Daniel Bayley",
       "url": "https://github.com/danielbayley"
+    },
+    {
+      "name": "Murphy Randle",
+      "url": "https://github.com/splodingsocks"
     }
   ],
   "engines": {

--- a/src/beautifiers/beautifier.coffee
+++ b/src/beautifiers/beautifier.coffee
@@ -54,10 +54,10 @@ module.exports = class Beautifier
   ###
   Create temporary file
   ###
-  tempFile: (name = "atom-beautify-temp", contents = "") ->
+  tempFile: (name = "atom-beautify-temp", contents = "", ext = "") ->
     return new Promise((resolve, reject) =>
       # create temp file
-      temp.open(name, (err, info) =>
+      temp.open({prefix: name, suffix: ext}, (err, info) =>
         @debug('tempFile', name, err, info)
         return reject(err) if err
         fs.write(info.fd, contents, (err) ->

--- a/src/beautifiers/elm-format.coffee
+++ b/src/beautifiers/elm-format.coffee
@@ -25,5 +25,5 @@ module.exports = class ElmFormat extends Beautifier
           '--yes',
           newName
           ])
-        .then () =>
+        .then () ->
           readFile newName, {encoding: 'utf-8'}

--- a/src/beautifiers/elm-format.coffee
+++ b/src/beautifiers/elm-format.coffee
@@ -1,9 +1,12 @@
 ###
 Requires https://github.com/avh4/elm-format
 ###
-
 "use strict"
 Beautifier = require('./beautifier')
+Promise = require("bluebird")
+fs = require("fs")
+readFile = Promise.promisify(fs.readFile)
+rename = Promise.promisify(fs.rename)
 
 module.exports = class ElmFormat extends Beautifier
   name: "elm-format"
@@ -13,6 +16,14 @@ module.exports = class ElmFormat extends Beautifier
   }
 
   beautify: (text, language, options) ->
-    @run("elm-format", [
-      @tempFile("input", text)
-      ])
+    tempfile = @tempFile("input", text)
+    .then (name) =>
+      newName = name + ".elm"
+      rename name, newName
+      .then () =>
+        @run("elm-format", [
+          '--yes',
+          newName
+          ])
+        .then () =>
+          readFile newName, {encoding: 'utf-8'}

--- a/src/beautifiers/elm-format.coffee
+++ b/src/beautifiers/elm-format.coffee
@@ -1,0 +1,18 @@
+###
+Requires https://github.com/avh4/elm-format
+###
+
+"use strict"
+Beautifier = require('./beautifier')
+
+module.exports = class ElmFormat extends Beautifier
+  name: "elm-format"
+
+  options: {
+    Elm: true
+  }
+
+  beautify: (text, language, options) ->
+    @run("elm-format", [
+      @tempFile("input", text)
+      ])

--- a/src/beautifiers/elm-format.coffee
+++ b/src/beautifiers/elm-format.coffee
@@ -3,10 +3,6 @@ Requires https://github.com/avh4/elm-format
 ###
 "use strict"
 Beautifier = require('./beautifier')
-Promise = require("bluebird")
-fs = require("fs")
-readFile = Promise.promisify(fs.readFile)
-rename = Promise.promisify(fs.rename)
 
 module.exports = class ElmFormat extends Beautifier
   name: "elm-format"
@@ -16,14 +12,13 @@ module.exports = class ElmFormat extends Beautifier
   }
 
   beautify: (text, language, options) ->
-    tempfile = @tempFile("input", text)
+    tempfile = @tempFile("input", text, ".elm")
     .then (name) =>
-      newName = name + ".elm"
-      rename name, newName
+      @run("elm-format", [
+        '--yes',
+        name
+        ],
+        { help: { link: 'https://github.com/avh4/elm-format' } }
+      )
       .then () =>
-        @run("elm-format", [
-          '--yes',
-          newName
-          ])
-        .then () ->
-          readFile newName, {encoding: 'utf-8'}
+        @readFile(name)

--- a/src/beautifiers/index.coffee
+++ b/src/beautifiers/index.coffee
@@ -38,6 +38,7 @@ module.exports = class Beautifiers extends EventEmitter
     'coffee-formatter'
     'coffee-fmt'
     'clang-format'
+    'elm-format'
     'htmlbeautifier'
     'csscomb'
     'gherkin'

--- a/src/languages/elm.coffee
+++ b/src/languages/elm.coffee
@@ -1,0 +1,22 @@
+module.exports = {
+
+  name: "Elm"
+  namespace: "elm"
+
+  ###
+  Supported Grammars
+  ###
+  grammars: [
+    "Elm"
+  ]
+
+  ###
+  Supported extensions
+  ###
+  extensions: [
+    "elm"
+  ]
+
+  options: []
+
+}

--- a/src/languages/index.coffee
+++ b/src/languages/index.coffee
@@ -21,6 +21,7 @@ module.exports = class Languages
     "csv"
     "d"
     "ejs"
+    "elm"
     "erb"
     "gherkin"
     "go"

--- a/test.elm
+++ b/test.elm
@@ -1,9 +1,0 @@
-module Main (..) where
-
-
-addThings x y =
-    Signal.map (x + y)
-
-
-main =
-    addThings 4 5

--- a/test.elm
+++ b/test.elm
@@ -1,0 +1,9 @@
+module Main (..) where
+
+
+addThings x y =
+    Signal.map (x + y)
+
+
+main =
+    addThings 4 5


### PR DESCRIPTION
Hoping I did this the right way. I just followed the example of the merged PR for supporting stylish-haskell.

Caveat: I don't like that the url for elm-format is hard-coded in the .travis.yml file, but the tool is new enough that it doesn't exist in brew yet.