### PR TITLE
Fix yapf style issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add [clang-format](http://clang.llvm.org/docs/ClangFormat.html) beautifier for C/C++/Obj-C languages.
 - Add [yapf](http://github.com/google/yapf) beautifier for Python.
 - Closes [#776] (https://github.com/Glavin001/atom-beautify/issues/776) Add support for `collapse-preserve-inline` brace_style for javascript.
+- Closes [#786](https://github.com/Glavin001/atom-beautify/issues/786) YAPF configuration files are ignored.
 
 # v0.29.0
 - Closes [#447](https://github.com/Glavin001/atom-beautify/issues/447). Improved Handlebars language support

--- a/package.json
+++ b/package.json
@@ -70,6 +70,10 @@
     {
       "name": "Bati Sengul",
       "url": "https://github.com/Focus"
+    },
+    {
+      "name": "Dheepak Krishnamurthy",
+      "url": "https://github.com/kdheepak89"
     }
   ],
   "engines": {

--- a/src/beautifiers/yapf.coffee
+++ b/src/beautifiers/yapf.coffee
@@ -16,7 +16,6 @@ module.exports = class Yapf extends Beautifier
   beautify: (text, language, options) ->
     @run("yapf", [
       "-i"
-      ["--style=pep8"]
       tempFile = @tempFile("input", text)
       ], help: {
         link: "https://github.com/google/yapf"


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

YAPF configuration files were previously being ignored. This was because the `run` call to yapf was explicitly defining a `--style` flag.

The --style flag accepts different types of input. From their documentation - "accepts one of the predefined styles (e.g., pep8 or google), a path to a configuration file that specifies the desired style, or a dictionary of key/value pairs."

By not explicitly specifying the --style flag, yapf will look for the following in order

1. In the [style] section of a .style.yapf file in either the current directory or one of its parent directories.
2. In the [yapf] secionf of a setup.cfg file in either the current directory or one of its parent directories.
3. In the ~/.config/yapf/style file in your home directory.

This pull request removes the `--style=pep8` flag in the `run` call to yapf. This is not required, since yapf uses `pep8` by default

### Does this close any currently open issues?

This closes #786 

### Any other comments?

A further improvement will be to have a field where the style can be entered as a dictionary.

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)