### PR TITLE
Adds 'unchanged' option to the SQL beautifier

### DIFF
--- a/src/beautifiers/sqlformat.coffee
+++ b/src/beautifiers/sqlformat.coffee
@@ -17,8 +17,8 @@ module.exports = class Sqlformat extends Beautifier
       @tempFile("input", text)
       "--reindent"
       "--indent_width=#{options.indent_size}" if options.indent_size?
-      "--keywords=#{options.keywords}" if options.keywords?
-      "--identifiers=#{options.identifiers}" if options.identifiers?
+      "--keywords=#{options.keywords}" if (options.keywords? && options.keywords != 'unchanged')
+      "--identifiers=#{options.identifiers}" if (options.identifiers? && options.identifiers != 'unchanged')
       ], help: {
         link: "https://github.com/andialbrecht/sqlparse"
       })

--- a/src/languages/sql.coffee
+++ b/src/languages/sql.coffee
@@ -37,11 +37,11 @@ module.exports = {
       type: 'string'
       default: "upper"
       description: "Change case of keywords"
-      enum: ["lower","upper","capitalize"]
+      enum: ["unchanged","lower","upper","capitalize"]
     identifiers:
       type: 'string'
-      default: "lower"
+      default: "unchanged"
       description: "Change case of identifiers"
-      enum: ["lower","upper","capitalize"]
+      enum: ["unchanged","lower","upper","capitalize"]
 
 }


### PR DESCRIPTION
The sqlformat tool can preserve identifier and keyword case. This is particularly useful for identifiers in cases where the RDBMS is case sensitive. Arguably it might be useful for SQL keywords too. This patch enables this by adding another option ('unchanged') that does exactly that and defaults to unchanged in the case of identifiers.