### PR TITLE
allow beatify *.pug files

### DIFF
--- a/src/languages/jade.coffee
+++ b/src/languages/jade.coffee
@@ -16,14 +16,14 @@ module.exports = {
   Supported Grammars
   ###
   grammars: [
-    "Jade"
+    "Jade", "Pug"
   ]
 
   ###
   Supported extensions
   ###
   extensions: [
-    "jade"
+    "jade", "pug"
   ]
 
   options: [


### PR DESCRIPTION
It seems, what default extension of jade now is `pug`, but atom-beautifier (with `language-pug` package) can't handle `*.pug` files