### PR TITLE
Add 'Babel ES6 JavaScript' as a grammar that supports JSX.

### DIFF
--- a/src/languages/jsx.coffee
+++ b/src/languages/jsx.coffee
@@ -8,6 +8,7 @@ module.exports = {
   Supported Grammars
   ###
   grammars: [
+    "Babel ES6 JavaScript"
     "JSX"
     "JavaScript (JSX)"
   ]


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Adds language-babel's grammar name to JSX supported languages.
...

### Does this close any currently open issues?
No
...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)

Add support for the language-babel package.