### PR TITLE
Added plist and recipe to XML extensions

### DIFF
--- a/src/languages/xml.coffee
+++ b/src/languages/xml.coffee
@@ -16,7 +16,7 @@ module.exports = {
   Supported extensions
   ###
   extensions: [
-    'sld', 'xml', 'xhtml', 'xsd', 'xsl', 'jsp', 'gsp'
+    'sld', 'xml', 'xhtml', 'xsd', 'xsl', 'jsp', 'gsp', 'plist', 'recipe'
   ]
 
   defaultBeautifier: "Pretty Diff"


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Add support for apple .plist files and .recipe plist files

### Does this close any currently open issues?

#1284

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)

.recipe is used by autopkg for plists