### PR TITLE
Revert ba09880. Fixes #1196

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # dev
+- Revert to `Remark v4.2.2`. See [#1196](https://github.com/Glavin001/atom-beautify/issues/1196)
 - Add beautifier for the Lua language.
 - Add [ocp-indent](https://github.com/OCamlPro/ocp-indent) beautifier for the OCaml language.
 - Add [elm-format](https://github.com/avh4/elm-format) beautifier for the Elm language.

--- a/package.json
+++ b/package.json
@@ -110,6 +110,10 @@
     {
       "name": "Elias Baryshnikov",
       "url": "https://github.com/qwemaze"
+    },
+    {
+      "name": "Victor Uriarte",
+      "url": "https://github.com/vmuriart"
     }
   ],
   "engines": {
@@ -143,7 +147,7 @@
     "open": "0.0.5",
     "prettydiff": "^1.16.27",
     "pug-beautify": "^0.1.1",
-    "remark": "^6.0.1",
+    "remark": "^4.2.2",
     "season": "^5.3.0",
     "space-pen": "^5.1.1",
     "strip-json-comments": "^2.0.1",


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Revert ba09880. Fixes #1196 
...

### Does this close any currently open issues?
Yes. Closes #1196
...

### Any other comments?
I tested using v.6.0.0, v.5.1.0, v5.0.0 with no success. 
...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)

Remark v4.2.2 is the latest compatible version. It breaks on Remark v5.0.0