### PR TITLE
Enable use of JavaScript beautifier with JXA files

### DIFF
--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -15,14 +15,17 @@ module.exports = {
   Supported Grammars
   ###
   grammars: [
-    "JavaScript"
+    "JavaScript",
+    "JavaScript for Automation (JXA)"
   ]
 
   ###
   Supported extensions
   ###
   extensions: [
-    "js"
+    "js",
+    "scpt",
+    "applescript"
   ]
 
   defaultBeautifier: "JS Beautify"

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -24,8 +24,10 @@ module.exports = {
   ###
   extensions: [
     "js",
-    "scpt",
-    "applescript"
+	"scpt"
+	"jxa"
+	"jxainc"
+	"applescript"
   ]
 
   defaultBeautifier: "JS Beautify"


### PR DESCRIPTION
Enable use of JavaScript beautifier with (OS X) JavaScript for
Automation (JXA) files.

JXA files use the extensions .scpt and .applescript

See package: language-javascript-jxa