### PR TITLE
Add "F90" extension

### DIFF
--- a/src/languages/fortran.coffee
+++ b/src/languages/fortran.coffee
@@ -15,6 +15,7 @@ module.exports = {
   ###
   extensions: [
     "f90"
+    "F90"
   ]
 
   ###


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This PR implements beautify compatibility with free-form Fortran files ending in ".F90".

### Does this close any currently open issues?

This resolves issue #1036.


Now works for Fortran files ending in ".F90"