### PR TITLE
Fix compatibility with atom 1.9.x #979

### DIFF
--- a/src/beautify.coffee
+++ b/src/beautify.coffee
@@ -28,10 +28,10 @@ $ = null
 # return data;
 # }
 getScrollTop = (editor) ->
-  view = editor.viewRegistry.getView(editor)
+  view = atom.views.getView(editor)
   view.getScrollTop()
 setScrollTop = (editor, value) ->
-  view = editor.viewRegistry.getView(editor)
+  view = atom.views.getView(editor)
   view.setScrollTop value
 
 getCursors = (editor) ->


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Due to changes between atom 1.8 and 1.9 is editor.viewRegistry not availbale,
it has to be changed to atom.views.

### Does this close any currently open issues?

#979 

### Any other comments?

Hasn't been tested in older version of atom

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)