### PR TITLE
Added notification for both YAML and JSON .jsbeautifyrc parse error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Closes [#776] (https://github.com/Glavin001/atom-beautify/issues/776) Add support for `collapse-preserve-inline` brace_style for javascript.
 - Closes [#786](https://github.com/Glavin001/atom-beautify/issues/786) YAPF configuration files are ignored.
 - Fix phpcbf hanging issue by closing stdin. See [#893](https://github.com/Glavin001/atom-beautify/issues/893)
+- Add warning notification when parsing `.jsbeautifyrc` as JSON or YAML fails. See [#1106](https://github.com/Glavin001/atom-beautify/issues/1106)
 
 # v0.29.0
 - Closes [#447](https://github.com/Glavin001/atom-beautify/issues/447). Improved Handlebars language support

--- a/package.json
+++ b/package.json
@@ -94,6 +94,10 @@
     {
       "name": "Arman Yessenamanov",
       "url": "https://github.com/yesenarman"
+    },
+    {
+      "name": "Émile Bergeron",
+      "url": "https://github.com/emileber"
     }
   ],
   "engines": {

--- a/src/beautifiers/index.coffee
+++ b/src/beautifiers/index.coffee
@@ -477,13 +477,23 @@ module.exports = class Beautifiers extends EventEmitter
           strip ?= require("strip-json-comments")
           externalOptions = JSON.parse(strip(contents))
         catch e
-
+          jsonError = e.message
           logger.debug "Failed parsing config as JSON: " + configPath
           # Attempt as YAML
           try
             yaml ?= require("yaml-front-matter")
             externalOptions = yaml.safeLoad(contents)
           catch e
+            title = "Atom Beautify failed to parse config as JSON or YAML"
+            detail = """
+                     Parsing '.jsbeautifyrc' at #{configPath}
+                     JSON: #{jsonError}
+                     YAML: #{e.message}
+                     """
+            atom?.notifications.addWarning(title, {
+              detail
+              dismissable : true
+            })
             logger.debug "Failed parsing config as YAML and JSON: " + configPath
             externalOptions = {}
     else


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This implement a warning when the parsing of the `.jsbeautifyrc` fails. It gives the path of the file, and the reasons it failed for JSON and YAML.

![atom-beautify-warning](https://cloud.githubusercontent.com/assets/3286135/17539737/8e916bdc-5e7e-11e6-9402-9f79bb8c486c.jpg)

### Does this close any currently open issues?

It's related to the feature request #1106

### Any other comments?

To test this, add an error to any `.jsbeautifyrc` file (like an additional comma) and beautify any related file.

