### PR TITLE
Marko v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Or Settings/Preferences ➔ Packages ➔ Search for `atom-beautify`
   - [x] XML
   - [x] SVG
   - [x] [Marko](https://github.com/marko-js/marko)
-    - Requires [language-marko](https://github.com/marko-js/atom-language-marko)
 - [x] CSS, including
   - [Sass](http://sass-lang.com/)
   - [Less](http://lesscss.org/)

--- a/docs/add-languages-and-beautifiers.md
+++ b/docs/add-languages-and-beautifiers.md
@@ -26,7 +26,12 @@ Now your Language is available and can be detected and beautifiers can support i
     - Prettydiff is a good example of complex options: https://github.com/Glavin001/atom-beautify/blob/master/src/beautifiers/prettydiff.coffee
     - PHP-CS-Fixer is a good example of a CLI beautifier with arguments: https://github.com/Glavin001/atom-beautify/blob/master/src/beautifiers/php-cs-fixer.coffee#L15-L39
   - `options` - the key represents the Language's name. The value could be `true` (supports all options), `false` (supports language, with no options), or an `object` whose keys are option keys and values are complex mappings. If you need to use these, let me know. `true` is probably what you want.
-  - The `beautify` function should return a `Promise` (use `@Promise` as shown). The arguments passed are: `text`, the source code from Atom's Text Editor, `language` is a string of the language's name (`JavaScript`), and `options` is an object of all of the options in their form as described by your Language definition (see `Configure the new language` above).
+  - The `beautify` function should return a `Promise` (use `@Promise` as shown). The arguments passed are:
+    - __`text`__ -  the source code from Atom's Text Editor
+    - __`language`__ - the language's name (`JavaScript`)
+    - __`options`__ - an object of all of the options in their form as described by your Language definition (see `Configure the new language` above).
+    - __`context`__ - an object with extra information:
+        - __`filePath`__ - The file path associated with the text being beautified (may be null)
 3. Add beautifier to list of `beautifierNames`: https://github.com/Glavin001/atom-beautify/blob/master/src/beautifiers/index.coffee#L34
 4. Add test example files in https://github.com/Glavin001/atom-beautify/tree/master/examples
   - You can put your test in `nested-jsbeautifyrc` directory, https://github.com/Glavin001/atom-beautify/tree/master/examples/nested-jsbeautifyrc

--- a/examples/nested-jsbeautifyrc/marko/expected/test.marko
+++ b/examples/nested-jsbeautifyrc/marko/expected/test.marko
@@ -1,8 +1,6 @@
-<if test="data.items">
-  <for each="item in data.items">
-    <div>${item.name}</div>
-  </for>
+<if(data.items)>
+    <for(item in data.items)>
+        <div>${item.name}</div>
+    </for>
 </if>
-<else>
-  content
-</else>
+<else>content</else>

--- a/examples/nested-jsbeautifyrc/marko/expected/test.marko
+++ b/examples/nested-jsbeautifyrc/marko/expected/test.marko
@@ -1,6 +1,6 @@
 <if(data.items)>
-    <for(item in data.items)>
-        <div>${item.name}</div>
-    </for>
+  <for(item in data.items)>
+    <div>${item.name}</div>
+  </for>
 </if>
 <else>content</else>

--- a/examples/nested-jsbeautifyrc/marko/original/test.marko
+++ b/examples/nested-jsbeautifyrc/marko/original/test.marko
@@ -1,8 +1,6 @@
-<if test="data.items">
-<for each="item in data.items">
- <div>${item.name}</div>
+<if(data.items)>
+<for(item in data.items)>
+<div>${item.name}</div>
 </for>
 </if>
-<else>
- content
-</else>
+<else>content</else>

--- a/examples/simple-jsbeautifyrc/marko/expected/test.marko
+++ b/examples/simple-jsbeautifyrc/marko/expected/test.marko
@@ -1,6 +1,2 @@
-<if test="${data.items}">
-  content
-</if>
-<else>
-  content
-</else>
+<if(data.items)>content</if>
+<else>content</else>

--- a/examples/simple-jsbeautifyrc/marko/original/test.marko
+++ b/examples/simple-jsbeautifyrc/marko/original/test.marko
@@ -1,6 +1,4 @@
-<if test="${data.items}">
-content
-</if>
-<else>
-content
-</else>
+if(data.items)
+    - content
+else
+    - content

--- a/package.json
+++ b/package.json
@@ -82,6 +82,10 @@
     {
       "name": "Frederic Delbos",
       "url": "https://github.com/fdelbos"
+    },
+    {
+      "name": "Patrick Steele-Idem",
+      "url": "https://github.com/psteeleidem"
     }
   ],
   "engines": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "jscs": "^3.0.3",
     "lodash": "^4.8.2",
     "loophole": "^1.0.0",
+    "marko-prettyprint": "^1.1.0",
     "node-dir": "^0.1.8",
     "node-uuid": "^1.4.3",
     "prettydiff": "^1.16.27",

--- a/src/beautifiers/index.coffee
+++ b/src/beautifiers/index.coffee
@@ -66,6 +66,7 @@ module.exports = class Beautifiers extends EventEmitter
     'typescript-formatter'
     'yapf'
     'erl_tidy'
+    'marko-beautifier'
   ]
 
   ###
@@ -276,7 +277,11 @@ module.exports = class Beautifiers extends EventEmitter
 
             # Beautify text with language options
             @emit "beautify::start"
-            beautifier.beautify(text, language.name, options)
+
+            context =
+              filePath: filePath
+
+            beautifier.beautify(text, language.name, options, context)
             .then(resolve)
             .catch(reject)
             .finally(=>

--- a/src/beautifiers/js-beautify.coffee
+++ b/src/beautifiers/js-beautify.coffee
@@ -9,7 +9,6 @@ module.exports = class JSBeautify extends Beautifier
     XML: true
     Handlebars: true
     Mustache: true
-    Marko: true
     JavaScript: true
     JSON: true
     CSS:
@@ -41,7 +40,7 @@ module.exports = class JSBeautify extends Beautifier
             beautifyHTML = require("js-beautify").html
             text = beautifyHTML(text, options)
             resolve text
-          when "HTML (Liquid)", "HTML", "XML", "Marko", "Web Form/Control (C#)", "Web Handler (C#)"
+          when "HTML (Liquid)", "HTML", "XML", "Web Form/Control (C#)", "Web Handler (C#)"
             beautifyHTML = require("js-beautify").html
             text = beautifyHTML(text, options)
             @debug("Beautified HTML: #{text}")

--- a/src/beautifiers/marko-beautifier.coffee
+++ b/src/beautifiers/marko-beautifier.coffee
@@ -1,0 +1,32 @@
+"use strict"
+Beautifier = require('./beautifier')
+
+module.exports = class MarkoBeautifier extends Beautifier
+  name: 'Marko Beautifier'
+
+  options:
+    Marko: true
+
+  beautify: (text, language, options, context) ->
+
+    return new @Promise((resolve, reject) ->
+      markoPrettyprint = require('marko-prettyprint')
+
+      indent_char = options.indent_char || ' '
+      indent_size = options.indent_size || 4
+
+      indent = ''
+
+      for i in [0...indent_size - 1] by 1
+        indent += indent_char
+
+      prettyprintOptions =
+        syntax : options.syntax
+        filename: if context.filePath then context.filePath else require.resolve('marko-prettyprint')
+
+      try
+        resolve(markoPrettyprint(text, prettyprintOptions))
+      catch error
+        # Error occurred
+        reject(error)
+    )

--- a/src/beautifiers/marko-beautifier.coffee
+++ b/src/beautifiers/marko-beautifier.coffee
@@ -17,12 +17,13 @@ module.exports = class MarkoBeautifier extends Beautifier
 
       indent = ''
 
-      for i in [0...indent_size - 1] by 1
+      for i in [0..indent_size - 1]
         indent += indent_char
 
       prettyprintOptions =
         syntax : options.syntax
         filename: if context.filePath then context.filePath else require.resolve('marko-prettyprint')
+        indent: indent
 
       try
         resolve(markoPrettyprint(text, prettyprintOptions))

--- a/src/languages/marko.coffee
+++ b/src/languages/marko.coffee
@@ -1,8 +1,15 @@
+# Get Atom defaults
+scope = ['text.marko']
+tabLength = atom?.config.get('editor.tabLength', scope: scope) ? 4
+softTabs = atom?.config.get('editor.softTabs', scope: scope) ? true
+defaultIndentSize = (if softTabs then tabLength else 4)
+defaultIndentChar = (if softTabs then " " else "\t")
+defaultIndentWithTabs = not softTabs
+
 module.exports = {
 
   name: "Marko"
   namespace: "marko"
-  fallback: ['html']
 
   ###
   Supported Grammars
@@ -18,6 +25,22 @@ module.exports = {
     "marko"
   ]
 
-  options: []
+  options:
+    indent_size:
+      type: 'integer'
+      default: defaultIndentSize
+      minimum: 0
+      description: "Indentation size/length"
+    indent_char:
+      type: 'string'
+      default: defaultIndentChar
+      description: "Indentation character"
+    syntax:
+      type: 'string'
+      default: "html"
+      enum: ["html", "concise"]
+      description: "[html|concise]"
+
+  defaultBeautifier: "Marko Beautifier"
 
 }

--- a/src/languages/marko.coffee
+++ b/src/languages/marko.coffee
@@ -10,6 +10,7 @@ module.exports = {
 
   name: "Marko"
   namespace: "marko"
+  fallback: ['html']
 
   ###
   Supported Grammars


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

The Marko templating language had a new major release that introduced a new syntax. Marko now parses all HTML attributes as JavaScript expressions and it supports both an HTML syntax and a concise syntax. See: [What's New in Marko v3](http://markojs.com/docs/marko/what-is-new-marko-v3/)

### Does this close any currently open issues?

No.

### Any other comments?

The Marko beautifier was updated to use the following package: [marko-prettyprint](https://github.com/marko-js/marko-prettyprint). The `marko-prettyprint` tool needs to know the file system path associated with the text being beautified since custom tags need to be resolved relative to the location of the template on disk and tag definitions can impact pretty printing (e.g., some tags are declared to preserve whitespace). The `atom-beautifier` plugin was not providing the file path so I introduced a new `context` argument that now includes the `filePath` property (if available) as a fourth argument. The new signature is: `beautify(text, language, options, context)`

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [X] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
