### PR TITLE
Added opencl language support

### DIFF
--- a/src/languages/c.coffee
+++ b/src/languages/c.coffee
@@ -8,6 +8,7 @@ module.exports = {
   ###
   grammars: [
     "C"
+    "opencl"
   ]
 
   ###

--- a/src/languages/c.coffee
+++ b/src/languages/c.coffee
@@ -15,6 +15,7 @@ module.exports = {
   ###
   extensions: [
     "c"
+    "cl"
   ]
 
   options:


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Added support for opencl language by including its file extension .cl in the c language support module.

### Does this close any currently open issues?

https://github.com/Glavin001/atom-beautify/issues/870

### Any other comments?

OpenCL language support is achieved here simply by attaching '.CL' extension to the 'C' language module. OpenCL is C based however beautify will not support beautification despite having C language support, due to the different file extension.