### PR TITLE
Fix incorrent enforcement of tabs to spaces conversion in typescript

### DIFF
--- a/src/beautifiers/typescript-formatter.coffee
+++ b/src/beautifiers/typescript-formatter.coffee
@@ -16,10 +16,14 @@ module.exports = class TypeScriptFormatter extends Beautifier
         # @verbose('format', format, formatterUtils)
 
         opts = formatterUtils.createDefaultFormatCodeOptions()
-        opts.TabSize = options.tab_width or options.indent_size
-        opts.IndentSize = options.indent_size
-        opts.IndentStyle = 'space'
-        opts.convertTabsToSpaces = true
+
+        if options.indent_with_tabs
+          opts.ConvertTabsToSpaces = false
+        else
+          opts.TabSize = options.tab_width or options.indent_size
+          opts.IndentSize = options.indent_size
+          opts.IndentStyle = 'space'
+          
         @verbose('typescript', text, opts)
         result = format('', text, opts)
         @verbose(result)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Hi, the typescript formatter was ignoring ident_with_tabs setting and enforcing "space" indent style and tabs-to-spaces conversion. This PR should fix that.

### Does this close any currently open issues?
Should close an issue that is mentioned in #910 but separate issue for typescript was not probably created.

### Any other comments?
There was another bug in typescript library that prevented changing space indented source to tab indented source. This is already fixed, but is not in an official release yet, only in nightly.

### Checklist

Check all those that are applicable and complete.

- [ x ] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [x] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)

