### PR TITLE
Rust - Add ability to read rustfmt.toml

### DIFF
--- a/src/beautifiers/rustfmt.coffee
+++ b/src/beautifiers/rustfmt.coffee
@@ -14,9 +14,19 @@ module.exports = class Rustfmt extends Beautifier
   }
 
   beautify: (text, language, options) ->
+
+    # get file path which is the search path for rustfmt.toml as
+    # the beautifier runs rustfmt in a tmp directory.
+    # This will pick up any rustfmt.toml defined in the crate root
+
+    editor = atom.workspace.getActivePaneItem()
+    file = editor?.buffer.file
+    filePath = file?.path
     program = options.rustfmt_path or "rustfmt"
     @run(program, [
       tmpFile = @tempFile("tmp", text)
+      ["--write-mode", "overwrite"]
+      ["--config-path", filePath]
       ], help: {
         link: "https://github.com/nrc/rustfmt"
         program: "rustfmt"


### PR DESCRIPTION
This is a breaking change for existing rust format users. rustfmt version 0.3.0 or newer is required. 

The older version of rustfmt will error with the message
```
Unrecognized option: 'config-path'.
```

This commit 
- adds the --config-path parameter with the current folder and will load any rust format in the file's path.
- sets the --write-output format to override. This will avoid creating an unnecessary backup of the tmp source file