### PR TITLE
fixed order of home-dir expansion and project resolution

### DIFF
--- a/src/beautifiers/uncrustify/index.coffee
+++ b/src/beautifiers/uncrustify/index.coffee
@@ -37,6 +37,8 @@ module.exports = class Uncrustify extends Beautifier
         editor = atom.workspace.getActiveTextEditor()
         if editor?
           basePath = path.dirname(editor.getPath())
+          # Expand Home Directory in Config Path
+          configPath = expandHomeDir(configPath)
           # console.log(basePath);
           configPath = path.resolve(basePath, configPath)
           resolve configPath
@@ -44,9 +46,6 @@ module.exports = class Uncrustify extends Beautifier
           reject(new Error("No Uncrustify Config Path set! Please configure Uncrustify with Atom Beautify."))
     )
     .then((configPath) =>
-
-      # Expand Home Directory in Config Path
-      configPath = expandHomeDir(configPath)
 
       # Select Uncrustify language
       lang = "C" # Default is C


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

The uncrutify config path was first resolved against the current project folder.
This would `expand-home-dir` to not expand the home folder.

### Does this close any currently open issues?

This patch should fix issues #747 and #818.

### Any other comments?

None

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch



