### PR TITLE
Removed cross-spawn dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,9 +125,6 @@
     "winston": "^2.2.0",
     "yaml-front-matter": "^3.2.3"
   },
-  "optionalDependencies": {
-    "cross-spawn": "^2.0.0"
-  },
   "activationCommands": {
     "atom-workspace": [
       "atom-beautify:help-debug-editor",

--- a/src/beautifiers/beautifier.coffee
+++ b/src/beautifiers/beautifier.coffee
@@ -4,12 +4,7 @@ fs = require("fs")
 temp = require("temp").track()
 readFile = Promise.promisify(fs.readFile)
 which = require('which')
-# Get optional dependency cross-spawn
-spawn = null
-try
-  spawn = require('cross-spawn')
-catch err
-  spawn = require('child_process').spawn
+spawn = require('child_process').spawn
 
 module.exports = class Beautifier
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Fixes the `spawn cmd.exe ENOENT` error on Windows and makes it possible to run various tools again.

### Does this close any currently open issues?

Probably #396, #456, #456, #598, #768, and #932. Possibly more.

### Any other comments?

This change fixed the support of `rustfmt` for me. I did not test it with any other tool like those in the linked issues above.

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)