### PR TITLE
Fix PHPCBF error when path to executable is not set

### DIFF
--- a/src/beautifiers/phpcbf.coffee
+++ b/src/beautifiers/phpcbf.coffee
@@ -14,8 +14,6 @@ module.exports = class PHPCBF extends Beautifier
         if (standard) then \
           standard else "PEAR"
       ]
-      phpcbf_path: (phpcbf_path) -> phpcbf_path or @which('phpcbf')
-      
     PHP: true
   }
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
When no phpcbf path is set in config, beautifier throws error. This fixes it.

### Does this close any currently open issues?
no
### Any other comments?
fixing thing I overlooked

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
