### PR TITLE
Added "h" as a extension to the C language

### DIFF
--- a/src/languages/c.coffee
+++ b/src/languages/c.coffee
@@ -15,6 +15,7 @@ module.exports = {
   Supported extensions
   ###
   extensions: [
+    "h"
     "c"
     "cl"
   ]


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
This allows beautification of h files when you're doing C development

### Does this close any currently open issues?
No

### Any other comments?
This might break the cpp language since it currently uses the "h" extension, I'm not sure

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [N/A] Added examples for testing to [examples/ directory](examples/)
- [X] Travis CI passes (Mac support)
- [X] AppVeyor passes (Windows support)