### PR TITLE
Add JavaScript and JSX language support for language-babel grammar.

### DIFF
--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -16,6 +16,7 @@ module.exports = {
   ###
   grammars: [
     "JavaScript"
+    "Babel ES6 JavaScript"
   ]
 
   ###

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -16,7 +16,6 @@ module.exports = {
   ###
   grammars: [
     "JavaScript"
-    "Babel ES6 JavaScript"
   ]
 
   ###

--- a/src/languages/jsx.coffee
+++ b/src/languages/jsx.coffee
@@ -10,6 +10,7 @@ module.exports = {
   grammars: [
     "JSX"
     "JavaScript (JSX)"
+    "Babel ES6 JavaScript"
   ]
 
   ###


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Adds language support in JavaScript and JSX for [language-babel](https://atom.io/packages/language-babel).

### Does this close any currently open issues?

The following issues mention language-babel (`Babel ES6 JavaScript`) https://github.com/Glavin001/atom-beautify/issues/974, https://github.com/Glavin001/atom-beautify/issues/1018, https://github.com/Glavin001/atom-beautify/issues/888, https://github.com/Glavin001/atom-beautify/issues/144

### Any other comments?


### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)

