### PR TITLE
remove python from mac installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,6 @@ before_install:
   # Sass language support
   - gem install sass
   # Python language support
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo chmod 777 -R /opt/python; fi
   - pip install --upgrade pip
   - pip install --upgrade autopep8


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Improve/fix builds on Travis CI @ mac !

For example see: https://travis-ci.org/Glavin001/atom-beautify/jobs/168139151#L233

"**Error**: python-2.7.12_1 already installed"

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Travis CI passes (Mac support)


