### PR TITLE
add ocaml language

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,3 +70,6 @@ before_install:
   # Elm
   - curl -L -o /tmp/elm-format.tgz https://github.com/avh4/elm-format/releases/download/0.2.0-alpha/elm-format-0.2.0-alpha-mac-x64.tgz
   - tar xvzf /tmp/elm-format.tgz -C /usr/local/bin
+  # OCaml
+  - brew install ocaml opam
+  - opam install ocp-indent

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,4 +72,6 @@ before_install:
   - tar xvzf /tmp/elm-format.tgz -C /usr/local/bin
   # OCaml
   - brew install ocaml opam
+  - opam init --auto-setup
   - opam install ocp-indent
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,5 +73,5 @@ before_install:
   # OCaml
   - brew install ocaml opam
   - opam init --auto-setup
-  - opam install ocp-indent
+  - opam install --yes ocp-indent
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # dev
+- Add [ocp-indent](https://github.com/OCamlPro/ocp-indent) beautifier for the OCaml language.
 - Add [elm-format](https://github.com/avh4/elm-format) beautifier for the Elm language.
 - Add [clang-format](http://clang.llvm.org/docs/ClangFormat.html) beautifier for C/C++/Obj-C languages.
 - Add [yapf](http://github.com/google/yapf) beautifier for Python.

--- a/examples/nested-jsbeautifyrc/ocaml/expected/js-pattern.ml
+++ b/examples/nested-jsbeautifyrc/ocaml/expected/js-pattern.ml
@@ -1,0 +1,51 @@
+let f = function
+  | _ -> 0
+;;
+
+let f x = match x with
+  | _ -> 0
+;;
+
+let f =
+  function
+  | _ -> 0
+;;
+
+let f x =
+  match x with
+  | _ -> 0
+;;
+
+let f x =
+  begin match x with
+    | _ -> 0
+  end
+;;
+
+let check_price t = function
+  | { Exec.
+      trade_at_settlement = (None | Some false);
+    } -> ()
+
+let check_price t = function
+  | simpler -> ()
+  | other -> ()
+
+(* Sometimes we like to write big alternations like this, in which case the
+   comment should typically align with the following clause. *)
+let 0 =
+  match x with
+  | A
+    (* a *)
+    -> a
+let 0 =
+  match x with
+    A
+    (* a *)
+    -> a
+
+let _ =
+  a
+  || match a with
+  | a -> true
+  | b -> false

--- a/examples/nested-jsbeautifyrc/ocaml/original/js-pattern.ml
+++ b/examples/nested-jsbeautifyrc/ocaml/original/js-pattern.ml
@@ -1,0 +1,51 @@
+let f = function
+  | _ -> 0
+;;
+
+let f x = match x with
+          | _ -> 0
+;;
+
+let f =
+  function
+  | _ -> 0
+;;
+
+let f x =
+  match x with
+  | _ -> 0
+;;
+
+let f x =
+  begin match x with
+        | _ -> 0
+  end
+;;
+
+let check_price t = function
+  | { Exec.
+      trade_at_settlement = (None | Some false);
+    } -> ()
+
+let check_price t = function
+  | simpler -> ()
+  | other -> ()
+
+(* Sometimes we like to write big alternations like this, in which case the
+   comment should typically align with the following clause. *)
+let 0 =
+  match x with
+  | A
+    (* a *)
+    -> a
+let 0 =
+  match x with
+    A
+    (* a *)
+    -> a
+
+let _ =
+  a
+  || match a with
+     | a -> true
+     | b -> false

--- a/package.json
+++ b/package.json
@@ -74,6 +74,10 @@
     {
       "name": "Dheepak Krishnamurthy",
       "url": "https://github.com/kdheepak89"
+    },
+    {
+      "name": "Frederic Delbos",
+      "url": "https://github.com/fdelbos"
     }
   ],
   "engines": {

--- a/src/beautifiers/index.coffee
+++ b/src/beautifiers/index.coffee
@@ -48,6 +48,7 @@ module.exports = class Beautifiers extends EventEmitter
     'fortran-beautifier'
     'js-beautify'
     'jscs'
+    'ocp-indent'
     'perltidy'
     'php-cs-fixer'
     'phpcbf'

--- a/src/beautifiers/ocp-indent.coffee
+++ b/src/beautifiers/ocp-indent.coffee
@@ -1,0 +1,18 @@
+###
+Requires https://github.com/OCamlPro/ocp-indent
+###
+
+"use strict"
+Beautifier = require('./beautifier')
+
+module.exports = class OCPIndent extends Beautifier
+  name: "ocp-indent"
+
+  options: {
+    OCaml: true
+  }
+
+  beautify: (text, language, options) ->
+    @run("ocp-indent", [
+      @tempFile("input", text)
+      ])

--- a/src/languages/index.coffee
+++ b/src/languages/index.coffee
@@ -43,6 +43,7 @@ module.exports = class Languages
     'marko'
     "mustache"
     "objective-c"
+    "ocaml"
     "pawn"
     "perl"
     "php"

--- a/src/languages/ocaml.coffee
+++ b/src/languages/ocaml.coffee
@@ -1,0 +1,22 @@
+module.exports = {
+
+  name: "OCaml"
+  namespace: "ocaml"
+
+  ###
+  Supported Grammars
+  ###
+  grammars: [
+    "OCaml"
+  ]
+
+  ###
+  Supported extensions
+  ###
+  extensions: [
+    "ml"
+  ]
+
+  options: []
+
+}


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Adds support for OCaml language indentation

### Does this close any currently open issues?

no

### Any other comments?

ocp-indent must be installed:
```
brew install ocaml opam
opam install ocp-indent
```

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)

