### PR TITLE
added EJS as Grammar since JavaScript Template is not longer used by …

### DIFF
--- a/src/languages/ejs.coffee
+++ b/src/languages/ejs.coffee
@@ -9,6 +9,7 @@ module.exports = {
   Supported Grammars
   ###
   grammars: [
+    "EJS"
     "JavaScript Template"
     "HTML (Angular)"
   ]


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

The Atom language package for EJS changed there Grammar to EJS from Javascript template:
https://github.com/darron/language-ejs/commit/608ffa19a929a6a25a8314c4d564fc0dc9ab4121

### Does this close any currently open issues?

nope

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)