### PR TITLE
Change path to uncrustify config file to be relative to the project rather than the open file.

### DIFF
--- a/src/beautifiers/uncrustify/index.coffee
+++ b/src/beautifiers/uncrustify/index.coffee
@@ -10,6 +10,7 @@ _ = require('lodash')
 
 module.exports = class Uncrustify extends Beautifier
   name: "Uncrustify"
+  link: "https://github.com/uncrustify/uncrustify"
   options: {
     Apex: true
     C: true

--- a/src/beautifiers/uncrustify/index.coffee
+++ b/src/beautifiers/uncrustify/index.coffee
@@ -10,7 +10,6 @@ _ = require('lodash')
 
 module.exports = class Uncrustify extends Beautifier
   name: "Uncrustify"
-  link: "https://github.com/uncrustify/uncrustify"
   options: {
     Apex: true
     C: true
@@ -38,15 +37,17 @@ module.exports = class Uncrustify extends Beautifier
         editor = atom.workspace.getActiveTextEditor()
         if editor?
           basePath = path.dirname(editor.getPath())
-          # Expand Home Directory in Config Path
-          configPath = expandHomeDir(configPath)
+          projectPath = atom.workspace.project.getPaths()[0]
           # console.log(basePath);
-          configPath = path.resolve(basePath, configPath)
+          # Expand Home Directory in Config Path
+          expandedConfigPath = expandHomeDir(configPath)
+          configPath = path.resolve(projectPath, expandedConfigPath)
           resolve configPath
         else
           reject(new Error("No Uncrustify Config Path set! Please configure Uncrustify with Atom Beautify."))
     )
     .then((configPath) =>
+
 
       # Select Uncrustify language
       lang = "C" # Default is C


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

When the configuration for the `uncrustify` config file path has no path
`atom-beautify` had the habit of pre-pending the path to the
file open in the editor pane. This meant that in order to use a
project specific configuration every directory would need to contain
a config file -- unacceptable. This changes the scheme to pre-pend
the path to the project when no path is specified making it possible
to have a single configuration file for an entire project and also
being able to maintain the configuration under source control.

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
