### PR TITLE
Add Apex language support

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -125,7 +125,31 @@ Supported options for each language.
 
 ---
 
-####  [Arduino - Config Path](#arduino---config-path) 
+####  [Apex - Config Path](#apex---config-path)
+
+**Namespace**: `apex`
+
+**Key**: `configPath`
+
+**Type**: `string`
+
+**Supported Beautifiers**:  [`Uncrustify`](#uncrustify)
+
+**Description**:
+
+Path to uncrustify config file. i.e. uncrustify.cfg (Supported by Uncrustify)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "apex": {
+        "configPath": ""
+    }
+}
+```
+
+####  [Arduino - Config Path](#arduino---config-path)
 
 **Namespace**: `arduino`
 

--- a/examples/nested-jsbeautifyrc/apex/expected/test.java
+++ b/examples/nested-jsbeautifyrc/apex/expected/test.java
@@ -1,0 +1,19 @@
+class Aligns {
+        final int SZF = 4;
+        final int SZ2F = 4;
+        final int aBarF;
+        final int[] someMoreIntsF;
+        final Tem<Plate> edVarF;
+        final int aBarSetF=null;
+        final int[] someMoreIntsSetF=null;
+        final Tem<Plate> edVarF=null;
+        int SZ = 4;
+        int SZ2 = 4;
+        int aBar;
+        int spacer;
+        int[] someMoreInts;
+        Tem<Plate> edVar;
+        int aBarSet=null;
+        int[] someMoreIntsSet=null;
+        Tem<Plate> edVar=null;
+}

--- a/examples/nested-jsbeautifyrc/apex/original/test.java
+++ b/examples/nested-jsbeautifyrc/apex/original/test.java
@@ -1,0 +1,19 @@
+class Aligns {
+final Integer SZF = 4;
+final Integer SZ2F = 4;
+final Integer aBarF;
+final Integer[] someMoreIntegersF;
+final Tem<Plate> edVarF;
+final Integer aBarSetF=null;
+final Integer[] someMoreIntegersSetF=null;
+final Tem<Plate> edVarF=null;
+Integer SZ = 4;
+Integer SZ2 = 4;
+Integer aBar;
+Integer spacer;
+Integer[] someMoreIntegers;
+Tem<Plate> edVar;
+Integer aBarSet=null;
+Integer[] someMoreIntegersSet=null;
+Tem<Plate> edVar=null;
+}

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "c#",
     "uncrustify",
     "java",
+    "apex",
     "pawn",
     "vala",
     "d",

--- a/spec/beautify-languages-spec.coffee
+++ b/spec/beautify-languages-spec.coffee
@@ -21,7 +21,7 @@ describe "BeautifyLanguages", ->
 
   # Activate all of the languages
   allLanguages = [
-    "c", "coffee-script", "css", "html",
+    "apex", "c", "coffee-script", "css", "html",
     "java", "javascript", "json", "less",
     "mustache", "objective-c", "perl", "php",
     "python", "ruby", "sass", "sql", "svg",
@@ -61,7 +61,7 @@ describe "BeautifyLanguages", ->
 
     # Set Uncrustify config path
     # uncrustifyConfigPath = path.resolve(__dirname, "../examples/nested-jsbeautifyrc/uncrustify.cfg")
-    # uncrustifyLangs = ["c", "cpp", "objectivec", "cs", "d", "java", "pawn", "vala"]
+    # uncrustifyLangs = ["apex", "c", "cpp", "objectivec", "cs", "d", "java", "pawn", "vala"]
     # for lang in uncrustifyLangs
     #     do (lang) ->
       # atom.config.set("atom-beautify.#{lang}_configPath", uncrustifyConfigPath)

--- a/src/beautifiers/uncrustify/index.coffee
+++ b/src/beautifiers/uncrustify/index.coffee
@@ -11,6 +11,7 @@ _ = require('lodash')
 module.exports = class Uncrustify extends Beautifier
   name: "Uncrustify"
   options: {
+    Apex: true
     C: true
     "C++": true
     "C#": true
@@ -50,6 +51,8 @@ module.exports = class Uncrustify extends Beautifier
       # Select Uncrustify language
       lang = "C" # Default is C
       switch language
+        when "Apex"
+          lang = "Apex"
         when "C"
           lang = "C"
         when "C++"

--- a/src/languages/apex.coffee
+++ b/src/languages/apex.coffee
@@ -1,0 +1,26 @@
+module.exports = {
+
+  name: "Apex"
+  namespace: "apex"
+
+  ###
+  Supported Grammars
+  ###
+  grammars: [
+    "Apex"
+  ]
+
+  ###
+  Supported extensions
+  ###
+  extensions: [
+    "cls"
+  ]
+
+  options:
+    configPath:
+      type: 'string'
+      default: ""
+      description: "Path to uncrustify config file. i.e. uncrustify.cfg"
+
+}

--- a/src/languages/index.coffee
+++ b/src/languages/index.coffee
@@ -12,6 +12,7 @@ module.exports = class Languages
   # Supported unique configuration keys
   # Used for detecting nested configurations in .jsbeautifyrc
   languageNames: [
+    "apex"
     "arduino"
     "c-sharp"
     "c"


### PR DESCRIPTION
Include support for Salesforce's Java-like "Apex" language. Language definition is already provided through MavensMate plugin.