### PR TITLE
run "phpcbf.bat" instead of "php phpcbf.bat"

### DIFF
--- a/src/beautifiers/phpcbf.coffee
+++ b/src/beautifiers/phpcbf.coffee
@@ -37,8 +37,13 @@ module.exports = class PHPCBF extends Beautifier
         # Check if phpcbf path was found
         if phpcbfPath?
           # Found phpcbf path
-          @run("php", [
-            phpcbfPath
+
+          # Check if phpcbf is an executable
+          isExec = path.extname(phpcbfPath) isnt ''
+          exec = if isExec then phpcbfPath else "php"
+
+          @run(exec, [
+            phpcbfPath unless isExec
             "--no-patch"
             "--standard=#{options.standard}" if options.standard
             tempFile = @tempFile("temp", text)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

If phpcbfPath is an executable then run it instead of running it as an argument to php

### Does this close any currently open issues?

Fixes #958 

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [x] AppVeyor passes (Windows support)

