### PR TITLE
Smarty and template support in HTML formatter

### DIFF
--- a/src/languages/html.coffee
+++ b/src/languages/html.coffee
@@ -22,7 +22,9 @@ module.exports = {
   Supported extensions
   ###
   extensions: [
-    "html"
+    "html",
+    "smarty",
+    "tpl"
   ]
 
   options:

--- a/src/languages/html.coffee
+++ b/src/languages/html.coffee
@@ -22,9 +22,7 @@ module.exports = {
   Supported extensions
   ###
   extensions: [
-    "html",
-    "smarty",
-    "tpl"
+    "html"
   ]
 
   options:

--- a/src/languages/smarty.coffee
+++ b/src/languages/smarty.coffee
@@ -1,0 +1,24 @@
+module.exports = {
+
+  name: "Smarty"
+  description: "Smarty"
+  namespace: "smarty"
+  fallback: ['html', 'js', 'php']
+
+  ###
+  Supported Grammars
+  ###
+  grammars: [
+    "HTML (Smarty)"
+  ]
+
+  ###
+  Supported extensions
+  ###
+  extensions: [
+    'smarty'
+  ]
+
+  options: []
+
+}


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Add smarty and tpl file extension support to the default HTML format engine.
### Does this close any currently open issues?
#940
### Any other comments?

Sorry I have not read into your build process to actually test this, but it looks pretty clean and simple to me.
### Checklist

Check all those that are applicable and complete.
- [ ] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)

Add smarty and tpl file extensions to default HTML format engine.
