### PR TITLE
Elixir examples based on @lexmag Elixir Style Guide

### DIFF
--- a/examples/nested-jsbeautifyrc/elixir/README.md
+++ b/examples/nested-jsbeautifyrc/elixir/README.md
@@ -1,0 +1,9 @@
+# Elixir examples for atom-beautify
+
+> An examples for [atom-beautify](https://github.com/Glavin001/atom-beautify) that were created to test and validate an [elixir-lang](http://elixir-lang.org/) (Elixir language) support.
+> For more informations see #545.
+
+**Author**: [Tomasz Marek Sulima](https://github.com/Eiji7)
+
+All rules and their descripions come from [Aleksei Magusev](https://github.com/lexmag)'s [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide).
+For information about license see: [License](https://github.com/lexmag/elixir-style-guide#license) section.

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_01_spaces_indentation.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_01_spaces_indentation.ex
@@ -1,0 +1,19 @@
+defmodule Lexmag1SourceCodeLayout01SpacesIndentation do
+  @moduledoc """
+  Source: [spaces-indentation](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#spaces-indentation)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use two __spaces__ per indentation level. No hard tabs.
+  """
+  @spec test() :: any
+  def test() do
+    # code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_02_no_semicolon.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_02_no_semicolon.ex
@@ -1,0 +1,20 @@
+defmodule Lexmag1SourceCodeLayout02NoSemicolon do
+  @moduledoc """
+  Source: [no-semicolon](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#no-semicolon)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use one expression per line, as a corollary - don't use semicolon `;` to separate statements and expressions.
+  """
+  @spec test() :: any
+  def test() do
+    value = 1 + 2
+    value * 2
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_03_spaces_in_code.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_03_spaces_in_code.ex
@@ -12,12 +12,10 @@ defmodule Lexmag1SourceCodeLayout03SpacesInCode do
   @doc """
   Use spaces around binary operators, after commas `,`, colons `:` and semicolons `;`. Do not put spaces around matched pairs like brackets `[]`, braces `{}`, etc. Whitespace might be (mostly) irrelevant to the Elixir compiler, but its proper use is the key to writing easily readable code.
 
-  ```elixir
-  sum = 1 + 2
-  [first | rest] = 'three'
-  {a1, a2} = {2, 3}
-  Enum.join(["one", <<"two">>, sum])
-  ```
+      sum = 1 + 2
+      [first | rest] = 'three'
+      {a1, a2} = {2, 3}
+      Enum.join(["one", <<"two">>, sum])
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_03_spaces_in_code.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_03_spaces_in_code.ex
@@ -1,0 +1,29 @@
+defmodule Lexmag1SourceCodeLayout03SpacesInCode do
+  @moduledoc """
+  Source: [spaces-in-code](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#spaces-in-code)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use spaces around binary operators, after commas `,`, colons `:` and semicolons `;`. Do not put spaces around matched pairs like brackets `[]`, braces `{}`, etc. Whitespace might be (mostly) irrelevant to the Elixir compiler, but its proper use is the key to writing easily readable code.
+
+  ```elixir
+  sum = 1 + 2
+  [first | rest] = 'three'
+  {a1, a2} = {2, 3}
+  Enum.join(["one", <<"two">>, sum])
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    sum = 1 + 2
+    [_first | _rest] = ~c[three]
+    {_a1, _a2} = {2, 3}
+    Enum.join(["one", <<"two">>, sum])
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_04_no_spaces_in_code.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_04_no_spaces_in_code.ex
@@ -1,0 +1,30 @@
+defmodule Lexmag1SourceCodeLayout04NoSpacesInCode do
+  @moduledoc """
+  Source: [no-spaces-in-code](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#no-spaces-in-code)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  No spaces after unary operators and inside range literals, the only exception is the `not` operator.
+
+  ```elixir
+  angle = -45
+  ^result = Float.parse("42.01")
+  2 in 1..5
+  not File.exists?(path)
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    _angle = -45
+    result = 42.01
+    ^result = Float.parse("42.01")
+    _should_be_true = 2 in 1..5
+    not File.exists?("a_path_to_file_that_does_not_exists")
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_04_no_spaces_in_code.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_04_no_spaces_in_code.ex
@@ -12,12 +12,10 @@ defmodule Lexmag1SourceCodeLayout04NoSpacesInCode do
   @doc """
   No spaces after unary operators and inside range literals, the only exception is the `not` operator.
 
-  ```elixir
-  angle = -45
-  ^result = Float.parse("42.01")
-  2 in 1..5
-  not File.exists?(path)
-  ```
+      angle = -45
+      ^result = Float.parse("42.01")
+      2 in 1..5
+      not File.exists?(path)
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_05_default_arguments.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_05_default_arguments.ex
@@ -1,0 +1,19 @@
+defmodule Lexmag1SourceCodeLayout05DefaultArguments do
+  @moduledoc """
+  Source: [default-arguments](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#default-arguments)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use spaces around default arguments `\\` definition.
+  """
+  @spec test(something :: any) :: any
+  def test(_something \\ nil) do
+    # code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_06_bitstring_segment_options.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_06_bitstring_segment_options.ex
@@ -1,0 +1,30 @@
+defmodule Lexmag1SourceCodeLayout06BitstringSegmentOptions do
+  @moduledoc """
+  Source: [bitstring-segment-options](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#bitstring-segment-options)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Do not put spaces around segment options definition in bitstrings.
+
+  ```elixir
+  # Bad
+  <<102 :: unsigned-big-integer, rest :: binary>>
+  <<102::unsigned - big - integer, rest::binary>>
+
+  # Good
+  <<102::unsigned-big-integer, rest::binary>>
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    rest = "example"
+    <<102::unsigned-big-integer, rest::binary>>
+    <<102::unsigned-big-integer, rest::binary>>
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_06_bitstring_segment_options.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_06_bitstring_segment_options.ex
@@ -12,14 +12,12 @@ defmodule Lexmag1SourceCodeLayout06BitstringSegmentOptions do
   @doc """
   Do not put spaces around segment options definition in bitstrings.
 
-  ```elixir
-  # Bad
-  <<102 :: unsigned-big-integer, rest :: binary>>
-  <<102::unsigned - big - integer, rest::binary>>
+      # Bad
+      <<102 :: unsigned-big-integer, rest :: binary>>
+      <<102::unsigned - big - integer, rest::binary>>
 
-  # Good
-  <<102::unsigned-big-integer, rest::binary>>
-  ```
+      # Good
+      <<102::unsigned-big-integer, rest::binary>>
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_07_guard_clauses.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_07_guard_clauses.ex
@@ -12,17 +12,15 @@ defmodule Lexmag1SourceCodeLayout07GuardClauses do
   @doc """
   Indent `when` guard clauses on the same level as the function/macro signature in the definition they're part of. Do this only if you cannot fit the `when` guard on the same line as the definition.
 
-  ```elixir
-  def format_error({exception, stacktrace})
-      when is_list(stacktrace) and stacktrace != [] do
-    # ...
-  end
+      def format_error({exception, stacktrace})
+          when is_list(stacktrace) and stacktrace != [] do
+        # ...
+      end
 
-  defmacro dngettext(domain, msgid, msgid_plural, count)
-           when is_binary(msgid) and is_binary(msgid_plural) do
-    # ...
-  end
-  ```
+      defmacro dngettext(domain, msgid, msgid_plural, count)
+               when is_binary(msgid) and is_binary(msgid_plural) do
+        # ...
+      end
   """
   @spec test(stacktrace :: list) :: any
   def test(stacktrace)

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_07_guard_clauses.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_07_guard_clauses.ex
@@ -1,0 +1,39 @@
+defmodule Lexmag1SourceCodeLayout07GuardClauses do
+  @moduledoc """
+  Source: [guard-clauses](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#guard-clauses)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Indent `when` guard clauses on the same level as the function/macro signature in the definition they're part of. Do this only if you cannot fit the `when` guard on the same line as the definition.
+
+  ```elixir
+  def format_error({exception, stacktrace})
+      when is_list(stacktrace) and stacktrace != [] do
+    # ...
+  end
+
+  defmacro dngettext(domain, msgid, msgid_plural, count)
+           when is_binary(msgid) and is_binary(msgid_plural) do
+    # ...
+  end
+  ```
+  """
+  @spec test(stacktrace :: list) :: any
+  def test(stacktrace)
+      when is_list(stacktrace) do
+      # code here ...
+  end
+
+  @doc false
+  @spec macro_test(stacktrace :: list) :: any
+  defmacro macro_test(stacktrace)
+           when is_list(stacktrace) do
+    # code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_08_multi_line_expr_assignment.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_08_multi_line_expr_assignment.ex
@@ -12,28 +12,26 @@ defmodule Lexmag1SourceCodeLayout08MultiLineExprAssignment do
   @doc """
   When assigning the result of a multi-line expression, do not preserve alignment of its parts.
 
-  ```elixir
-  # Bad
-  {found, not_found} = Enum.map(files, &Path.expand(&1, path))
-                       |> Enum.partition(&File.exists?/1)
+      # Bad
+      {found, not_found} = Enum.map(files, &Path.expand(&1, path))
+                           |> Enum.partition(&File.exists?/1)
 
-  prefix = case base do
-             :binary -> "0b"
-             :octal -> "0o"
-             :hex -> "0x"
-           end
+      prefix = case base do
+                 :binary -> "0b"
+                 :octal -> "0o"
+                 :hex -> "0x"
+               end
 
-  # Good
-  {found, not_found} =
-    Enum.map(files, &Path.expand(&1, path))
-    |> Enum.partition(&File.exists?/1)
+      # Good
+      {found, not_found} =
+        Enum.map(files, &Path.expand(&1, path))
+        |> Enum.partition(&File.exists?/1)
 
-  prefix = case base do
-    :binary -> "0b"
-    :octal -> "0o"
-    :hex -> "0x"
-  end
-  ```
+      prefix = case base do
+        :binary -> "0b"
+        :octal -> "0o"
+        :hex -> "0x"
+      end
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_08_multi_line_expr_assignment.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_08_multi_line_expr_assignment.ex
@@ -1,0 +1,53 @@
+defmodule Lexmag1SourceCodeLayout08MultiLineExprAssignment do
+  @moduledoc """
+  Source: [multi-line-expr-assignment](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#multi-line-expr-assignment)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  When assigning the result of a multi-line expression, do not preserve alignment of its parts.
+
+  ```elixir
+  # Bad
+  {found, not_found} = Enum.map(files, &Path.expand(&1, path))
+                       |> Enum.partition(&File.exists?/1)
+
+  prefix = case base do
+             :binary -> "0b"
+             :octal -> "0o"
+             :hex -> "0x"
+           end
+
+  # Good
+  {found, not_found} =
+    Enum.map(files, &Path.expand(&1, path))
+    |> Enum.partition(&File.exists?/1)
+
+  prefix = case base do
+    :binary -> "0b"
+    :octal -> "0o"
+    :hex -> "0x"
+  end
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    files = []
+    path = File.cwd!
+    {_found, _not_found} =
+      files
+      |> Enum.map(&Path.expand(&1, path))
+      |> Enum.partition(&File.exists?/1)
+    base = :binary
+    _prefix = case base do
+      :binary -> "0b"
+      :octal -> "0o"
+      :hex -> "0x"
+    end
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_09_underscores_in_numerics.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_09_underscores_in_numerics.ex
@@ -1,0 +1,23 @@
+defmodule Lexmag1SourceCodeLayout09UnderscoresInNumerics do
+  @moduledoc """
+  Source: [underscores-in-numerics](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#underscores-in-numerics)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Add underscores to large numeric literals to improve their readability.
+
+  ```elixir
+  num = 1_000_000
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    _num = 1_000_000
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_09_underscores_in_numerics.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_09_underscores_in_numerics.ex
@@ -12,9 +12,7 @@ defmodule Lexmag1SourceCodeLayout09UnderscoresInNumerics do
   @doc """
   Add underscores to large numeric literals to improve their readability.
 
-  ```elixir
-  num = 1_000_000
-  ```
+      num = 1_000_000
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_10_quotes_around_atoms.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_10_quotes_around_atoms.ex
@@ -1,0 +1,31 @@
+defmodule Lexmag1SourceCodeLayout10QuotesAroundAtoms do
+  @moduledoc """
+  Source: [quotes-around-atoms](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#quotes-around-atoms)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  When using atom literals that need to be quoted because they contain characters that are invalid in atoms (such as `:"foo-bar"`), use double quotes around the atom name:
+
+  ```elixir
+  # Bad
+  :'foo-bar'
+  :'atom number \#{index}'
+
+  # Good
+  :"foo-bar"
+  :"atom number \#{index}"
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    index = 5
+    :"foo-bar"
+    :"atom number #{index}"
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_10_quotes_around_atoms.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_10_quotes_around_atoms.ex
@@ -12,15 +12,13 @@ defmodule Lexmag1SourceCodeLayout10QuotesAroundAtoms do
   @doc """
   When using atom literals that need to be quoted because they contain characters that are invalid in atoms (such as `:"foo-bar"`), use double quotes around the atom name:
 
-  ```elixir
-  # Bad
-  :'foo-bar'
-  :'atom number \#{index}'
+      # Bad
+      :'foo-bar'
+      :'atom number \#{index}'
 
-  # Good
-  :"foo-bar"
-  :"atom number \#{index}"
-  ```
+      # Good
+      :"foo-bar"
+      :"atom number \#{index}"
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_11_no_trailing_whitespaces.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_11_no_trailing_whitespaces.ex
@@ -1,0 +1,19 @@
+defmodule Lexmag1SourceCodeLayout11NoTrailingWhitespaces do
+  @moduledoc """
+  Source: [no-trailing-whitespaces](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#no-trailing-whitespaces)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Avoid trailing whitespaces.
+  """
+  @spec test() :: any
+  def test() do
+    # code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_12_newline_eof.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_12_newline_eof.ex
@@ -1,0 +1,19 @@
+defmodule Lexmag1SourceCodeLayout12NewlineEof do
+  @moduledoc """
+  Source: [newline-eof](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#newline-eof)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  End each file with a newline.
+  """
+  @spec test() :: any
+  def test() do
+    # code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_13_trailing_comma.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_13_trailing_comma.ex
@@ -1,0 +1,31 @@
+defmodule Lexmag1SourceCodeLayout13TrailingComma do
+  @moduledoc """
+  Source: [trailing-comma](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#trailing-comma)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  When dealing with lists, maps, structs, or tuples whose elements span over multiple lines and are on separate lines with regard to the enclosing brackets, it's advised to use a trailing comma even for the last element:
+
+  ```elixir
+  [
+    :foo,
+    :bar,
+    :baz,
+  ]
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    [
+      :foo,
+      :bar,
+      :baz,
+    ]
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_13_trailing_comma.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_13_trailing_comma.ex
@@ -12,13 +12,11 @@ defmodule Lexmag1SourceCodeLayout13TrailingComma do
   @doc """
   When dealing with lists, maps, structs, or tuples whose elements span over multiple lines and are on separate lines with regard to the enclosing brackets, it's advised to use a trailing comma even for the last element:
 
-  ```elixir
-  [
-    :foo,
-    :bar,
-    :baz,
-  ]
-  ```
+      [
+        :foo,
+        :bar,
+        :baz,
+      ]
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_14_expression_group_alignment.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_14_expression_group_alignment.ex
@@ -1,0 +1,49 @@
+defmodule Lexmag1SourceCodeLayout14ExpressionGroupAlignment do
+  @moduledoc """
+  Source: [expression-group-alignment](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#expression-group-alignment)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Avoid aligning expression groups:
+
+  ```elixir
+  # Bad
+  module = env.module
+  arity  = length(args)
+
+  def inspect(false), do: "false"
+  def inspect(true),  do: "true"
+  def inspect(nil),   do: "nil"
+
+  # Good
+  module = env.module
+  arity = length(args)
+
+  def inspect(false), do: "false"
+  def inspect(true), do: "true"
+  def inspect(nil), do: "nil"
+  ```
+
+  The same non-alignment rule applies to `<-` and `->` clauses as well.
+  """
+  @spec test() :: any
+  def test() do
+    args = []
+    env = %{module: "something"}
+    _module = env.module
+    _arity = length(args)
+  end
+
+  @doc false
+  @spec my_inspect(sample :: any) :: any
+  def my_inspect(false), do: false
+  def my_inspect(true), do: true
+  def my_inspect(nil), do: nil
+  def my_inspect(sample), do: inspect(sample)
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_14_expression_group_alignment.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_1_source_code_layout_14_expression_group_alignment.ex
@@ -12,23 +12,21 @@ defmodule Lexmag1SourceCodeLayout14ExpressionGroupAlignment do
   @doc """
   Avoid aligning expression groups:
 
-  ```elixir
-  # Bad
-  module = env.module
-  arity  = length(args)
+      # Bad
+      module = env.module
+      arity  = length(args)
 
-  def inspect(false), do: "false"
-  def inspect(true),  do: "true"
-  def inspect(nil),   do: "nil"
+      def inspect(false), do: "false"
+      def inspect(true),  do: "true"
+      def inspect(nil),   do: "nil"
 
-  # Good
-  module = env.module
-  arity = length(args)
+      # Good
+      module = env.module
+      arity = length(args)
 
-  def inspect(false), do: "false"
-  def inspect(true), do: "true"
-  def inspect(nil), do: "nil"
-  ```
+      def inspect(false), do: "false"
+      def inspect(true), do: "true"
+      def inspect(nil), do: "nil"
 
   The same non-alignment rule applies to `<-` and `->` clauses as well.
   """

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_01_fun_parens.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_01_fun_parens.ex
@@ -12,25 +12,23 @@ defmodule Lexmag2Syntax01FunParens do
   @doc """
   Always use parentheses around `def` arguments, don't omit them even when a function has no arguments.
 
-  ```elixir
-  # Bad
-  def main arg1, arg2 do
-    #...
-  end
+      # Bad
+      def main arg1, arg2 do
+        #...
+      end
 
-  def main do
-    #...
-  end
+      def main do
+        #...
+      end
 
-  # Good
-  def main(arg1, arg2) do
-    #...
-  end
+      # Good
+      def main(arg1, arg2) do
+        #...
+      end
 
-  def main() do
-    #...
-  end
-  ```
+      def main() do
+        #...
+      end
   """
   @spec test(argument :: any) :: any
   def test(_argument) do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_01_fun_parens.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_01_fun_parens.ex
@@ -1,0 +1,45 @@
+defmodule Lexmag2Syntax01FunParens do
+  @moduledoc """
+  Source: [fun-parens](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#fun-parens)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Always use parentheses around `def` arguments, don't omit them even when a function has no arguments.
+
+  ```elixir
+  # Bad
+  def main arg1, arg2 do
+    #...
+  end
+
+  def main do
+    #...
+  end
+
+  # Good
+  def main(arg1, arg2) do
+    #...
+  end
+
+  def main() do
+    #...
+  end
+  ```
+  """
+  @spec test(argument :: any) :: any
+  def test(_argument) do
+    # code here ...
+  end
+
+  @doc false
+  @spec test_no_args() :: any
+  def test_no_args() do
+    # code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_02_zero_arity_parens.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_02_zero_arity_parens.ex
@@ -12,22 +12,20 @@ defmodule Lexmag2Syntax02ZeroArityParens do
   @doc """
   Parentheses are a must for __local__ zero-arity function calls and definitions.
 
-  ```elixir
-  # Bad
-  pid = self
-  def new, do: %MapSet{}
+      # Bad
+      pid = self
+      def new, do: %MapSet{}
 
-  # Good
-  pid = self()
-  def new(), do: %MapSet{}
-  config = IEx.Config.new
-  ```
+      # Good
+      pid = self()
+      def new(), do: %MapSet{}
+      config = IEx.Config.new
+      ```
 
-  The same applies to __local__ one-arity function calls in pipelines.
+      The same applies to __local__ one-arity function calls in pipelines.
 
-  ```elixir
-  String.strip(input) |> decode()
-  ```
+      ```elixir
+      String.strip(input) |> decode()
   """
   @spec test(argument :: any) :: any
   def test(_argument), do: _pid = self()

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_02_zero_arity_parens.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_02_zero_arity_parens.ex
@@ -1,0 +1,44 @@
+defmodule Lexmag2Syntax02ZeroArityParens do
+  @moduledoc """
+  Source: [zero-arity-parens](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#zero-arity-parens)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Parentheses are a must for __local__ zero-arity function calls and definitions.
+
+  ```elixir
+  # Bad
+  pid = self
+  def new, do: %MapSet{}
+
+  # Good
+  pid = self()
+  def new(), do: %MapSet{}
+  config = IEx.Config.new
+  ```
+
+  The same applies to __local__ one-arity function calls in pipelines.
+
+  ```elixir
+  String.strip(input) |> decode()
+  ```
+  """
+  @spec test(argument :: any) :: any
+  def test(_argument), do: _pid = self()
+
+  @spec test_not_local() :: any
+  def test_not_local(), do: _config = IEx.Config.new
+
+  @spec test_pipeline(input :: bitstring) :: any
+  def test_pipeline(input) do
+    input
+    |> String.strip
+    |> test()
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_03_pipeline_operator.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_03_pipeline_operator.ex
@@ -12,33 +12,26 @@ defmodule Lexmag2Syntax03PipelineOperator do
   @doc """
   Favor the pipeline operator `|>` to chain function calls together.
 
-  ```elixir
-  # Bad
-  String.downcase(String.strip(input))
+      # Bad
+      String.downcase(String.strip(input))
 
-  # Good
-  input |> String.strip |> String.downcase
-  String.strip(input) |> String.downcase
-  ```
+      # Good
+      input |> String.strip |> String.downcase
+      String.strip(input) |> String.downcase
 
   Use a single level of indentation for multi-line pipelines.
 
-  ```elixir
-  String.strip(input)
-  |> String.downcase
-  |> String.slice(1, 3)
-  ```
+      String.strip(input)
+      |> String.downcase
+      |> String.slice(1, 3)
 
-  <a name="needless-pipeline"></a>
   Avoid needless pipelines like the plague.
 
-  ```elixir
-  # Bad
-  result = input |> String.strip
+      # Bad
+      result = input |> String.strip
 
-  # Good
-  result = String.strip(input)
-  ```
+      # Good
+      result = String.strip(input)
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_03_pipeline_operator.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_03_pipeline_operator.ex
@@ -1,0 +1,50 @@
+defmodule Lexmag2Syntax03PipelineOperator do
+  @moduledoc """
+  Source: [pipeline-operator](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#pipeline-operator)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Favor the pipeline operator `|>` to chain function calls together.
+
+  ```elixir
+  # Bad
+  String.downcase(String.strip(input))
+
+  # Good
+  input |> String.strip |> String.downcase
+  String.strip(input) |> String.downcase
+  ```
+
+  Use a single level of indentation for multi-line pipelines.
+
+  ```elixir
+  String.strip(input)
+  |> String.downcase
+  |> String.slice(1, 3)
+  ```
+
+  <a name="needless-pipeline"></a>
+  Avoid needless pipelines like the plague.
+
+  ```elixir
+  # Bad
+  result = input |> String.strip
+
+  # Good
+  result = String.strip(input)
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    " EXAMPLE "
+    |> String.strip
+    |> String.downcase
+    String.upcase("example")
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_03_pipeline_operator.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_03_pipeline_operator.ex
@@ -45,6 +45,7 @@ defmodule Lexmag2Syntax03PipelineOperator do
     " EXAMPLE "
     |> String.strip
     |> String.downcase
+
     String.upcase("example")
   end
 end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_04_binary_operators_at_eols.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_04_binary_operators_at_eols.ex
@@ -1,0 +1,33 @@
+defmodule Lexmag2Syntax04BinaryOperatorsAtEols do
+  @moduledoc """
+  Source: [binary-operators-at-eols](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#binary-operators-at-eols)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  When making a multi-line expression, keep binary operators (the only exception is the `|>` operator) at the ends of the lines.
+
+  ```elixir
+  # Bad
+  "No matching message.\n"
+  <> "Process mailbox:\n"
+  <> mailbox
+
+  # Good
+  "No matching message.\n" <>
+  "Process mailbox:\n" <>
+  mailbox
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    "First line.\n" <>
+    "Second line:\n" <>
+    "Third line."
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_04_binary_operators_at_eols.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_04_binary_operators_at_eols.ex
@@ -12,17 +12,15 @@ defmodule Lexmag2Syntax04BinaryOperatorsAtEols do
   @doc """
   When making a multi-line expression, keep binary operators (the only exception is the `|>` operator) at the ends of the lines.
 
-  ```elixir
-  # Bad
-  "No matching message.\n"
-  <> "Process mailbox:\n"
-  <> mailbox
+      # Bad
+      "No matching message.\n"
+      <> "Process mailbox:\n"
+      <> mailbox
 
-  # Good
-  "No matching message.\n" <>
-  "Process mailbox:\n" <>
-  mailbox
-  ```
+      # Good
+      "No matching message.\n" <>
+      "Process mailbox:\n" <>
+      mailbox
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_05_with_indentation.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_05_with_indentation.ex
@@ -1,0 +1,49 @@
+defmodule Lexmag2Syntax05WithIndentation do
+  @moduledoc """
+  Source: [with-indentation](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#with-indentation)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use the indentation shown below for the `with` special form:
+
+  ```elixir
+  with {year, ""} <- Integer.parse(year),
+       {month, ""} <- Integer.parse(month),
+       {day, ""} <- Integer.parse(day) do
+    new(year, month, day)
+  else
+    _ ->
+      {:error, :invalid_format}
+  end
+  ```
+
+  Always use the indentation above if there's an `else` option. If there isn't, the following indentation works as well:
+
+  ```elixir
+  with {:ok, date} <- Calendar.ISO.date(year, month, day),
+       {:ok, time} <- Time.new(hour, minute, second, microsecond),
+       do: new(date, time)
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    with {year, ""} <- Integer.parse("2016"),
+         {month, ""} <- Integer.parse("12"),
+         {day, ""} <- Integer.parse("24") do
+      {year, month, day}
+    else
+      _ ->
+        {:error, :invalid_format}
+    end
+
+    with {:ok, date} <- Calendar.ISO.date(2016, 12, 24),
+         {:ok, time} <- Time.new(0, 0, 0, 0),
+         do: {date, time}
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_05_with_indentation.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_05_with_indentation.ex
@@ -12,24 +12,20 @@ defmodule Lexmag2Syntax05WithIndentation do
   @doc """
   Use the indentation shown below for the `with` special form:
 
-  ```elixir
-  with {year, ""} <- Integer.parse(year),
-       {month, ""} <- Integer.parse(month),
-       {day, ""} <- Integer.parse(day) do
-    new(year, month, day)
-  else
-    _ ->
-      {:error, :invalid_format}
-  end
-  ```
+      with {year, ""} <- Integer.parse(year),
+           {month, ""} <- Integer.parse(month),
+           {day, ""} <- Integer.parse(day) do
+        new(year, month, day)
+      else
+        _ ->
+          {:error, :invalid_format}
+      end
 
   Always use the indentation above if there's an `else` option. If there isn't, the following indentation works as well:
 
-  ```elixir
-  with {:ok, date} <- Calendar.ISO.date(year, month, day),
-       {:ok, time} <- Time.new(hour, minute, second, microsecond),
-       do: new(date, time)
-  ```
+      with {:ok, date} <- Calendar.ISO.date(year, month, day),
+           {:ok, time} <- Time.new(hour, minute, second, microsecond),
+           do: new(date, time)
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_06_for_indentation.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_06_for_indentation.ex
@@ -12,23 +12,19 @@ defmodule Lexmag2Syntax06ForIndentation do
   @doc """
   Use the indentation shown below for the `for` special form:
 
-  ```elixir
-  for {alias, _module} <- aliases_from_env(server),
-      [name] = Module.split(alias),
-      starts_with?(name, hint),
-      into: [] do
-    %{kind: :module, type: :alias, name: name}
-  end
-  ```
+      for {alias, _module} <- aliases_from_env(server),
+          [name] = Module.split(alias),
+          starts_with?(name, hint),
+          into: [] do
+        %{kind: :module, type: :alias, name: name}
+      end
 
   If the body of the `do` block is short, the following indentation works as well:
 
-  ```elixir
-  for partition <- 0..(partitions - 1),
-      pair <- safe_lookup(registry, partition, key),
-      into: [],
-      do: pair
-  ```
+      for partition <- 0..(partitions - 1),
+          pair <- safe_lookup(registry, partition, key),
+          into: [],
+          do: pair
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_06_for_indentation.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_06_for_indentation.ex
@@ -40,13 +40,13 @@ defmodule Lexmag2Syntax06ForIndentation do
     end
 
     indexes = 0..999
-    max_count =
+    max_size =
       indexes
       |> Enum.max
       |> Integer.to_string
       |> String.length
     for index <- indexes,
-        padded_index = String.pad_leading("#{index}", max_count, "0"),
+        padded_index = String.pad_leading("#{index}", max_size, "0"),
         into: %{},
         do: {index, padded_index}
   end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_06_for_indentation.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_06_for_indentation.ex
@@ -1,0 +1,53 @@
+defmodule Lexmag2Syntax06ForIndentation do
+  @moduledoc """
+  Source: [for-indentation](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#for-indentation)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use the indentation shown below for the `for` special form:
+
+  ```elixir
+  for {alias, _module} <- aliases_from_env(server),
+      [name] = Module.split(alias),
+      starts_with?(name, hint),
+      into: [] do
+    %{kind: :module, type: :alias, name: name}
+  end
+  ```
+
+  If the body of the `do` block is short, the following indentation works as well:
+
+  ```elixir
+  for partition <- 0..(partitions - 1),
+      pair <- safe_lookup(registry, partition, key),
+      into: [],
+      do: pair
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    for element <- [],
+        [name] = String.capitalize(element),
+        String.starts_with?(name, "Jo"),
+        into: [] do
+      %{modifications: [:capitalize], validators: [starts_with: "Jo"], value: name}
+    end
+
+    indexes = 0..999
+    max_count =
+      indexes
+      |> Enum.max
+      |> Integer.to_string
+      |> String.length
+    for index <- indexes,
+        padded_index = String.pad_leading("#{index}", max_count, "0"),
+        into: %{},
+        do: {index, padded_index}
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_07_no_else_with_unless.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_07_no_else_with_unless.ex
@@ -1,0 +1,39 @@
+defmodule Lexmag2Syntax07NoElseWithUnless do
+  @moduledoc """
+  Source: [no-else-with-unless](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#no-else-with-unless)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Never use `unless` with `else`. Rewrite these with the positive case first.
+
+  ```elixir
+  # Bad
+  unless Enum.empty?(coll) do
+    :ok
+  else
+    :error
+  end
+
+  # Good
+  if Enum.empty?(coll) do
+    :error
+  else
+    :ok
+  end
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    if Enum.empty?([]) do
+      :error
+    else
+      :ok
+    end
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_07_no_else_with_unless.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_07_no_else_with_unless.ex
@@ -12,21 +12,19 @@ defmodule Lexmag2Syntax07NoElseWithUnless do
   @doc """
   Never use `unless` with `else`. Rewrite these with the positive case first.
 
-  ```elixir
-  # Bad
-  unless Enum.empty?(coll) do
-    :ok
-  else
-    :error
-  end
+      # Bad
+      unless Enum.empty?(coll) do
+        :ok
+      else
+        :error
+      end
 
-  # Good
-  if Enum.empty?(coll) do
-    :error
-  else
-    :ok
-  end
-  ```
+      # Good
+      if Enum.empty?(coll) do
+        :error
+      else
+        :ok
+      end
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_08_no_nil_else.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_08_no_nil_else.ex
@@ -12,13 +12,11 @@ defmodule Lexmag2Syntax08NoNilElse do
   @doc """
   Omit `else` option in `if` and `unless` clauses if it returns `nil`.
 
-  ```elixir
-  # Bad
-  if byte_size(data) > 0, do: data, else: nil
+      # Bad
+      if byte_size(data) > 0, do: data, else: nil
 
-  # Good
-  if byte_size(data) > 0, do: data
-  ```
+      # Good
+      if byte_size(data) > 0, do: data
   """
   @spec test(data :: bitstring) :: any
   def test(data) do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_08_no_nil_else.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_08_no_nil_else.ex
@@ -1,0 +1,27 @@
+defmodule Lexmag2Syntax08NoNilElse do
+  @moduledoc """
+  Source: [no-nil-else](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#no-nil-else)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Omit `else` option in `if` and `unless` clauses if it returns `nil`.
+
+  ```elixir
+  # Bad
+  if byte_size(data) > 0, do: data, else: nil
+
+  # Good
+  if byte_size(data) > 0, do: data
+  ```
+  """
+  @spec test(data :: bitstring) :: any
+  def test(data) do
+    if byte_size(data) > 0, do: data
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_09_true_in_cond.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_09_true_in_cond.ex
@@ -1,0 +1,37 @@
+defmodule Lexmag2Syntax09TrueInCond do
+  @moduledoc """
+  Source: [true-in-cond](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#true-in-cond)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use `true` as the always-match condition of the `cond` special form.
+
+  ```elixir
+  cond do
+    char in ?0..?9 ->
+      char - ?0
+    char in ?A..?Z ->
+      char - ?A + 10
+    true ->
+      char - ?a + 10
+  end
+  ```
+  """
+  @spec test(char :: integer) :: any
+  def test(char) do
+    cond do
+      char in ?0..?9 ->
+        char - ?0
+      char in ?A..?Z ->
+        char - ?A + 10
+      true ->
+        nil # NOTE: beautifier info to fill: "`true` as the always-match condition"
+    end
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_09_true_in_cond.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_09_true_in_cond.ex
@@ -12,16 +12,14 @@ defmodule Lexmag2Syntax09TrueInCond do
   @doc """
   Use `true` as the always-match condition of the `cond` special form.
 
-  ```elixir
-  cond do
-    char in ?0..?9 ->
-      char - ?0
-    char in ?A..?Z ->
-      char - ?A + 10
-    true ->
-      char - ?a + 10
-  end
-  ```
+      cond do
+        char in ?0..?9 ->
+          char - ?0
+        char in ?A..?Z ->
+          char - ?A + 10
+        true ->
+          char - ?a + 10
+      end
   """
   @spec test(char :: integer) :: any
   def test(char) do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_09_true_in_cond.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_09_true_in_cond.ex
@@ -29,7 +29,7 @@ defmodule Lexmag2Syntax09TrueInCond do
       char in ?A..?Z ->
         char - ?A + 10
       true ->
-        nil # NOTE: beautifier info to fill: "`true` as the always-match condition"
+        char - ?a + 10
     end
   end
 end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_10_boolean_operators.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_10_boolean_operators.ex
@@ -1,0 +1,33 @@
+defmodule Lexmag2Syntax10BooleanOperators do
+  @moduledoc """
+  Source: [boolean-operators](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#boolean-operators)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Never use `||`, `&&` and `!` for strictly boolean checks. Use these operators only if any of the arguments are non-boolean.
+
+  ```elixir
+  # Bad
+  is_atom(name) && name != nil
+  is_binary(task) || is_atom(task)
+
+  # Good
+  is_atom(name) and name != nil
+  is_binary(task) or is_atom(task)
+  line && line != 0
+  file || "sample.exs"
+  ```
+  """
+  @spec test(name :: atom) :: any
+  def test(name) do
+    task = :spying
+    is_atom(name) and !is_nil(name) and !is_boolean(name)
+    is_binary(task) or is_atom(task)
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_10_boolean_operators.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_10_boolean_operators.ex
@@ -12,17 +12,15 @@ defmodule Lexmag2Syntax10BooleanOperators do
   @doc """
   Never use `||`, `&&` and `!` for strictly boolean checks. Use these operators only if any of the arguments are non-boolean.
 
-  ```elixir
-  # Bad
-  is_atom(name) && name != nil
-  is_binary(task) || is_atom(task)
+      # Bad
+      is_atom(name) && name != nil
+      is_binary(task) || is_atom(task)
 
-  # Good
-  is_atom(name) and name != nil
-  is_binary(task) or is_atom(task)
-  line && line != 0
-  file || "sample.exs"
-  ```
+      # Good
+      is_atom(name) and name != nil
+      is_binary(task) or is_atom(task)
+      line && line != 0
+      file || "sample.exs"
   """
   @spec test(name :: atom) :: any
   def test(name) do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_10_boolean_operators.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_10_boolean_operators.ex
@@ -27,7 +27,7 @@ defmodule Lexmag2Syntax10BooleanOperators do
   @spec test(name :: atom) :: any
   def test(name) do
     task = :spying
-    is_atom(name) and !is_nil(name) and !is_boolean(name)
+    _ = not is_nil(name) and not is_boolean(name)
     is_binary(task) or is_atom(task)
   end
 end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_11_patterns_matching_binaries.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_11_patterns_matching_binaries.ex
@@ -1,0 +1,30 @@
+defmodule Lexmag2Syntax11PatternsMatchingBinaries do
+  @moduledoc """
+  Source: [patterns-matching-binaries](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#patterns-matching-binaries)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Favor the binary concatenation operator `<>` over bitstring syntax for patterns matching binaries.
+
+  ```elixir
+  # Bad
+  <<"http://", _rest::bytes>> = input
+  <<first::utf8, rest::bytes>> = input
+
+  # Good
+  "http://" <> _rest = input
+  <<first::utf8>> <> rest = input
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    "http://" <> _rest = "http://elixir-lang.org/"
+    <<_first::utf8>> <> _rest = "Something"
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_11_patterns_matching_binaries.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_11_patterns_matching_binaries.ex
@@ -12,15 +12,13 @@ defmodule Lexmag2Syntax11PatternsMatchingBinaries do
   @doc """
   Favor the binary concatenation operator `<>` over bitstring syntax for patterns matching binaries.
 
-  ```elixir
-  # Bad
-  <<"http://", _rest::bytes>> = input
-  <<first::utf8, rest::bytes>> = input
+      # Bad
+      <<"http://", _rest::bytes>> = input
+      <<first::utf8, rest::bytes>> = input
 
-  # Good
-  "http://" <> _rest = input
-  <<first::utf8>> <> rest = input
-  ```
+      # Good
+      "http://" <> _rest = input
+      <<first::utf8>> <> rest = input
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_12_hex_literals.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_12_hex_literals.ex
@@ -12,13 +12,11 @@ defmodule Lexmag2Syntax12HexLiterals do
   @doc """
   Use uppercase in definition of hex literals.
 
-  ```elixir
-  # Bad
-  <<0xef, 0xbb, 0xbf>>
+      # Bad
+      <<0xef, 0xbb, 0xbf>>
 
-  # Good
-  <<0xEF, 0xBB, 0xBF>>
-  ```
+      # Good
+      <<0xEF, 0xBB, 0xBF>>
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_12_hex_literals.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_2_syntax_12_hex_literals.ex
@@ -1,0 +1,27 @@
+defmodule Lexmag2Syntax12HexLiterals do
+  @moduledoc """
+  Source: [hex-literals](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#hex-literals)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use uppercase in definition of hex literals.
+
+  ```elixir
+  # Bad
+  <<0xef, 0xbb, 0xbf>>
+
+  # Good
+  <<0xEF, 0xBB, 0xBF>>
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    <<0xEF, 0xBB, 0xBF>>
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_3_naming_1_snake_case_atoms_funs_vars_attrs.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_3_naming_1_snake_case_atoms_funs_vars_attrs.ex
@@ -14,33 +14,31 @@ defmodule Lexmag3Naming1SnakeCaseAtomsFunsVarsAttrs do
   @doc """
   Use `snake_case` for atoms, functions, variables and module attributes.
 
-  ```elixir
-  # Bad
-  :"no match"
-  :Error
-  :badReturn
+      # Bad
+      :"no match"
+      :Error
+      :badReturn
 
-  fileName = "sample.txt"
+      fileName = "sample.txt"
 
-  @_VERSION "0.0.1"
+      @_VERSION "0.0.1"
 
-  def readFile(path) do
-    #...
-  end
+      def readFile(path) do
+        #...
+      end
 
-  # Good
-  :no_match
-  :error
-  :bad_return
+      # Good
+      :no_match
+      :error
+      :bad_return
 
-  file_name = "sample.txt"
+      file_name = "sample.txt"
 
-  @version "0.0.1"
+      @version "0.0.1"
 
-  def read_file(path) do
-    #...
-  end
-  ```
+      def read_file(path) do
+        #...
+      end
   """
   @spec test_me() :: any
   def test_me() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_3_naming_1_snake_case_atoms_funs_vars_attrs.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_3_naming_1_snake_case_atoms_funs_vars_attrs.ex
@@ -1,0 +1,52 @@
+defmodule Lexmag3Naming1SnakeCaseAtomsFunsVarsAttrs do
+  @moduledoc """
+  Source: [snake-case-atoms-funs-vars-attrs](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#snake-case-atoms-funs-vars-attrs)
+   from section: [Naming](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#naming)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @version "0.0.1"
+
+  @doc """
+  Use `snake_case` for atoms, functions, variables and module attributes.
+
+  ```elixir
+  # Bad
+  :"no match"
+  :Error
+  :badReturn
+
+  fileName = "sample.txt"
+
+  @_VERSION "0.0.1"
+
+  def readFile(path) do
+    #...
+  end
+
+  # Good
+  :no_match
+  :error
+  :bad_return
+
+  file_name = "sample.txt"
+
+  @version "0.0.1"
+
+  def read_file(path) do
+    #...
+  end
+  ```
+  """
+  @spec test_me() :: any
+  def test_me() do
+    :no_match
+    :error
+    :bad_return
+    _file_name = "sample.txt"
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_3_naming_2_camelcase_modules.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_3_naming_2_camelcase_modules.ex
@@ -1,0 +1,49 @@
+defmodule Lexmag3Naming2CamelcaseModules do
+  @moduledoc """
+  Source: [camelcase-modules](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#camelcase-modules)
+   from section: [Naming](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#naming)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  defmodule FirstAppStack do
+    @moduledoc false
+    # code here ...
+  end
+
+  defmodule SecondAppStack do
+    @moduledoc false
+    # code here ...
+  end
+
+  @doc """
+  Use `CamelCase` for module names.
+
+  ```elixir
+  # Bad
+  defmodule :appStack do
+    #...
+  end
+
+  defmodule App_Stack do
+    #...
+  end
+
+  defmodule Appstack do
+    #...
+  end
+
+  # Good
+  defmodule AppStack do
+    #...
+  end
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    # code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_3_naming_2_camelcase_modules.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_3_naming_2_camelcase_modules.ex
@@ -22,25 +22,23 @@ defmodule Lexmag3Naming2CamelcaseModules do
   @doc """
   Use `CamelCase` for module names.
 
-  ```elixir
-  # Bad
-  defmodule :appStack do
-    #...
-  end
+      # Bad
+      defmodule :appStack do
+        #...
+      end
 
-  defmodule App_Stack do
-    #...
-  end
+      defmodule App_Stack do
+        #...
+      end
 
-  defmodule Appstack do
-    #...
-  end
+      defmodule Appstack do
+        #...
+      end
 
-  # Good
-  defmodule AppStack do
-    #...
-  end
-  ```
+      # Good
+      defmodule AppStack do
+        #...
+      end
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_3_naming_3_predicate_funs_name.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_3_naming_3_predicate_funs_name.ex
@@ -30,7 +30,7 @@ defmodule Lexmag3Naming3PredicateFunsName do
   def ok?(:ok), do: true
   def ok?(_), do: false
 
-  @spec is_ok?(sample :: any) :: boolean
-  defmacro is_ok?(:ok), do: true
-  defmacro is_ok?(_), do: false
+  @spec is_ok(sample :: any) :: boolean
+  defmacro is_ok(:ok), do: true
+  defmacro is_ok(_), do: false
 end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_3_naming_3_predicate_funs_name.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_3_naming_3_predicate_funs_name.ex
@@ -1,0 +1,36 @@
+defmodule Lexmag3Naming3PredicateFunsName do
+  @moduledoc """
+  Source: [predicate-funs-name](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#predicate-funs-name)
+   from section: [Naming](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#naming)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  The names of predicate functions (a function that return a boolean value) should have a trailing question mark `?` rather than a leading `has_` or similar.
+
+  ```elixir
+  def leap?(year) do
+    #...
+  end
+  ```
+
+  Always use a leading `is_` when naming guard-safe predicate macros.
+
+  ```elixir
+  defmacro is_date(month, day) do
+    #...
+  end
+  ```
+  """
+  @spec ok?(sample :: any) :: boolean
+  def ok?(:ok), do: true
+  def ok?(_), do: false
+
+  @spec is_ok?(sample :: any) :: boolean
+  defmacro is_ok?(:ok), do: true
+  defmacro is_ok?(_), do: false
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_3_naming_3_predicate_funs_name.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_3_naming_3_predicate_funs_name.ex
@@ -12,19 +12,15 @@ defmodule Lexmag3Naming3PredicateFunsName do
   @doc """
   The names of predicate functions (a function that return a boolean value) should have a trailing question mark `?` rather than a leading `has_` or similar.
 
-  ```elixir
-  def leap?(year) do
-    #...
-  end
-  ```
+      def leap?(year) do
+        #...
+      end
 
   Always use a leading `is_` when naming guard-safe predicate macros.
 
-  ```elixir
-  defmacro is_date(month, day) do
-    #...
-  end
-  ```
+      defmacro is_date(month, day) do
+        #...
+      end
   """
   @spec ok?(sample :: any) :: boolean
   def ok?(:ok), do: true

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_3_naming_4_snake_case_dirs_files.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_3_naming_4_snake_case_dirs_files.ex
@@ -1,0 +1,19 @@
+defmodule Lexmag3Naming4SnakeCaseDirsFiles do
+  @moduledoc """
+  Source: [snake-case-dirs-files](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#snake-case-dirs-files)
+   from section: [Naming](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#naming)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use `snake_case` for naming directories and files, e.g. `lib/my_app/task_server.ex`.
+  """
+  @spec test() :: any
+  def test() do
+    # code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_3_naming_5_one_letter_var.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_3_naming_5_one_letter_var.ex
@@ -1,0 +1,19 @@
+defmodule Lexmag3Naming5OneLetterVar do
+  @moduledoc """
+  Source: [one-letter-var](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#one-letter-var)
+   from section: [Naming](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#naming)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Avoid using one-letter variable names.
+  """
+  @spec test() :: any
+  def test() do
+    _o = :ok # NOTE: beautifier info to change variable name
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_4_comments_1_no_need_for_comments.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_4_comments_1_no_need_for_comments.ex
@@ -1,0 +1,25 @@
+defmodule Lexmag4Comments1NoNeedForComments do
+  @moduledoc """
+  Source: [no-need-for-comments](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#no-need-for-comments)
+   from section: [Comments](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#comments)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Write self-documenting code and ignore the rest of this section. Seriously!
+  """
+  @spec test() :: any
+  def test() do
+    # code here ...
+  end
+
+  @spec doc_test(first_argument :: any, second_argument :: any) :: any # NOTE: beautifier info to change spec
+  @doc "NOTE: beautifier info to fill comment (same for moduledoc)"
+  def doc_test(first_argument, {second, argument}) do
+    {first_argument, second, argument}
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_4_comments_2_leading_space_comment.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_4_comments_2_leading_space_comment.ex
@@ -1,0 +1,19 @@
+defmodule Lexmag4Comments2LeadingSpaceComment do
+  @moduledoc """
+  Source: [leading-space-comment](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#leading-space-comment)
+   from section: [Comments](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#comments)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use one space between the leading `#` character of the comment and the text of the comment.
+  """
+  @spec test() :: any
+  def test() do
+    # code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_4_comments_3_no_superfluous_comments.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_4_comments_3_no_superfluous_comments.ex
@@ -12,10 +12,8 @@ defmodule Lexmag4Comments3NoSuperfluousComments do
   @doc """
   Avoid superfluous comments.
 
-  ```elixir
-  # Bad
-  String.first(input) # Get first grapheme.
-  ```
+      # Bad
+      String.first(input) # Get first grapheme.
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_4_comments_3_no_superfluous_comments.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_4_comments_3_no_superfluous_comments.ex
@@ -19,7 +19,7 @@ defmodule Lexmag4Comments3NoSuperfluousComments do
   """
   @spec test() :: any
   def test() do
-    # capitalize sentence
+    # NOTE: beautifier question if comment: `capitalize sentence` needed
     String.capitalize("example sentence is here.")
   end
 end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_4_comments_3_no_superfluous_comments.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_4_comments_3_no_superfluous_comments.ex
@@ -1,0 +1,25 @@
+defmodule Lexmag4Comments3NoSuperfluousComments do
+  @moduledoc """
+  Source: [no-superfluous-comments](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#no-superfluous-comments)
+   from section: [Comments](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#comments)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Avoid superfluous comments.
+
+  ```elixir
+  # Bad
+  String.first(input) # Get first grapheme.
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    # capitalize sentence
+    String.capitalize("example sentence is here.")
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_5_modules_1_module_layout.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_5_modules_1_module_layout.ex
@@ -21,17 +21,15 @@ defmodule Lexmag5Modules1ModuleLayout do
   Use a consistent structure when calling `use`/`import`/`alias`/`require`: call
   them in this order and group multiple calls to each of them.
 
-  ```elixir
-  use GenServer
+      use GenServer
 
-  import Bitwise
-  import Kernel, except: [length: 1]
+      import Bitwise
+      import Kernel, except: [length: 1]
 
-  alias Mix.Utils
-  alias MapSet, as: Set
+      alias Mix.Utils
+      alias MapSet, as: Set
 
-  require Logger
-  ```
+      require Logger
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_5_modules_1_module_layout.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_5_modules_1_module_layout.ex
@@ -1,0 +1,41 @@
+defmodule Lexmag5Modules1ModuleLayout do
+  @moduledoc """
+  Source: [module-layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#module-layout)
+   from section: [Modules](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#modules)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  use GenServer
+
+  import Enum
+
+  alias Calendar.ISO
+
+  require Logger
+
+  @doc """
+  Use a consistent structure when calling `use`/`import`/`alias`/`require`: call
+  them in this order and group multiple calls to each of them.
+
+  ```elixir
+  use GenServer
+
+  import Bitwise
+  import Kernel, except: [length: 1]
+
+  alias Mix.Utils
+  alias MapSet, as: Set
+
+  require Logger
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    ISO.day_of_week(2016, 12, 24)
+    at([1, 2, 3], 1)
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_5_modules_2_current_module_reference.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_5_modules_2_current_module_reference.ex
@@ -1,0 +1,29 @@
+defmodule Lexmag5Modules2CurrentModuleReference do
+  @moduledoc """
+  Source: [current-module-reference](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#current-module-reference)
+   from section: [Modules](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#modules)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use `__MODULE__` pseudo variable to reference current module.
+
+  ```elixir
+  # Bad
+  :ets.new(Kernel.LexicalTracker, [:named_table])
+  GenServer.start_link(Module.LocalsTracker, nil, [])
+
+  # Good
+  :ets.new(__MODULE__, [:named_table])
+  GenServer.start_link(__MODULE__, nil, [])
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    :etc.new(__MODULE__, [:named_table])
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_5_modules_2_current_module_reference.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_5_modules_2_current_module_reference.ex
@@ -12,15 +12,13 @@ defmodule Lexmag5Modules2CurrentModuleReference do
   @doc """
   Use `__MODULE__` pseudo variable to reference current module.
 
-  ```elixir
-  # Bad
-  :ets.new(Kernel.LexicalTracker, [:named_table])
-  GenServer.start_link(Module.LocalsTracker, nil, [])
+      # Bad
+      :ets.new(Kernel.LexicalTracker, [:named_table])
+      GenServer.start_link(Module.LocalsTracker, nil, [])
 
-  # Good
-  :ets.new(__MODULE__, [:named_table])
-  GenServer.start_link(__MODULE__, nil, [])
-  ```
+      # Good
+      :ets.new(__MODULE__, [:named_table])
+      GenServer.start_link(__MODULE__, nil, [])
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_6_regular_expressions_1_pattern_matching_over_regexp.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_6_regular_expressions_1_pattern_matching_over_regexp.ex
@@ -12,15 +12,13 @@ defmodule Lexmag6RegularExpressions1PatternMatchingOverRegexp do
   @doc """
   Regular expressions are the last resort. Pattern matching and `String` module are things to start with.
 
-  ```elixir
-  # Bad
-  Regex.run(~r/#(\d{2})(\d{2})(\d{2})/, color)
-  Regex.match?(~r/(email|password)/, input)
+      # Bad
+      Regex.run(~r/#(\d{2})(\d{2})(\d{2})/, color)
+      Regex.match?(~r/(email|password)/, input)
 
-  # Good
-  <<?#, p1::2-bytes, p2::2-bytes, p3::2-bytes>> = color
-  String.contains?(input, ["email", "password"])
-  ```
+      # Good
+      <<?#, p1::2-bytes, p2::2-bytes, p3::2-bytes>> = color
+      String.contains?(input, ["email", "password"])
   """
   @spec test(color :: bitstring, input :: bitstring) :: any
   def test(color, input) do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_6_regular_expressions_1_pattern_matching_over_regexp.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_6_regular_expressions_1_pattern_matching_over_regexp.ex
@@ -1,0 +1,30 @@
+defmodule Lexmag6RegularExpressions1PatternMatchingOverRegexp do
+  @moduledoc """
+  Source: [pattern-matching-over-regexp](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#pattern-matching-over-regexp)
+   from section: [Regular Expressions](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#regular-expressions)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Regular expressions are the last resort. Pattern matching and `String` module are things to start with.
+
+  ```elixir
+  # Bad
+  Regex.run(~r/#(\d{2})(\d{2})(\d{2})/, color)
+  Regex.match?(~r/(email|password)/, input)
+
+  # Good
+  <<?#, p1::2-bytes, p2::2-bytes, p3::2-bytes>> = color
+  String.contains?(input, ["email", "password"])
+  ```
+  """
+  @spec test(color :: bitstring, input :: bitstring) :: any
+  def test(color, input) do
+    <<?#, _red::2-bytes, _green::2-bytes, _blue::2-bytes>> = color
+    String.contains?(input, ["email", "password"])
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_6_regular_expressions_2_non_capturing_regexp.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_6_regular_expressions_2_non_capturing_regexp.ex
@@ -1,0 +1,23 @@
+defmodule Lexmag6RegularExpressions2NonCapturingRegexp do
+  @moduledoc """
+  Source: [non-capturing-regexp](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#non-capturing-regexp)
+   from section: [Regular Expressions](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#regular-expressions)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use non-capturing groups when you don't use the captured result.
+
+  ```elixir
+  ~r/(?:post|zip )code: (\d+)/
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    # NOTE: we cannot validate this rule
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_6_regular_expressions_2_non_capturing_regexp.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_6_regular_expressions_2_non_capturing_regexp.ex
@@ -12,9 +12,7 @@ defmodule Lexmag6RegularExpressions2NonCapturingRegexp do
   @doc """
   Use non-capturing groups when you don't use the captured result.
 
-  ```elixir
-  ~r/(?:post|zip )code: (\d+)/
-  ```
+      ~r/(?:post|zip )code: (\d+)/
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_6_regular_expressions_3_caret_and_dollar_regexp.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_6_regular_expressions_3_caret_and_dollar_regexp.ex
@@ -1,0 +1,19 @@
+defmodule Lexmag6RegularExpressions3CaretAndDollarRegexp do
+  @moduledoc """
+  Source: [caret-and-dollar-regexp](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#caret-and-dollar-regexp)
+   from section: [Regular Expressions](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#regular-expressions)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Be careful with `^` and `$` as they match start and end of the __line__ respectively. If you want to match the __whole__ string use: `\A` and `\z` (not to be confused with `\Z` which is the equivalent of `\n?\z`).
+  """
+  @spec test() :: any
+  def test() do
+    # NOTE: we cannot validate this rule
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_7_structs_1_defstruct_fields_default.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_7_structs_1_defstruct_fields_default.ex
@@ -14,13 +14,11 @@ defmodule Lexmag7Structs1DefstructFieldsDefault do
   @doc """
   When calling `defstruct/1`, don't explicitly specify `nil` for fields that default to `nil`.
 
-  ```elixir
-  # Bad
-  defstruct first_name: nil, last_name: nil, admin?: false
+      # Bad
+      defstruct first_name: nil, last_name: nil, admin?: false
 
-  # Good
-  defstruct [:first_name, :last_name, admin?: false]
-  ```
+      # Good
+      defstruct [:first_name, :last_name, admin?: false]
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_7_structs_1_defstruct_fields_default.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_7_structs_1_defstruct_fields_default.ex
@@ -1,0 +1,29 @@
+defmodule Lexmag7Structs1DefstructFieldsDefault do
+  @moduledoc """
+  Source: [defstruct-fields-default](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#defstruct-fields-default)
+   from section: [Structs](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#structs)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  defstruct [:first_name, :last_name, admin?: false]
+
+  @doc """
+  When calling `defstruct/1`, don't explicitly specify `nil` for fields that default to `nil`.
+
+  ```elixir
+  # Bad
+  defstruct first_name: nil, last_name: nil, admin?: false
+
+  # Good
+  defstruct [:first_name, :last_name, admin?: false]
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    # code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_8_exceptions_1_exception_naming.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_8_exceptions_1_exception_naming.ex
@@ -16,14 +16,12 @@ defmodule Lexmag8Exceptions1ExceptionNaming do
   @doc """
   Make exception names end with a trailing `Error`.
 
-  ```elixir
-  # Bad
-  BadResponse
-  ResponseException
+      # Bad
+      BadResponse
+      ResponseException
 
-  # Good
-  ResponseError
-  ```
+      # Good
+      ResponseError
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_8_exceptions_1_exception_naming.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_8_exceptions_1_exception_naming.ex
@@ -1,0 +1,36 @@
+defmodule Lexmag8Exceptions1ExceptionNaming do
+  @moduledoc """
+  Source: [exception-naming](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#exception-naming)
+   from section: [Exceptions](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#exceptions)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  defmodule CustomError do
+    defexception message: "default custom error message"
+  end
+
+  @doc """
+  Make exception names end with a trailing `Error`.
+
+  ```elixir
+  # Bad
+  BadResponse
+  ResponseException
+
+  # Good
+  ResponseError
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    try do
+      raise CustomError
+    rescue
+      error in CustomError -> error
+    end
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_8_exceptions_2_exception_message.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_8_exceptions_2_exception_message.ex
@@ -1,0 +1,41 @@
+defmodule Lexmag8Exceptions2ExceptionMessage do
+  @moduledoc """
+  Source: [exception-message](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#exception-message)
+   from section: [Exceptions](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#exceptions)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use non-capitalized error messages when raising exceptions, with no trailing punctuation.
+
+  ```elixir
+  # Bad
+  raise ArgumentError, "Malformed payload."
+
+  # Good
+  raise ArgumentError, "malformed payload"
+  ```
+
+  There is one exception to the rule - always capitalize Mix error messages.
+
+  ```elixir
+  Mix.raise "Could not find dependency"
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    try do
+      if Enum.random(0..9) < 5 do
+        raise RuntimeError, message: "an error occurred"
+      else
+        Mix.raise "An error occurred"
+      end
+    rescue
+      error -> error
+    end
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_8_exceptions_2_exception_message.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_8_exceptions_2_exception_message.ex
@@ -12,19 +12,15 @@ defmodule Lexmag8Exceptions2ExceptionMessage do
   @doc """
   Use non-capitalized error messages when raising exceptions, with no trailing punctuation.
 
-  ```elixir
-  # Bad
-  raise ArgumentError, "Malformed payload."
+      # Bad
+      raise ArgumentError, "Malformed payload."
 
-  # Good
-  raise ArgumentError, "malformed payload"
-  ```
+      # Good
+      raise ArgumentError, "malformed payload"
 
   There is one exception to the rule - always capitalize Mix error messages.
 
-  ```elixir
-  Mix.raise "Could not find dependency"
-  ```
+      Mix.raise "Could not find dependency"
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_9_exunit_1_exunit_assertion_side.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_9_exunit_1_exunit_assertion_side.ex
@@ -12,19 +12,15 @@ defmodule Lexmag9Exunit1ExunitAssertionSide do
   @doc """
   When asserting (or refuting) something with comparison operators (such as `==`, `<`, `>=`, and similar), put the expression being tested on the left-hand side of the operator and the value you're testing against on the right-hand side.
 
-  ```elixir
-  # Bad
-  assert "héllo" == Atom.to_string(:"héllo")
+      # Bad
+      assert "héllo" == Atom.to_string(:"héllo")
 
-  # Good
-  assert Atom.to_string(:"héllo") == "héllo"
-  ```
+      # Good
+      assert Atom.to_string(:"héllo") == "héllo"
 
   When using the match operator `=`, put the pattern on the left-hand side (as it won't work otherwise).
 
-  ```elixir
-  assert {:error, _reason} = File.stat("./non_existent_file")
-  ```
+      assert {:error, _reason} = File.stat("./non_existent_file")
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/expected/lexmag_9_exunit_1_exunit_assertion_side.ex
+++ b/examples/nested-jsbeautifyrc/elixir/expected/lexmag_9_exunit_1_exunit_assertion_side.ex
@@ -1,0 +1,33 @@
+defmodule Lexmag9Exunit1ExunitAssertionSide do
+  @moduledoc """
+  Source: [exunit-assertion-side](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#exunit-assertion-side)
+   from section: [ExUnit](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#exunit)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  When asserting (or refuting) something with comparison operators (such as `==`, `<`, `>=`, and similar), put the expression being tested on the left-hand side of the operator and the value you're testing against on the right-hand side.
+
+  ```elixir
+  # Bad
+  assert "héllo" == Atom.to_string(:"héllo")
+
+  # Good
+  assert Atom.to_string(:"héllo") == "héllo"
+  ```
+
+  When using the match operator `=`, put the pattern on the left-hand side (as it won't work otherwise).
+
+  ```elixir
+  assert {:error, _reason} = File.stat("./non_existent_file")
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    # NOTE: we cannot validate this rule in some cases
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_01_spaces_indentation.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_01_spaces_indentation.ex
@@ -1,0 +1,19 @@
+defmodule Lexmag1SourceCodeLayout01SpacesIndentation do
+  @moduledoc """
+  Source: [spaces-indentation](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#spaces-indentation)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use two __spaces__ per indentation level. No hard tabs.
+  """
+  @spec test() :: any
+  def test() do
+		# code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_02_no_semicolon.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_02_no_semicolon.ex
@@ -1,0 +1,19 @@
+defmodule Lexmag1SourceCodeLayout02NoSemicolon do
+  @moduledoc """
+  Source: [no-semicolon](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#no-semicolon)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use one expression per line, as a corollary - don't use semicolon `;` to separate statements and expressions.
+  """
+  @spec test() :: any
+  def test() do
+    value = 1 + 2; value * 2
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_03_spaces_in_code.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_03_spaces_in_code.ex
@@ -12,12 +12,10 @@ defmodule Lexmag1SourceCodeLayout03SpacesInCode do
   @doc """
   Use spaces around binary operators, after commas `,`, colons `:` and semicolons `;`. Do not put spaces around matched pairs like brackets `[]`, braces `{}`, etc. Whitespace might be (mostly) irrelevant to the Elixir compiler, but its proper use is the key to writing easily readable code.
 
-  ```elixir
-  sum = 1 + 2
-  [first | rest] = 'three'
-  {a1, a2} = {2, 3}
-  Enum.join(["one", <<"two">>, sum])
-  ```
+      sum = 1 + 2
+      [first | rest] = 'three'
+      {a1, a2} = {2, 3}
+      Enum.join(["one", <<"two">>, sum])
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_03_spaces_in_code.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_03_spaces_in_code.ex
@@ -1,0 +1,29 @@
+defmodule Lexmag1SourceCodeLayout03SpacesInCode do
+  @moduledoc """
+  Source: [spaces-in-code](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#spaces-in-code)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use spaces around binary operators, after commas `,`, colons `:` and semicolons `;`. Do not put spaces around matched pairs like brackets `[]`, braces `{}`, etc. Whitespace might be (mostly) irrelevant to the Elixir compiler, but its proper use is the key to writing easily readable code.
+
+  ```elixir
+  sum = 1 + 2
+  [first | rest] = 'three'
+  {a1, a2} = {2, 3}
+  Enum.join(["one", <<"two">>, sum])
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    sum=1+2
+    [ _first|_rest ] = ~c[ three ]
+    { _a1 ,_a2 }={ 2,3 }
+    Enum.join( [ "one",<< "two" >>,sum ] )
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_04_no_spaces_in_code.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_04_no_spaces_in_code.ex
@@ -1,0 +1,30 @@
+defmodule Lexmag1SourceCodeLayout04NoSpacesInCode do
+  @moduledoc """
+  Source: [no-spaces-in-code](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#no-spaces-in-code)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  No spaces after unary operators and inside range literals, the only exception is the `not` operator.
+
+  ```elixir
+  angle = -45
+  ^result = Float.parse("42.01")
+  2 in 1..5
+  not File.exists?(path)
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    _angle = - 45
+    result = 42.01
+    ^ result = Float.parse("42.01")
+    _should_be_true = 2 in 1 .. 5
+    not File.exists?("a_path_to_file_that_does_not_exists")
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_04_no_spaces_in_code.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_04_no_spaces_in_code.ex
@@ -12,12 +12,10 @@ defmodule Lexmag1SourceCodeLayout04NoSpacesInCode do
   @doc """
   No spaces after unary operators and inside range literals, the only exception is the `not` operator.
 
-  ```elixir
-  angle = -45
-  ^result = Float.parse("42.01")
-  2 in 1..5
-  not File.exists?(path)
-  ```
+      angle = -45
+      ^result = Float.parse("42.01")
+      2 in 1..5
+      not File.exists?(path)
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_05_default_arguments.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_05_default_arguments.ex
@@ -1,0 +1,19 @@
+defmodule Lexmag1SourceCodeLayout05DefaultArguments do
+  @moduledoc """
+  Source: [default-arguments](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#default-arguments)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use spaces around default arguments `\\` definition.
+  """
+  @spec test(something :: any) :: any
+  def test(_something\\nil) do
+    # code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_06_bitstring_segment_options.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_06_bitstring_segment_options.ex
@@ -1,0 +1,30 @@
+defmodule Lexmag1SourceCodeLayout06BitstringSegmentOptions do
+  @moduledoc """
+  Source: [bitstring-segment-options](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#bitstring-segment-options)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Do not put spaces around segment options definition in bitstrings.
+
+  ```elixir
+  # Bad
+  <<102 :: unsigned-big-integer, rest :: binary>>
+  <<102::unsigned - big - integer, rest::binary>>
+
+  # Good
+  <<102::unsigned-big-integer, rest::binary>>
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    rest = "example"
+    <<102 :: unsigned-big-integer, rest :: binary>>
+    <<102::unsigned - big - integer, rest::binary>>
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_06_bitstring_segment_options.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_06_bitstring_segment_options.ex
@@ -12,14 +12,12 @@ defmodule Lexmag1SourceCodeLayout06BitstringSegmentOptions do
   @doc """
   Do not put spaces around segment options definition in bitstrings.
 
-  ```elixir
-  # Bad
-  <<102 :: unsigned-big-integer, rest :: binary>>
-  <<102::unsigned - big - integer, rest::binary>>
+      # Bad
+      <<102 :: unsigned-big-integer, rest :: binary>>
+      <<102::unsigned - big - integer, rest::binary>>
 
-  # Good
-  <<102::unsigned-big-integer, rest::binary>>
-  ```
+      # Good
+      <<102::unsigned-big-integer, rest::binary>>
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_07_guard_clauses.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_07_guard_clauses.ex
@@ -12,17 +12,15 @@ defmodule Lexmag1SourceCodeLayout07GuardClauses do
   @doc """
   Indent `when` guard clauses on the same level as the function/macro signature in the definition they're part of. Do this only if you cannot fit the `when` guard on the same line as the definition.
 
-  ```elixir
-  def format_error({exception, stacktrace})
-      when is_list(stacktrace) and stacktrace != [] do
-    # ...
-  end
+      def format_error({exception, stacktrace})
+          when is_list(stacktrace) and stacktrace != [] do
+        # ...
+      end
 
-  defmacro dngettext(domain, msgid, msgid_plural, count)
-           when is_binary(msgid) and is_binary(msgid_plural) do
-    # ...
-  end
-  ```
+      defmacro dngettext(domain, msgid, msgid_plural, count)
+               when is_binary(msgid) and is_binary(msgid_plural) do
+        # ...
+      end
   """
   @spec test(stacktrace :: list) :: any
   def test(stacktrace)

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_07_guard_clauses.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_07_guard_clauses.ex
@@ -1,0 +1,39 @@
+defmodule Lexmag1SourceCodeLayout07GuardClauses do
+  @moduledoc """
+  Source: [guard-clauses](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#guard-clauses)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Indent `when` guard clauses on the same level as the function/macro signature in the definition they're part of. Do this only if you cannot fit the `when` guard on the same line as the definition.
+
+  ```elixir
+  def format_error({exception, stacktrace})
+      when is_list(stacktrace) and stacktrace != [] do
+    # ...
+  end
+
+  defmacro dngettext(domain, msgid, msgid_plural, count)
+           when is_binary(msgid) and is_binary(msgid_plural) do
+    # ...
+  end
+  ```
+  """
+  @spec test(stacktrace :: list) :: any
+  def test(stacktrace)
+    when is_list(stacktrace) do
+      # code here ...
+  end
+
+  @doc false
+  @spec macro_test(stacktrace :: list) :: any
+  defmacro macro_test(stacktrace)
+  when is_list(stacktrace) do
+    # code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_08_multi_line_expr_assignment.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_08_multi_line_expr_assignment.ex
@@ -12,28 +12,26 @@ defmodule Lexmag1SourceCodeLayout08MultiLineExprAssignment do
   @doc """
   When assigning the result of a multi-line expression, do not preserve alignment of its parts.
 
-  ```elixir
-  # Bad
-  {found, not_found} = Enum.map(files, &Path.expand(&1, path))
-                       |> Enum.partition(&File.exists?/1)
+      # Bad
+      {found, not_found} = Enum.map(files, &Path.expand(&1, path))
+                           |> Enum.partition(&File.exists?/1)
 
-  prefix = case base do
-             :binary -> "0b"
-             :octal -> "0o"
-             :hex -> "0x"
-           end
+      prefix = case base do
+                 :binary -> "0b"
+                 :octal -> "0o"
+                 :hex -> "0x"
+               end
 
-  # Good
-  {found, not_found} =
-    Enum.map(files, &Path.expand(&1, path))
-    |> Enum.partition(&File.exists?/1)
+      # Good
+      {found, not_found} =
+        Enum.map(files, &Path.expand(&1, path))
+        |> Enum.partition(&File.exists?/1)
 
-  prefix = case base do
-    :binary -> "0b"
-    :octal -> "0o"
-    :hex -> "0x"
-  end
-  ```
+      prefix = case base do
+        :binary -> "0b"
+        :octal -> "0o"
+        :hex -> "0x"
+      end
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_08_multi_line_expr_assignment.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_08_multi_line_expr_assignment.ex
@@ -1,0 +1,51 @@
+defmodule Lexmag1SourceCodeLayout08MultiLineExprAssignment do
+  @moduledoc """
+  Source: [multi-line-expr-assignment](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#multi-line-expr-assignment)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  When assigning the result of a multi-line expression, do not preserve alignment of its parts.
+
+  ```elixir
+  # Bad
+  {found, not_found} = Enum.map(files, &Path.expand(&1, path))
+                       |> Enum.partition(&File.exists?/1)
+
+  prefix = case base do
+             :binary -> "0b"
+             :octal -> "0o"
+             :hex -> "0x"
+           end
+
+  # Good
+  {found, not_found} =
+    Enum.map(files, &Path.expand(&1, path))
+    |> Enum.partition(&File.exists?/1)
+
+  prefix = case base do
+    :binary -> "0b"
+    :octal -> "0o"
+    :hex -> "0x"
+  end
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    files = []
+    path = File.cwd!
+    {_found, _not_found} = Enum.map(files, &Path.expand(&1, path))
+                         |> Enum.partition(&File.exists?/1)
+    base = :binary
+    _prefix = case base do
+               :binary -> "0b"
+               :octal -> "0o"
+               :hex -> "0x"
+             end
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_09_underscores_in_numerics.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_09_underscores_in_numerics.ex
@@ -1,0 +1,23 @@
+defmodule Lexmag1SourceCodeLayout09UnderscoresInNumerics do
+  @moduledoc """
+  Source: [underscores-in-numerics](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#underscores-in-numerics)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Add underscores to large numeric literals to improve their readability.
+
+  ```elixir
+  num = 1_000_000
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    _num = 1000000
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_10_quotes_around_atoms.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_10_quotes_around_atoms.ex
@@ -1,0 +1,31 @@
+defmodule Lexmag1SourceCodeLayout10QuotesAroundAtoms do
+  @moduledoc """
+  Source: [quotes-around-atoms](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#quotes-around-atoms)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  When using atom literals that need to be quoted because they contain characters that are invalid in atoms (such as `:"foo-bar"`), use double quotes around the atom name:
+
+  ```elixir
+  # Bad
+  :'foo-bar'
+  :'atom number \#{index}'
+
+  # Good
+  :"foo-bar"
+  :"atom number \#{index}"
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    index = 5
+    :'foo-bar'
+    :'atom number #{index}'
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_10_quotes_around_atoms.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_10_quotes_around_atoms.ex
@@ -12,15 +12,13 @@ defmodule Lexmag1SourceCodeLayout10QuotesAroundAtoms do
   @doc """
   When using atom literals that need to be quoted because they contain characters that are invalid in atoms (such as `:"foo-bar"`), use double quotes around the atom name:
 
-  ```elixir
-  # Bad
-  :'foo-bar'
-  :'atom number \#{index}'
+      # Bad
+      :'foo-bar'
+      :'atom number \#{index}'
 
-  # Good
-  :"foo-bar"
-  :"atom number \#{index}"
-  ```
+      # Good
+      :"foo-bar"
+      :"atom number \#{index}"
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_11_no_trailing_whitespaces.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_11_no_trailing_whitespaces.ex
@@ -1,0 +1,19 @@
+defmodule Lexmag1SourceCodeLayout11NoTrailingWhitespaces do
+  @moduledoc """
+  Source: [no-trailing-whitespaces](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#no-trailing-whitespaces)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Avoid trailing whitespaces.
+  """
+  @spec test() :: any
+  def test() do
+    # code here ...    		  	
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_12_newline_eof.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_12_newline_eof.ex
@@ -1,0 +1,19 @@
+defmodule Lexmag1SourceCodeLayout12NewlineEof do
+  @moduledoc """
+  Source: [newline-eof](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#newline-eof)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  End each file with a newline.
+  """
+  @spec test() :: any
+  def test() do
+    # code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_13_trailing_comma.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_13_trailing_comma.ex
@@ -12,13 +12,11 @@ defmodule Lexmag1SourceCodeLayout13TrailingComma do
   @doc """
   When dealing with lists, maps, structs, or tuples whose elements span over multiple lines and are on separate lines with regard to the enclosing brackets, it's advised to use a trailing comma even for the last element:
 
-  ```elixir
-  [
-    :foo,
-    :bar,
-    :baz,
-  ]
-  ```
+      [
+        :foo,
+        :bar,
+        :baz,
+      ]
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_13_trailing_comma.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_13_trailing_comma.ex
@@ -1,0 +1,31 @@
+defmodule Lexmag1SourceCodeLayout13TrailingComma do
+  @moduledoc """
+  Source: [trailing-comma](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#trailing-comma)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  When dealing with lists, maps, structs, or tuples whose elements span over multiple lines and are on separate lines with regard to the enclosing brackets, it's advised to use a trailing comma even for the last element:
+
+  ```elixir
+  [
+    :foo,
+    :bar,
+    :baz,
+  ]
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    [
+      :foo,
+      :bar,
+      :baz
+    ]
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_14_expression_group_alignment.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_14_expression_group_alignment.ex
@@ -1,0 +1,49 @@
+defmodule Lexmag1SourceCodeLayout14ExpressionGroupAlignment do
+  @moduledoc """
+  Source: [expression-group-alignment](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#expression-group-alignment)
+   from section: [Source Code Layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#source-code-layout)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Avoid aligning expression groups:
+
+  ```elixir
+  # Bad
+  module = env.module
+  arity  = length(args)
+
+  def inspect(false), do: "false"
+  def inspect(true),  do: "true"
+  def inspect(nil),   do: "nil"
+
+  # Good
+  module = env.module
+  arity = length(args)
+
+  def inspect(false), do: "false"
+  def inspect(true), do: "true"
+  def inspect(nil), do: "nil"
+  ```
+
+  The same non-alignment rule applies to `<-` and `->` clauses as well.
+  """
+  @spec test() :: any
+  def test() do
+    env     = %{module: "something"}
+    args    = []
+    _module = env.module
+    _arity  = length(args)
+  end
+
+  @doc false
+  @spec my_inspect(sample :: any) :: any
+  def my_inspect(false),    do: false
+  def my_inspect(true),     do: true
+  def my_inspect(nil),      do: nil
+  def my_inspect(sample),   do: inspect(sample)
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_14_expression_group_alignment.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_1_source_code_layout_14_expression_group_alignment.ex
@@ -12,23 +12,21 @@ defmodule Lexmag1SourceCodeLayout14ExpressionGroupAlignment do
   @doc """
   Avoid aligning expression groups:
 
-  ```elixir
-  # Bad
-  module = env.module
-  arity  = length(args)
+      # Bad
+      module = env.module
+      arity  = length(args)
 
-  def inspect(false), do: "false"
-  def inspect(true),  do: "true"
-  def inspect(nil),   do: "nil"
+      def inspect(false), do: "false"
+      def inspect(true),  do: "true"
+      def inspect(nil),   do: "nil"
 
-  # Good
-  module = env.module
-  arity = length(args)
+      # Good
+      module = env.module
+      arity = length(args)
 
-  def inspect(false), do: "false"
-  def inspect(true), do: "true"
-  def inspect(nil), do: "nil"
-  ```
+      def inspect(false), do: "false"
+      def inspect(true), do: "true"
+      def inspect(nil), do: "nil"
 
   The same non-alignment rule applies to `<-` and `->` clauses as well.
   """

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_01_fun_parens.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_01_fun_parens.ex
@@ -12,25 +12,23 @@ defmodule Lexmag2Syntax01FunParens do
   @doc """
   Always use parentheses around `def` arguments, don't omit them even when a function has no arguments.
 
-  ```elixir
-  # Bad
-  def main arg1, arg2 do
-    #...
-  end
+      # Bad
+      def main arg1, arg2 do
+        #...
+      end
 
-  def main do
-    #...
-  end
+      def main do
+        #...
+      end
 
-  # Good
-  def main(arg1, arg2) do
-    #...
-  end
+      # Good
+      def main(arg1, arg2) do
+        #...
+      end
 
-  def main() do
-    #...
-  end
-  ```
+      def main() do
+        #...
+      end
   """
   @spec test(argument :: any) :: any
   def test _argument do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_01_fun_parens.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_01_fun_parens.ex
@@ -1,0 +1,45 @@
+defmodule Lexmag2Syntax01FunParens do
+  @moduledoc """
+  Source: [fun-parens](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#fun-parens)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Always use parentheses around `def` arguments, don't omit them even when a function has no arguments.
+
+  ```elixir
+  # Bad
+  def main arg1, arg2 do
+    #...
+  end
+
+  def main do
+    #...
+  end
+
+  # Good
+  def main(arg1, arg2) do
+    #...
+  end
+
+  def main() do
+    #...
+  end
+  ```
+  """
+  @spec test(argument :: any) :: any
+  def test _argument do
+    # code here ...
+  end
+
+  @doc false
+  @spec test_no_args() :: any
+  def test_no_args do
+    # code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_02_zero_arity_parens.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_02_zero_arity_parens.ex
@@ -12,22 +12,18 @@ defmodule Lexmag2Syntax02ZeroArityParens do
   @doc """
   Parentheses are a must for __local__ zero-arity function calls and definitions.
 
-  ```elixir
-  # Bad
-  pid = self
-  def new, do: %MapSet{}
+      # Bad
+      pid = self
+      def new, do: %MapSet{}
 
-  # Good
-  pid = self()
-  def new(), do: %MapSet{}
-  config = IEx.Config.new
-  ```
+      # Good
+      pid = self()
+      def new(), do: %MapSet{}
+      config = IEx.Config.new
 
   The same applies to __local__ one-arity function calls in pipelines.
 
-  ```elixir
-  String.strip(input) |> decode()
-  ```
+      String.strip(input) |> decode()
   """
   @spec test(argument :: any) :: any
   def test(_argument), do: _pid = self

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_02_zero_arity_parens.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_02_zero_arity_parens.ex
@@ -1,0 +1,44 @@
+defmodule Lexmag2Syntax02ZeroArityParens do
+  @moduledoc """
+  Source: [zero-arity-parens](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#zero-arity-parens)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Parentheses are a must for __local__ zero-arity function calls and definitions.
+
+  ```elixir
+  # Bad
+  pid = self
+  def new, do: %MapSet{}
+
+  # Good
+  pid = self()
+  def new(), do: %MapSet{}
+  config = IEx.Config.new
+  ```
+
+  The same applies to __local__ one-arity function calls in pipelines.
+
+  ```elixir
+  String.strip(input) |> decode()
+  ```
+  """
+  @spec test(argument :: any) :: any
+  def test(_argument), do: _pid = self
+
+  @spec test_not_local() :: any
+  def test_not_local(), do: _config = IEx.Config.new
+
+  @spec test_pipeline(input :: bitstring) :: any
+  def test_pipeline(input) do
+    input
+    |> String.strip
+    |> test
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_03_pipeline_operator.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_03_pipeline_operator.ex
@@ -43,6 +43,7 @@ defmodule Lexmag2Syntax03PipelineOperator do
   @spec test() :: any
   def test() do
     String.downcase(String.strip(" EXAMPLE "))
+
     "example" |> String.upcase
   end
 end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_03_pipeline_operator.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_03_pipeline_operator.ex
@@ -12,33 +12,26 @@ defmodule Lexmag2Syntax03PipelineOperator do
   @doc """
   Favor the pipeline operator `|>` to chain function calls together.
 
-  ```elixir
-  # Bad
-  String.downcase(String.strip(input))
+      # Bad
+      String.downcase(String.strip(input))
 
-  # Good
-  input |> String.strip |> String.downcase
-  String.strip(input) |> String.downcase
-  ```
+      # Good
+      input |> String.strip |> String.downcase
+      String.strip(input) |> String.downcase
 
   Use a single level of indentation for multi-line pipelines.
 
-  ```elixir
-  String.strip(input)
-  |> String.downcase
-  |> String.slice(1, 3)
-  ```
+      String.strip(input)
+      |> String.downcase
+      |> String.slice(1, 3)
 
-  <a name="needless-pipeline"></a>
   Avoid needless pipelines like the plague.
 
-  ```elixir
-  # Bad
-  result = input |> String.strip
+      # Bad
+      result = input |> String.strip
 
-  # Good
-  result = String.strip(input)
-  ```
+      # Good
+      result = String.strip(input)
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_03_pipeline_operator.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_03_pipeline_operator.ex
@@ -1,0 +1,48 @@
+defmodule Lexmag2Syntax03PipelineOperator do
+  @moduledoc """
+  Source: [pipeline-operator](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#pipeline-operator)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Favor the pipeline operator `|>` to chain function calls together.
+
+  ```elixir
+  # Bad
+  String.downcase(String.strip(input))
+
+  # Good
+  input |> String.strip |> String.downcase
+  String.strip(input) |> String.downcase
+  ```
+
+  Use a single level of indentation for multi-line pipelines.
+
+  ```elixir
+  String.strip(input)
+  |> String.downcase
+  |> String.slice(1, 3)
+  ```
+
+  <a name="needless-pipeline"></a>
+  Avoid needless pipelines like the plague.
+
+  ```elixir
+  # Bad
+  result = input |> String.strip
+
+  # Good
+  result = String.strip(input)
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    String.downcase(String.strip(" EXAMPLE "))
+    "example" |> String.upcase
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_04_binary_operators_at_eols.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_04_binary_operators_at_eols.ex
@@ -1,0 +1,33 @@
+defmodule Lexmag2Syntax04BinaryOperatorsAtEols do
+  @moduledoc """
+  Source: [binary-operators-at-eols](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#binary-operators-at-eols)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  When making a multi-line expression, keep binary operators (the only exception is the `|>` operator) at the ends of the lines.
+
+  ```elixir
+  # Bad
+  "No matching message.\n"
+  <> "Process mailbox:\n"
+  <> mailbox
+
+  # Good
+  "No matching message.\n" <>
+  "Process mailbox:\n" <>
+  mailbox
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    "First line.\n"
+    <> "Second line:\n"
+    <> "Third line."
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_04_binary_operators_at_eols.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_04_binary_operators_at_eols.ex
@@ -12,17 +12,15 @@ defmodule Lexmag2Syntax04BinaryOperatorsAtEols do
   @doc """
   When making a multi-line expression, keep binary operators (the only exception is the `|>` operator) at the ends of the lines.
 
-  ```elixir
-  # Bad
-  "No matching message.\n"
-  <> "Process mailbox:\n"
-  <> mailbox
+      # Bad
+      "No matching message.\n"
+      <> "Process mailbox:\n"
+      <> mailbox
 
-  # Good
-  "No matching message.\n" <>
-  "Process mailbox:\n" <>
-  mailbox
-  ```
+      # Good
+      "No matching message.\n" <>
+      "Process mailbox:\n" <>
+      mailbox
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_05_with_indentation.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_05_with_indentation.ex
@@ -1,0 +1,49 @@
+defmodule Lexmag2Syntax05WithIndentation do
+  @moduledoc """
+  Source: [with-indentation](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#with-indentation)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use the indentation shown below for the `with` special form:
+
+  ```elixir
+  with {year, ""} <- Integer.parse(year),
+       {month, ""} <- Integer.parse(month),
+       {day, ""} <- Integer.parse(day) do
+    new(year, month, day)
+  else
+    _ ->
+      {:error, :invalid_format}
+  end
+  ```
+
+  Always use the indentation above if there's an `else` option. If there isn't, the following indentation works as well:
+
+  ```elixir
+  with {:ok, date} <- Calendar.ISO.date(year, month, day),
+       {:ok, time} <- Time.new(hour, minute, second, microsecond),
+       do: new(date, time)
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    with {year, ""} <- Integer.parse("2016"),
+      {month, ""} <- Integer.parse("12"),
+       {day, ""} <- Integer.parse("24") do
+     {year, month, day}
+      else
+    _ ->
+     {:error, :invalid_format}
+    end
+
+    with {:ok, date} <- Calendar.ISO.date(2016, 12, 24),
+      {:ok, time} <- Time.new(0, 0, 0, 0),
+    do: {date, time}
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_05_with_indentation.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_05_with_indentation.ex
@@ -12,24 +12,20 @@ defmodule Lexmag2Syntax05WithIndentation do
   @doc """
   Use the indentation shown below for the `with` special form:
 
-  ```elixir
-  with {year, ""} <- Integer.parse(year),
-       {month, ""} <- Integer.parse(month),
-       {day, ""} <- Integer.parse(day) do
-    new(year, month, day)
-  else
-    _ ->
-      {:error, :invalid_format}
-  end
-  ```
+      with {year, ""} <- Integer.parse(year),
+           {month, ""} <- Integer.parse(month),
+           {day, ""} <- Integer.parse(day) do
+        new(year, month, day)
+      else
+        _ ->
+          {:error, :invalid_format}
+      end
 
   Always use the indentation above if there's an `else` option. If there isn't, the following indentation works as well:
 
-  ```elixir
-  with {:ok, date} <- Calendar.ISO.date(year, month, day),
-       {:ok, time} <- Time.new(hour, minute, second, microsecond),
-       do: new(date, time)
-  ```
+      with {:ok, date} <- Calendar.ISO.date(year, month, day),
+           {:ok, time} <- Time.new(hour, minute, second, microsecond),
+           do: new(date, time)
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_06_for_indentation.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_06_for_indentation.ex
@@ -40,13 +40,13 @@ defmodule Lexmag2Syntax06ForIndentation do
     end
 
     indexes = 0..999
-    max_count =
+    max_size =
       indexes
       |> Enum.max
       |> Integer.to_string
       |> String.length
     for index <- indexes,
-     padded_index = String.pad_leading("#{index}", max_count, "0"),
+     padded_index = String.pad_leading("#{index}", max_size, "0"),
       into: %{},
     do: {index, padded_index}
   end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_06_for_indentation.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_06_for_indentation.ex
@@ -12,23 +12,19 @@ defmodule Lexmag2Syntax06ForIndentation do
   @doc """
   Use the indentation shown below for the `for` special form:
 
-  ```elixir
-  for {alias, _module} <- aliases_from_env(server),
-      [name] = Module.split(alias),
-      starts_with?(name, hint),
-      into: [] do
-    %{kind: :module, type: :alias, name: name}
-  end
-  ```
+      for {alias, _module} <- aliases_from_env(server),
+          [name] = Module.split(alias),
+          starts_with?(name, hint),
+          into: [] do
+        %{kind: :module, type: :alias, name: name}
+      end
 
   If the body of the `do` block is short, the following indentation works as well:
 
-  ```elixir
-  for partition <- 0..(partitions - 1),
-      pair <- safe_lookup(registry, partition, key),
-      into: [],
-      do: pair
-  ```
+      for partition <- 0..(partitions - 1),
+          pair <- safe_lookup(registry, partition, key),
+          into: [],
+          do: pair
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_06_for_indentation.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_06_for_indentation.ex
@@ -1,0 +1,53 @@
+defmodule Lexmag2Syntax06ForIndentation do
+  @moduledoc """
+  Source: [for-indentation](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#for-indentation)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use the indentation shown below for the `for` special form:
+
+  ```elixir
+  for {alias, _module} <- aliases_from_env(server),
+      [name] = Module.split(alias),
+      starts_with?(name, hint),
+      into: [] do
+    %{kind: :module, type: :alias, name: name}
+  end
+  ```
+
+  If the body of the `do` block is short, the following indentation works as well:
+
+  ```elixir
+  for partition <- 0..(partitions - 1),
+      pair <- safe_lookup(registry, partition, key),
+      into: [],
+      do: pair
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    for element <- [],
+       [name] = String.capitalize(element),
+     String.starts_with?(name, "Jo"),
+      into: [] do
+    %{modifications: [:capitalize], validators: [starts_with: "Jo"], value: name}
+    end
+
+    indexes = 0..999
+    max_count =
+      indexes
+      |> Enum.max
+      |> Integer.to_string
+      |> String.length
+    for index <- indexes,
+     padded_index = String.pad_leading("#{index}", max_count, "0"),
+      into: %{},
+    do: {index, padded_index}
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_07_no_else_with_unless.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_07_no_else_with_unless.ex
@@ -1,0 +1,39 @@
+defmodule Lexmag2Syntax07NoElseWithUnless do
+  @moduledoc """
+  Source: [no-else-with-unless](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#no-else-with-unless)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Never use `unless` with `else`. Rewrite these with the positive case first.
+
+  ```elixir
+  # Bad
+  unless Enum.empty?(coll) do
+    :ok
+  else
+    :error
+  end
+
+  # Good
+  if Enum.empty?(coll) do
+    :error
+  else
+    :ok
+  end
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    unless Enum.empty?([]) do
+      :ok
+    else
+      :error
+    end
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_07_no_else_with_unless.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_07_no_else_with_unless.ex
@@ -12,21 +12,19 @@ defmodule Lexmag2Syntax07NoElseWithUnless do
   @doc """
   Never use `unless` with `else`. Rewrite these with the positive case first.
 
-  ```elixir
-  # Bad
-  unless Enum.empty?(coll) do
-    :ok
-  else
-    :error
-  end
+      # Bad
+      unless Enum.empty?(coll) do
+        :ok
+      else
+        :error
+      end
 
-  # Good
-  if Enum.empty?(coll) do
-    :error
-  else
-    :ok
-  end
-  ```
+      # Good
+      if Enum.empty?(coll) do
+        :error
+      else
+        :ok
+      end
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_08_no_nil_else.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_08_no_nil_else.ex
@@ -12,13 +12,11 @@ defmodule Lexmag2Syntax08NoNilElse do
   @doc """
   Omit `else` option in `if` and `unless` clauses if it returns `nil`.
 
-  ```elixir
-  # Bad
-  if byte_size(data) > 0, do: data, else: nil
+      # Bad
+      if byte_size(data) > 0, do: data, else: nil
 
-  # Good
-  if byte_size(data) > 0, do: data
-  ```
+      # Good
+      if byte_size(data) > 0, do: data
   """
   @spec test(data :: bitstring) :: any
   def test(data) do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_08_no_nil_else.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_08_no_nil_else.ex
@@ -1,0 +1,27 @@
+defmodule Lexmag2Syntax08NoNilElse do
+  @moduledoc """
+  Source: [no-nil-else](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#no-nil-else)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Omit `else` option in `if` and `unless` clauses if it returns `nil`.
+
+  ```elixir
+  # Bad
+  if byte_size(data) > 0, do: data, else: nil
+
+  # Good
+  if byte_size(data) > 0, do: data
+  ```
+  """
+  @spec test(data :: bitstring) :: any
+  def test(data) do
+    if byte_size(data) > 0, do: data, else: nil
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_09_true_in_cond.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_09_true_in_cond.ex
@@ -12,16 +12,14 @@ defmodule Lexmag2Syntax09TrueInCond do
   @doc """
   Use `true` as the always-match condition of the `cond` special form.
 
-  ```elixir
-  cond do
-    char in ?0..?9 ->
-      char - ?0
-    char in ?A..?Z ->
-      char - ?A + 10
-    true ->
-      char - ?a + 10
-  end
-  ```
+      cond do
+        char in ?0..?9 ->
+          char - ?0
+        char in ?A..?Z ->
+          char - ?A + 10
+        true ->
+          char - ?a + 10
+      end
   """
   @spec test(char :: integer) :: any
   def test(char) do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_09_true_in_cond.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_09_true_in_cond.ex
@@ -1,0 +1,35 @@
+defmodule Lexmag2Syntax09TrueInCond do
+  @moduledoc """
+  Source: [true-in-cond](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#true-in-cond)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use `true` as the always-match condition of the `cond` special form.
+
+  ```elixir
+  cond do
+    char in ?0..?9 ->
+      char - ?0
+    char in ?A..?Z ->
+      char - ?A + 10
+    true ->
+      char - ?a + 10
+  end
+  ```
+  """
+  @spec test(char :: integer) :: any
+  def test(char) do
+    cond do
+      char in ?0..?9 ->
+        char - ?0
+      char in ?A..?Z ->
+        char - ?A + 10
+    end
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_09_true_in_cond.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_09_true_in_cond.ex
@@ -28,6 +28,8 @@ defmodule Lexmag2Syntax09TrueInCond do
         char - ?0
       char in ?A..?Z ->
         char - ?A + 10
+      :any ->
+        char - ?a + 10
     end
   end
 end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_10_boolean_operators.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_10_boolean_operators.ex
@@ -12,17 +12,15 @@ defmodule Lexmag2Syntax10BooleanOperators do
   @doc """
   Never use `||`, `&&` and `!` for strictly boolean checks. Use these operators only if any of the arguments are non-boolean.
 
-  ```elixir
-  # Bad
-  is_atom(name) && name != nil
-  is_binary(task) || is_atom(task)
+      # Bad
+      is_atom(name) && name != nil
+      is_binary(task) || is_atom(task)
 
-  # Good
-  is_atom(name) and name != nil
-  is_binary(task) or is_atom(task)
-  line && line != 0
-  file || "sample.exs"
-  ```
+      # Good
+      is_atom(name) and name != nil
+      is_binary(task) or is_atom(task)
+      line && line != 0
+      file || "sample.exs"
   """
   @spec test(name :: atom) :: any
   def test(name) do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_10_boolean_operators.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_10_boolean_operators.ex
@@ -27,7 +27,7 @@ defmodule Lexmag2Syntax10BooleanOperators do
   @spec test(name :: atom) :: any
   def test(name) do
     task = :spying
-    is_atom(name) && !is_nil(name) && !is_boolean(name)
+    !is_nil(name) && !is_boolean(name)
     is_binary(task) || is_atom(task)
   end
 end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_10_boolean_operators.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_10_boolean_operators.ex
@@ -1,0 +1,33 @@
+defmodule Lexmag2Syntax10BooleanOperators do
+  @moduledoc """
+  Source: [boolean-operators](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#boolean-operators)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Never use `||`, `&&` and `!` for strictly boolean checks. Use these operators only if any of the arguments are non-boolean.
+
+  ```elixir
+  # Bad
+  is_atom(name) && name != nil
+  is_binary(task) || is_atom(task)
+
+  # Good
+  is_atom(name) and name != nil
+  is_binary(task) or is_atom(task)
+  line && line != 0
+  file || "sample.exs"
+  ```
+  """
+  @spec test(name :: atom) :: any
+  def test(name) do
+    task = :spying
+    is_atom(name) && !is_nil(name) && !is_boolean(name)
+    is_binary(task) || is_atom(task)
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_11_patterns_matching_binaries.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_11_patterns_matching_binaries.ex
@@ -1,0 +1,30 @@
+defmodule Lexmag2Syntax11PatternsMatchingBinaries do
+  @moduledoc """
+  Source: [patterns-matching-binaries](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#patterns-matching-binaries)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Favor the binary concatenation operator `<>` over bitstring syntax for patterns matching binaries.
+
+  ```elixir
+  # Bad
+  <<"http://", _rest::bytes>> = input
+  <<first::utf8, rest::bytes>> = input
+
+  # Good
+  "http://" <> _rest = input
+  <<first::utf8>> <> rest = input
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    <<"http://", _rest::bytes>> = "http://elixir-lang.org/"
+    <<_first::utf8, _rest::bytes>> = "Something"
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_11_patterns_matching_binaries.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_11_patterns_matching_binaries.ex
@@ -12,15 +12,13 @@ defmodule Lexmag2Syntax11PatternsMatchingBinaries do
   @doc """
   Favor the binary concatenation operator `<>` over bitstring syntax for patterns matching binaries.
 
-  ```elixir
-  # Bad
-  <<"http://", _rest::bytes>> = input
-  <<first::utf8, rest::bytes>> = input
+      # Bad
+      <<"http://", _rest::bytes>> = input
+      <<first::utf8, rest::bytes>> = input
 
-  # Good
-  "http://" <> _rest = input
-  <<first::utf8>> <> rest = input
-  ```
+      # Good
+      "http://" <> _rest = input
+      <<first::utf8>> <> rest = input
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_12_hex_literals.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_12_hex_literals.ex
@@ -12,13 +12,11 @@ defmodule Lexmag2Syntax12HexLiterals do
   @doc """
   Use uppercase in definition of hex literals.
 
-  ```elixir
-  # Bad
-  <<0xef, 0xbb, 0xbf>>
+      # Bad
+      <<0xef, 0xbb, 0xbf>>
 
-  # Good
-  <<0xEF, 0xBB, 0xBF>>
-  ```
+      # Good
+      <<0xEF, 0xBB, 0xBF>>
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_12_hex_literals.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_2_syntax_12_hex_literals.ex
@@ -1,0 +1,27 @@
+defmodule Lexmag2Syntax12HexLiterals do
+  @moduledoc """
+  Source: [hex-literals](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#hex-literals)
+   from section: [Syntax](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#syntax)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use uppercase in definition of hex literals.
+
+  ```elixir
+  # Bad
+  <<0xef, 0xbb, 0xbf>>
+
+  # Good
+  <<0xEF, 0xBB, 0xBF>>
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    <<0xef, 0xbb, 0xbf>>
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_3_naming_1_snake_case_atoms_funs_vars_attrs.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_3_naming_1_snake_case_atoms_funs_vars_attrs.ex
@@ -14,33 +14,31 @@ defmodule Lexmag3Naming1SnakeCaseAtomsFunsVarsAttrs do
   @doc """
   Use `snake_case` for atoms, functions, variables and module attributes.
 
-  ```elixir
-  # Bad
-  :"no match"
-  :Error
-  :badReturn
+      # Bad
+      :"no match"
+      :Error
+      :badReturn
 
-  fileName = "sample.txt"
+      fileName = "sample.txt"
 
-  @_VERSION "0.0.1"
+      @_VERSION "0.0.1"
 
-  def readFile(path) do
-    #...
-  end
+      def readFile(path) do
+        #...
+      end
 
-  # Good
-  :no_match
-  :error
-  :bad_return
+      # Good
+      :no_match
+      :error
+      :bad_return
 
-  file_name = "sample.txt"
+      file_name = "sample.txt"
 
-  @version "0.0.1"
+      @version "0.0.1"
 
-  def read_file(path) do
-    #...
-  end
-  ```
+      def read_file(path) do
+        #...
+      end
   """
   @spec testMe() :: any
   def testMe() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_3_naming_1_snake_case_atoms_funs_vars_attrs.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_3_naming_1_snake_case_atoms_funs_vars_attrs.ex
@@ -1,0 +1,52 @@
+defmodule Lexmag3Naming1SnakeCaseAtomsFunsVarsAttrs do
+  @moduledoc """
+  Source: [snake-case-atoms-funs-vars-attrs](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#snake-case-atoms-funs-vars-attrs)
+   from section: [Naming](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#naming)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @_VERSION "0.0.1"
+
+  @doc """
+  Use `snake_case` for atoms, functions, variables and module attributes.
+
+  ```elixir
+  # Bad
+  :"no match"
+  :Error
+  :badReturn
+
+  fileName = "sample.txt"
+
+  @_VERSION "0.0.1"
+
+  def readFile(path) do
+    #...
+  end
+
+  # Good
+  :no_match
+  :error
+  :bad_return
+
+  file_name = "sample.txt"
+
+  @version "0.0.1"
+
+  def read_file(path) do
+    #...
+  end
+  ```
+  """
+  @spec testMe() :: any
+  def testMe() do
+    :"no match"
+    :Error
+    :badReturn
+    _fileName = "sample.txt"
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_3_naming_2_camelcase_modules.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_3_naming_2_camelcase_modules.ex
@@ -1,0 +1,49 @@
+defmodule Lexmag3Naming2CamelcaseModules do
+  @moduledoc """
+  Source: [camelcase-modules](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#camelcase-modules)
+   from section: [Naming](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#naming)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  defmodule :firstAppStack do
+    @moduledoc false
+    # code here ...
+  end
+
+  defmodule Second_App_Stack do
+    @moduledoc false
+    # code here ...
+  end
+
+  @doc """
+  Use `CamelCase` for module names.
+
+  ```elixir
+  # Bad
+  defmodule :appStack do
+    #...
+  end
+
+  defmodule App_Stack do
+    #...
+  end
+
+  defmodule Appstack do
+    #...
+  end
+
+  # Good
+  defmodule AppStack do
+    #...
+  end
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    # code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_3_naming_2_camelcase_modules.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_3_naming_2_camelcase_modules.ex
@@ -22,25 +22,23 @@ defmodule Lexmag3Naming2CamelcaseModules do
   @doc """
   Use `CamelCase` for module names.
 
-  ```elixir
-  # Bad
-  defmodule :appStack do
-    #...
-  end
+      # Bad
+      defmodule :appStack do
+        #...
+      end
 
-  defmodule App_Stack do
-    #...
-  end
+      defmodule App_Stack do
+        #...
+      end
 
-  defmodule Appstack do
-    #...
-  end
+      defmodule Appstack do
+        #...
+      end
 
-  # Good
-  defmodule AppStack do
-    #...
-  end
-  ```
+      # Good
+      defmodule AppStack do
+        #...
+      end
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_3_naming_3_predicate_funs_name.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_3_naming_3_predicate_funs_name.ex
@@ -1,0 +1,36 @@
+defmodule Lexmag3Naming3PredicateFunsName do
+  @moduledoc """
+  Source: [predicate-funs-name](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#predicate-funs-name)
+   from section: [Naming](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#naming)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  The names of predicate functions (a function that return a boolean value) should have a trailing question mark `?` rather than a leading `has_` or similar.
+
+  ```elixir
+  def leap?(year) do
+    #...
+  end
+  ```
+
+  Always use a leading `is_` when naming guard-safe predicate macros.
+
+  ```elixir
+  defmacro is_date(month, day) do
+    #...
+  end
+  ```
+  """
+  @spec is_ok?(sample :: any) :: boolean
+  def is_ok?(:ok), do: true
+  def is_ok?(_), do: false
+
+  @spec ok?(sample :: any) :: boolean
+  defmacro ok?(:ok), do: true
+  defmacro ok?(_), do: false
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_3_naming_3_predicate_funs_name.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_3_naming_3_predicate_funs_name.ex
@@ -12,19 +12,15 @@ defmodule Lexmag3Naming3PredicateFunsName do
   @doc """
   The names of predicate functions (a function that return a boolean value) should have a trailing question mark `?` rather than a leading `has_` or similar.
 
-  ```elixir
-  def leap?(year) do
-    #...
-  end
-  ```
+      def leap?(year) do
+        #...
+      end
 
   Always use a leading `is_` when naming guard-safe predicate macros.
 
-  ```elixir
-  defmacro is_date(month, day) do
-    #...
-  end
-  ```
+      defmacro is_date(month, day) do
+        #...
+      end
   """
   @spec is_ok?(sample :: any) :: boolean
   def is_ok?(:ok), do: true

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_3_naming_4_snakeCaseDirsFiles.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_3_naming_4_snakeCaseDirsFiles.ex
@@ -1,0 +1,19 @@
+defmodule Lexmag3Naming4SnakeCaseDirsFiles do
+  @moduledoc """
+  Source: [snake-case-dirs-files](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#snake-case-dirs-files)
+   from section: [Naming](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#naming)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use `snake_case` for naming directories and files, e.g. `lib/my_app/task_server.ex`.
+  """
+  @spec test() :: any
+  def test() do
+    # code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_3_naming_5_one_letter_var.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_3_naming_5_one_letter_var.ex
@@ -1,0 +1,19 @@
+defmodule Lexmag3Naming5OneLetterVar do
+  @moduledoc """
+  Source: [one-letter-var](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#one-letter-var)
+   from section: [Naming](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#naming)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Avoid using one-letter variable names.
+  """
+  @spec test() :: any
+  def test() do
+    _o = :ok
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_4_comments_1_no_need_for_comments.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_4_comments_1_no_need_for_comments.ex
@@ -1,0 +1,23 @@
+defmodule Lexmag4Comments1NoNeedForComments do
+  @moduledoc """
+  Source: [no-need-for-comments](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#no-need-for-comments)
+   from section: [Comments](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#comments)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Write self-documenting code and ignore the rest of this section. Seriously!
+  """
+  @spec test() :: any
+  def test() do
+    # code here ...
+  end
+
+  def doc_test(first_argument, {second, argument}) do
+    {first_argument, second, argument}
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_4_comments_2_leading_space_comment.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_4_comments_2_leading_space_comment.ex
@@ -1,0 +1,19 @@
+defmodule Lexmag4Comments2LeadingSpaceComment do
+  @moduledoc """
+  Source: [leading-space-comment](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#leading-space-comment)
+   from section: [Comments](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#comments)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use one space between the leading `#` character of the comment and the text of the comment.
+  """
+  @spec test() :: any
+  def test() do
+    #code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_4_comments_3_no_superfluous_comments.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_4_comments_3_no_superfluous_comments.ex
@@ -12,10 +12,8 @@ defmodule Lexmag4Comments3NoSuperfluousComments do
   @doc """
   Avoid superfluous comments.
 
-  ```elixir
-  # Bad
-  String.first(input) # Get first grapheme.
-  ```
+      # Bad
+      String.first(input) # Get first grapheme.
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_4_comments_3_no_superfluous_comments.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_4_comments_3_no_superfluous_comments.ex
@@ -1,0 +1,24 @@
+defmodule Lexmag4Comments3NoSuperfluousComments do
+  @moduledoc """
+  Source: [no-superfluous-comments](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#no-superfluous-comments)
+   from section: [Comments](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#comments)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Avoid superfluous comments.
+
+  ```elixir
+  # Bad
+  String.first(input) # Get first grapheme.
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    String.capitalize("example sentence is here.") # capitalize sentence
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_5_modules_1_module_layout.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_5_modules_1_module_layout.ex
@@ -1,0 +1,38 @@
+defmodule Lexmag5Modules1ModuleLayout do
+  @moduledoc """
+  Source: [module-layout](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#module-layout)
+   from section: [Modules](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#modules)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  alias Calendar.ISO
+  import Enum
+  require Logger
+  use GenServer
+
+  @doc """
+  Use a consistent structure when calling `use`/`import`/`alias`/`require`: call
+  them in this order and group multiple calls to each of them.
+
+  ```elixir
+  use GenServer
+
+  import Bitwise
+  import Kernel, except: [length: 1]
+
+  alias Mix.Utils
+  alias MapSet, as: Set
+
+  require Logger
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    ISO.day_of_week(2016, 12, 24)
+    at([1, 2, 3], 1)
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_5_modules_1_module_layout.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_5_modules_1_module_layout.ex
@@ -18,17 +18,15 @@ defmodule Lexmag5Modules1ModuleLayout do
   Use a consistent structure when calling `use`/`import`/`alias`/`require`: call
   them in this order and group multiple calls to each of them.
 
-  ```elixir
-  use GenServer
+      use GenServer
 
-  import Bitwise
-  import Kernel, except: [length: 1]
+      import Bitwise
+      import Kernel, except: [length: 1]
 
-  alias Mix.Utils
-  alias MapSet, as: Set
+      alias Mix.Utils
+      alias MapSet, as: Set
 
-  require Logger
-  ```
+      require Logger
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_5_modules_2_current_module_reference.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_5_modules_2_current_module_reference.ex
@@ -12,15 +12,13 @@ defmodule Lexmag5Modules2CurrentModuleReference do
   @doc """
   Use `__MODULE__` pseudo variable to reference current module.
 
-  ```elixir
-  # Bad
-  :ets.new(Kernel.LexicalTracker, [:named_table])
-  GenServer.start_link(Module.LocalsTracker, nil, [])
+      # Bad
+      :ets.new(Kernel.LexicalTracker, [:named_table])
+      GenServer.start_link(Module.LocalsTracker, nil, [])
 
-  # Good
-  :ets.new(__MODULE__, [:named_table])
-  GenServer.start_link(__MODULE__, nil, [])
-  ```
+      # Good
+      :ets.new(__MODULE__, [:named_table])
+      GenServer.start_link(__MODULE__, nil, [])
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_5_modules_2_current_module_reference.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_5_modules_2_current_module_reference.ex
@@ -1,0 +1,29 @@
+defmodule Lexmag5Modules2CurrentModuleReference do
+  @moduledoc """
+  Source: [current-module-reference](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#current-module-reference)
+   from section: [Modules](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#modules)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use `__MODULE__` pseudo variable to reference current module.
+
+  ```elixir
+  # Bad
+  :ets.new(Kernel.LexicalTracker, [:named_table])
+  GenServer.start_link(Module.LocalsTracker, nil, [])
+
+  # Good
+  :ets.new(__MODULE__, [:named_table])
+  GenServer.start_link(__MODULE__, nil, [])
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    :etc.new(Lexmag5Modules2CurrentModuleReference, [:named_table])
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_6_regular_expressions_1_pattern_matching_over_regexp.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_6_regular_expressions_1_pattern_matching_over_regexp.ex
@@ -1,0 +1,30 @@
+defmodule Lexmag6RegularExpressions1PatternMatchingOverRegexp do
+  @moduledoc """
+  Source: [pattern-matching-over-regexp](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#pattern-matching-over-regexp)
+   from section: [Regular Expressions](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#regular-expressions)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Regular expressions are the last resort. Pattern matching and `String` module are things to start with.
+
+  ```elixir
+  # Bad
+  Regex.run(~r/#(\d{2})(\d{2})(\d{2})/, color)
+  Regex.match?(~r/(email|password)/, input)
+
+  # Good
+  <<?#, p1::2-bytes, p2::2-bytes, p3::2-bytes>> = color
+  String.contains?(input, ["email", "password"])
+  ```
+  """
+  @spec test(color :: bitstring, input :: bitstring) :: any
+  def test(color, input) do
+    Regex.run(~r/#(\d{2})(\d{2})(\d{2})/, color)
+    Regex.match?(~r/(email|password)/, input)
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_6_regular_expressions_1_pattern_matching_over_regexp.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_6_regular_expressions_1_pattern_matching_over_regexp.ex
@@ -12,15 +12,13 @@ defmodule Lexmag6RegularExpressions1PatternMatchingOverRegexp do
   @doc """
   Regular expressions are the last resort. Pattern matching and `String` module are things to start with.
 
-  ```elixir
-  # Bad
-  Regex.run(~r/#(\d{2})(\d{2})(\d{2})/, color)
-  Regex.match?(~r/(email|password)/, input)
+      # Bad
+      Regex.run(~r/#(\d{2})(\d{2})(\d{2})/, color)
+      Regex.match?(~r/(email|password)/, input)
 
-  # Good
-  <<?#, p1::2-bytes, p2::2-bytes, p3::2-bytes>> = color
-  String.contains?(input, ["email", "password"])
-  ```
+      # Good
+      <<?#, p1::2-bytes, p2::2-bytes, p3::2-bytes>> = color
+      String.contains?(input, ["email", "password"])
   """
   @spec test(color :: bitstring, input :: bitstring) :: any
   def test(color, input) do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_6_regular_expressions_2_non_capturing_regexp.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_6_regular_expressions_2_non_capturing_regexp.ex
@@ -1,0 +1,23 @@
+defmodule Lexmag6RegularExpressions2NonCapturingRegexp do
+  @moduledoc """
+  Source: [non-capturing-regexp](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#non-capturing-regexp)
+   from section: [Regular Expressions](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#regular-expressions)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use non-capturing groups when you don't use the captured result.
+
+  ```elixir
+  ~r/(?:post|zip )code: (\d+)/
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    # NOTE: we cannot validate this rule
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_6_regular_expressions_2_non_capturing_regexp.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_6_regular_expressions_2_non_capturing_regexp.ex
@@ -12,9 +12,7 @@ defmodule Lexmag6RegularExpressions2NonCapturingRegexp do
   @doc """
   Use non-capturing groups when you don't use the captured result.
 
-  ```elixir
-  ~r/(?:post|zip )code: (\d+)/
-  ```
+      ~r/(?:post|zip )code: (\d+)/
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_6_regular_expressions_3_caret_and_dollar_regexp.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_6_regular_expressions_3_caret_and_dollar_regexp.ex
@@ -1,0 +1,19 @@
+defmodule Lexmag6RegularExpressions3CaretAndDollarRegexp do
+  @moduledoc """
+  Source: [caret-and-dollar-regexp](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#caret-and-dollar-regexp)
+   from section: [Regular Expressions](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#regular-expressions)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Be careful with `^` and `$` as they match start and end of the __line__ respectively. If you want to match the __whole__ string use: `\A` and `\z` (not to be confused with `\Z` which is the equivalent of `\n?\z`).
+  """
+  @spec test() :: any
+  def test() do
+    # NOTE: we cannot validate this rule
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_7_structs_1_defstruct_fields_default.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_7_structs_1_defstruct_fields_default.ex
@@ -14,13 +14,11 @@ defmodule Lexmag7Structs1DefstructFieldsDefault do
   @doc """
   When calling `defstruct/1`, don't explicitly specify `nil` for fields that default to `nil`.
 
-  ```elixir
-  # Bad
-  defstruct first_name: nil, last_name: nil, admin?: false
+      # Bad
+      defstruct first_name: nil, last_name: nil, admin?: false
 
-  # Good
-  defstruct [:first_name, :last_name, admin?: false]
-  ```
+      # Good
+      defstruct [:first_name, :last_name, admin?: false]
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_7_structs_1_defstruct_fields_default.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_7_structs_1_defstruct_fields_default.ex
@@ -1,0 +1,29 @@
+defmodule Lexmag7Structs1DefstructFieldsDefault do
+  @moduledoc """
+  Source: [defstruct-fields-default](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#defstruct-fields-default)
+   from section: [Structs](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#structs)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  defstruct first_name: nil, last_name: nil, admin?: false
+
+  @doc """
+  When calling `defstruct/1`, don't explicitly specify `nil` for fields that default to `nil`.
+
+  ```elixir
+  # Bad
+  defstruct first_name: nil, last_name: nil, admin?: false
+
+  # Good
+  defstruct [:first_name, :last_name, admin?: false]
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    # code here ...
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_8_exceptions_1_exception_naming.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_8_exceptions_1_exception_naming.ex
@@ -16,14 +16,12 @@ defmodule Lexmag8Exceptions1ExceptionNaming do
   @doc """
   Make exception names end with a trailing `Error`.
 
-  ```elixir
-  # Bad
-  BadResponse
-  ResponseException
+      # Bad
+      BadResponse
+      ResponseException
 
-  # Good
-  ResponseError
-  ```
+      # Good
+      ResponseError
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_8_exceptions_1_exception_naming.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_8_exceptions_1_exception_naming.ex
@@ -1,0 +1,36 @@
+defmodule Lexmag8Exceptions1ExceptionNaming do
+  @moduledoc """
+  Source: [exception-naming](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#exception-naming)
+   from section: [Exceptions](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#exceptions)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  defmodule Custom do
+    defexception message: "default custom error message"
+  end
+
+  @doc """
+  Make exception names end with a trailing `Error`.
+
+  ```elixir
+  # Bad
+  BadResponse
+  ResponseException
+
+  # Good
+  ResponseError
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    try do
+      raise Custom
+    rescue
+      error in Custom -> error
+    end
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_8_exceptions_2_exception_message.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_8_exceptions_2_exception_message.ex
@@ -1,0 +1,41 @@
+defmodule Lexmag8Exceptions2ExceptionMessage do
+  @moduledoc """
+  Source: [exception-message](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#exception-message)
+   from section: [Exceptions](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#exceptions)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  Use non-capitalized error messages when raising exceptions, with no trailing punctuation.
+
+  ```elixir
+  # Bad
+  raise ArgumentError, "Malformed payload."
+
+  # Good
+  raise ArgumentError, "malformed payload"
+  ```
+
+  There is one exception to the rule - always capitalize Mix error messages.
+
+  ```elixir
+  Mix.raise "Could not find dependency"
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    try do
+      if Enum.random(0..9) < 5 do
+        raise RuntimeError, message: "An error occurred"
+      else
+        Mix.raise "an error occurred"
+      end
+    rescue
+      error -> error
+    end
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_8_exceptions_2_exception_message.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_8_exceptions_2_exception_message.ex
@@ -12,19 +12,15 @@ defmodule Lexmag8Exceptions2ExceptionMessage do
   @doc """
   Use non-capitalized error messages when raising exceptions, with no trailing punctuation.
 
-  ```elixir
-  # Bad
-  raise ArgumentError, "Malformed payload."
+      # Bad
+      raise ArgumentError, "Malformed payload."
 
-  # Good
-  raise ArgumentError, "malformed payload"
-  ```
+      # Good
+      raise ArgumentError, "malformed payload"
 
   There is one exception to the rule - always capitalize Mix error messages.
 
-  ```elixir
-  Mix.raise "Could not find dependency"
-  ```
+      Mix.raise "Could not find dependency"
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_9_exunit_1_exunit_assertion_side.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_9_exunit_1_exunit_assertion_side.ex
@@ -12,19 +12,15 @@ defmodule Lexmag9Exunit1ExunitAssertionSide do
   @doc """
   When asserting (or refuting) something with comparison operators (such as `==`, `<`, `>=`, and similar), put the expression being tested on the left-hand side of the operator and the value you're testing against on the right-hand side.
 
-  ```elixir
-  # Bad
-  assert "héllo" == Atom.to_string(:"héllo")
+      # Bad
+      assert "héllo" == Atom.to_string(:"héllo")
 
-  # Good
-  assert Atom.to_string(:"héllo") == "héllo"
-  ```
+      # Good
+      assert Atom.to_string(:"héllo") == "héllo"
 
   When using the match operator `=`, put the pattern on the left-hand side (as it won't work otherwise).
 
-  ```elixir
-  assert {:error, _reason} = File.stat("./non_existent_file")
-  ```
+      assert {:error, _reason} = File.stat("./non_existent_file")
   """
   @spec test() :: any
   def test() do

--- a/examples/nested-jsbeautifyrc/elixir/original/lexmag_9_exunit_1_exunit_assertion_side.ex
+++ b/examples/nested-jsbeautifyrc/elixir/original/lexmag_9_exunit_1_exunit_assertion_side.ex
@@ -1,0 +1,33 @@
+defmodule Lexmag9Exunit1ExunitAssertionSide do
+  @moduledoc """
+  Source: [exunit-assertion-side](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#exunit-assertion-side)
+   from section: [ExUnit](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#exunit)
+   in: [Elixir Style Guide](https://github.com/lexmag/elixir-style-guide)
+   owned by: [@lexmag](https://github.com/lexmag).
+  This work was created by Aleksei Magusev and is licensed under [the CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0).
+
+  ![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)
+  """
+
+  @doc """
+  When asserting (or refuting) something with comparison operators (such as `==`, `<`, `>=`, and similar), put the expression being tested on the left-hand side of the operator and the value you're testing against on the right-hand side.
+
+  ```elixir
+  # Bad
+  assert "héllo" == Atom.to_string(:"héllo")
+
+  # Good
+  assert Atom.to_string(:"héllo") == "héllo"
+  ```
+
+  When using the match operator `=`, put the pattern on the left-hand side (as it won't work otherwise).
+
+  ```elixir
+  assert {:error, _reason} = File.stat("./non_existent_file")
+  ```
+  """
+  @spec test() :: any
+  def test() do
+    # NOTE: we cannot validate this rule in some cases
+  end
+end

--- a/examples/nested-jsbeautifyrc/elixir/test_syntax_in_elixir_files.sh
+++ b/examples/nested-jsbeautifyrc/elixir/test_syntax_in_elixir_files.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+find . -type f \( -iname \*.ex -o -iname \*.exs \) -exec elixir {} \;


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Examples for [elixir](https://github.com/elixir-lang/elixir) (Elixir language).
Elixir Original <=> Expected examples based on @lexmag https://github.com/lexmag/elixir-style-guide
For more information see related issue: #545.

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
