### PR TITLE
Add .php_cs file support to php-cs-fixer beautifier

### DIFF
--- a/src/beautifiers/beautifier.coffee
+++ b/src/beautifiers/beautifier.coffee
@@ -1,10 +1,11 @@
-Promise = require("bluebird")
+Promise = require('bluebird')
 _ = require('lodash')
-fs = require("fs")
-temp = require("temp").track()
+fs = require('fs')
+temp = require('temp').track()
 readFile = Promise.promisify(fs.readFile)
 which = require('which')
 spawn = require('child_process').spawn
+path = require('path')
 
 module.exports = class Beautifier
 
@@ -27,7 +28,6 @@ module.exports = class Beautifier
   - <string:language>:<string:option_key>:<string:rename>
   - <string:language>:<string:option_key>:<function:transform>
   - <string:language>:<string:option_key>:<array:mapper>
-
   ###
   options: {}
 
@@ -78,6 +78,24 @@ module.exports = class Beautifier
     .then((filePath) ->
       return readFile(filePath, "utf8")
     )
+
+  ###
+  Find file
+  ###
+  findFile: (startDir, fileNames) ->
+    throw new Error "Specify file names to find." unless arguments.length
+    unless fileNames instanceof Array
+      fileNames = [fileNames]
+    startDir = startDir.split(path.sep)
+    while startDir.length
+      currentDir = startDir.join(path.sep)
+      for fileName in fileNames
+        filePath = path.join(currentDir, fileName)
+        try
+          fs.accessSync(filePath, fs.R_OK)
+          return filePath
+      startDir.pop()
+    return null
 
   ###
   If platform is Windows

--- a/src/beautifiers/marko-beautifier.coffee
+++ b/src/beautifiers/marko-beautifier.coffee
@@ -2,6 +2,7 @@
 Beautifier = require('./beautifier')
 
 module.exports = class MarkoBeautifier extends Beautifier
+
   name: 'Marko Beautifier'
 
   options:
@@ -22,7 +23,7 @@ module.exports = class MarkoBeautifier extends Beautifier
 
       prettyprintOptions =
         syntax : options.syntax
-        filename: if context.filePath then context.filePath else require.resolve('marko-prettyprint')
+        filename: if context? and context.filePath? then context.filePath else require.resolve('marko-prettyprint')
         indent: indent
 
       try

--- a/src/beautifiers/php-cs-fixer.coffee
+++ b/src/beautifiers/php-cs-fixer.coffee
@@ -4,19 +4,22 @@ Requires https://github.com/FriendsOfPHP/PHP-CS-Fixer
 
 "use strict"
 Beautifier = require('./beautifier')
+path = require('path')
 
 module.exports = class PHPCSFixer extends Beautifier
+
   name: "PHP-CS-Fixer"
 
   options: {
     PHP: true
   }
 
-  beautify: (text, language, options) ->
+  beautify: (text, language, options, context) ->
     @debug('php-cs-fixer', options)
 
-    isWin = @isWindows
-    if isWin
+    configFile = @findFile(path.dirname(context.filePath), '.php_cs');
+
+    if @isWindows
       # Find php-cs-fixer.phar script
       @Promise.all([
         @which(options.cs_fixer_path) if options.cs_fixer_path
@@ -24,7 +27,6 @@ module.exports = class PHPCSFixer extends Beautifier
       ]).then((paths) =>
         @debug('php-cs-fixer paths', paths)
         _ = require 'lodash'
-        path = require 'path'
         # Get first valid, absolute path
         phpCSFixerPath = _.find(paths, (p) -> p and path.isAbsolute(p) )
         @verbose('phpCSFixerPath', phpCSFixerPath)
@@ -37,6 +39,7 @@ module.exports = class PHPCSFixer extends Beautifier
             "fix"
             "--level=#{options.level}" if options.level
             "--fixers=#{options.fixers}" if options.fixers
+            "--config-file=#{configFile}" if configFile
             tempFile = @tempFile("temp", text)
             ], {
               ignoreReturnCode: true
@@ -64,6 +67,7 @@ module.exports = class PHPCSFixer extends Beautifier
         "fix"
         "--level=#{options.level}" if options.level
         "--fixers=#{options.fixers}" if options.fixers
+        "--config-file=#{configFile}" if configFile
         tempFile = @tempFile("temp", text)
         ], {
           ignoreReturnCode: true

--- a/src/beautifiers/php-cs-fixer.coffee
+++ b/src/beautifiers/php-cs-fixer.coffee
@@ -17,7 +17,7 @@ module.exports = class PHPCSFixer extends Beautifier
   beautify: (text, language, options, context) ->
     @debug('php-cs-fixer', options)
 
-    configFile = @findFile(path.dirname(context.filePath), '.php_cs')
+    configFile = if context.filePath then @findFile(path.dirname(context.filePath), '.php_cs')
 
     if @isWindows
       # Find php-cs-fixer.phar script

--- a/src/beautifiers/php-cs-fixer.coffee
+++ b/src/beautifiers/php-cs-fixer.coffee
@@ -17,7 +17,7 @@ module.exports = class PHPCSFixer extends Beautifier
   beautify: (text, language, options, context) ->
     @debug('php-cs-fixer', options)
 
-    configFile = @findFile(path.dirname(context.filePath), '.php_cs');
+    configFile = @findFile(path.dirname(context.filePath), '.php_cs')
 
     if @isWindows
       # Find php-cs-fixer.phar script

--- a/src/beautifiers/php-cs-fixer.coffee
+++ b/src/beautifiers/php-cs-fixer.coffee
@@ -8,16 +8,15 @@ path = require('path')
 
 module.exports = class PHPCSFixer extends Beautifier
 
-  name: "PHP-CS-Fixer"
+  name: 'PHP-CS-Fixer'
 
-  options: {
+  options:
     PHP: true
-  }
 
   beautify: (text, language, options, context) ->
     @debug('php-cs-fixer', options)
 
-    configFile = if context.filePath then @findFile(path.dirname(context.filePath), '.php_cs')
+    configFile = if context? and context.filePath? then @findFile(path.dirname(context.filePath), '.php_cs')
 
     if @isWindows
       # Find php-cs-fixer.phar script


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Add .php_cs file (php-cs-fixer config file) support to php-cs-fixer beautifier.
...

### Does this close any currently open issues?

Yes, #564 
...

### Any other comments?

1- I was added a `findFile` method, i think we can use this method in other beautifiers which support config file (e.g. rustfmt beautifier).
2- I think will be better if you chose a same coding style guild for all coffee files.
...

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)

