### PR TITLE
[#776] Bump jsbeautify to 1.6.2.  Add support for collapse-preserve-inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Add [elm-format](https://github.com/avh4/elm-format) beautifier for the Elm language.
 - Add [clang-format](http://clang.llvm.org/docs/ClangFormat.html) beautifier for C/C++/Obj-C languages.
 - Add [yapf](http://github.com/google/yapf) beautifier for Python.
+- Closes [#776] (https://github.com/Glavin001/atom-beautify/issues/776) Add support for `collapse-preserve-inline` brace_style for javascript.
 
 # v0.29.0
 - Closes [#447](https://github.com/Glavin001/atom-beautify/issues/447). Improved Handlebars language support

--- a/docs/options.md
+++ b/docs/options.md
@@ -1311,13 +1311,13 @@ Add a space before an anonymous function's parens, ie. function () (Supported by
 
 **Type**: `string`
 
-**Enum**:  `collapse`  `expand`  `end-expand`  `none` 
+**Enum**:  `collapse`  `collapse-preserve-inline`  `expand`  `end-expand`  `none` 
 
 **Supported Beautifiers**:  [`JS Beautify`](#js-beautify) 
 
 **Description**:
 
-[collapse|expand|end-expand|none] (Supported by JS Beautify)
+[collapse|collapse-preserve-inline|expand|end-expand|none] (Supported by JS Beautify)
 
 **Example `.jsbeautifyrc` Configuration**
 
@@ -5470,13 +5470,13 @@ Add a space before an anonymous function's parens, ie. function () (Supported by
 
 **Type**: `string`
 
-**Enum**:  `collapse`  `expand`  `end-expand`  `none` 
+**Enum**:  `collapse`  `collapse-preserve-inline`  `expand`  `end-expand`  `none` 
 
 **Supported Beautifiers**:  [`JS Beautify`](#js-beautify) 
 
 **Description**:
 
-[collapse|expand|end-expand|none] (Supported by JS Beautify)
+[collapse|collapse-preserve-inline|expand|end-expand|none] (Supported by JS Beautify)
 
 **Example `.jsbeautifyrc` Configuration**
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,10 @@
     {
       "name": "Murphy Randle",
       "url": "https://github.com/splodingsocks"
+    },
+    {
+      "name": "Luis Arias",
+      "url": "https://github.com/kaaloo"
     }
   ],
   "engines": {
@@ -84,7 +88,7 @@
     "extend": "^3.0.0",
     "gherkin": "2.12.2",
     "handlebars": "^4.0.2",
-    "js-beautify": "^1.5.10",
+    "js-beautify": "^1.6.2",
     "jscs": "^2.1.1",
     "lodash": "3.10.1",
     "loophole": "^1.0.0",

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -72,8 +72,8 @@ module.exports = {
     brace_style:
       type: 'string'
       default: "collapse"
-      enum: ["collapse", "expand", "end-expand", "none"]
-      description: "[collapse|expand|end-expand|none]"
+      enum: ["collapse", "collapse-preserve-inline", "expand", "end-expand", "none"]
+      description: "[collapse|collapse-preserve-inline|expand|end-expand|none]"
     break_chained_methods:
       type: 'boolean'
       default: false


### PR DESCRIPTION
I have tested the package locally and the option seems to work fine now.