### PR TITLE
Fix phpcbf hanging issue by closing stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add [yapf](http://github.com/google/yapf) beautifier for Python.
 - Closes [#776] (https://github.com/Glavin001/atom-beautify/issues/776) Add support for `collapse-preserve-inline` brace_style for javascript.
 - Closes [#786](https://github.com/Glavin001/atom-beautify/issues/786) YAPF configuration files are ignored.
+- Fix phpcbf hanging issue by closing stdin. See [#893](https://github.com/Glavin001/atom-beautify/issues/893)
 
 # v0.29.0
 - Closes [#447](https://github.com/Glavin001/atom-beautify/issues/447). Improved Handlebars language support

--- a/package.json
+++ b/package.json
@@ -90,6 +90,10 @@
     {
       "name": "Joost van Doorn",
       "url": "https://github.com/JoostvDoorn"
+    },
+    {
+      "name": "Arman Yessenamanov",
+      "url": "https://github.com/yesenarman"
     }
   ],
   "engines": {

--- a/src/beautifiers/phpcbf.coffee
+++ b/src/beautifiers/phpcbf.coffee
@@ -53,6 +53,8 @@ module.exports = class PHPCBF extends Beautifier
               help: {
                 link: "http://php.net/manual/en/install.php"
               }
+              onStdin: (stdin) ->
+                stdin.end()
             })
             .then(=>
               @readFile(tempFile)
@@ -79,6 +81,8 @@ module.exports = class PHPCBF extends Beautifier
           help: {
             link: "https://github.com/squizlabs/PHP_CodeSniffer"
           }
+          onStdin: (stdin) ->
+            stdin.end()
         })
         .then(=>
           @readFile(tempFile)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This is a fix for issue #893.
There is an issue squizlabs/PHP_CodeSniffer#993 in `phpcbf` where it hangs when waiting for stdin.
The workaround is to close stdin of the child process since it is not being used anyway.

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [x] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)

