### PR TITLE
Fix deprecation warnings triggered by editor.[gs]etScrollTop

### DIFF
--- a/src/beautify.coffee
+++ b/src/beautify.coffee
@@ -27,6 +27,12 @@ $ = null
 # nopt.clean(data, types);
 # return data;
 # }
+getScrollTop = (editor) ->
+  view = editor.viewRegistry.getView(editor)
+  view.getScrollTop()
+setScrollTop = (editor, value) ->
+  view = editor.viewRegistry.getView(editor)
+  view.setScrollTop value
 getCursors = (editor) ->
   cursors = editor.getCursors()
   posArray = []
@@ -109,7 +115,7 @@ beautify = ({onSave}) ->
         posArray = getCursors(editor)
 
         # console.log "posArray:
-        origScrollTop = editor.getScrollTop()
+        origScrollTop = getScrollTop(editor)
 
         # console.log "origScrollTop:
         if not forceEntireFile and isSelection
@@ -132,7 +138,7 @@ beautify = ({onSave}) ->
         setTimeout ( ->
 
           # console.log "setScrollTop"
-          editor.setScrollTop origScrollTop
+          setScrollTop editor, origScrollTop
           return
         ), 0
     else
@@ -495,7 +501,7 @@ handleSaveEvent = ->
       logger.verbose('save editor positions', key, beautifyOnSave)
       if beautifyOnSave
         posArray = getCursors(editor)
-        origScrollTop = editor.getScrollTop()
+        origScrollTop = getScrollTop(editor)
         beautifyFilePath(filePath, ->
           if editor.isAlive() is true
             buffer.reload()
@@ -505,7 +511,7 @@ handleSaveEvent = ->
             # addition happens asynchronously
             setTimeout ( ->
               setCursors(editor, posArray)
-              editor.setScrollTop(origScrollTop)
+              setScrollTop(editor, origScrollTop)
               # console.log "setScrollTop"
               return
             ), 0


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Deprecation warnings raised by the use of `editor.getScrollTop` and `editor.setScrollTop`.

### Does this close any currently open issues?
No. I expected it to have been reported already, but the errors were only raised when running in dev mode (and only after I invoked the beautify function).

### Any other comments?
I'm eating fresh green grapes.

Dude, they're delicious.

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
