### PR TITLE
Update installation instructions link for elm-format

### DIFF
--- a/src/beautifiers/elm-format.coffee
+++ b/src/beautifiers/elm-format.coffee
@@ -19,7 +19,7 @@ module.exports = class ElmFormat extends Beautifier
         '--yes',
         name
         ],
-        { help: { link: 'https://github.com/avh4/elm-format' } }
+        { help: { link: 'https://github.com/avh4/elm-format#installation-' } }
       )
       .then () =>
         @readFile(name)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Changes the help URL for elm-format to the official installation instructions URL.

### Does this close any currently open issues?

No

### Any other comments?

(I'm the maintainer of elm-format)

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)

