### PR TITLE
Fix JS beautify on JSX and EJS

### DIFF
--- a/src/beautifiers/js-beautify.coffee
+++ b/src/beautifiers/js-beautify.coffee
@@ -33,7 +33,7 @@ module.exports = class JSBeautify extends Beautifier
     return new @Promise((resolve, reject) =>
       try
         switch language
-          when "JSON", "JavaScript"
+          when "JSON", "JavaScript", "JSX"
             beautifyJS = require("js-beautify")
             text = beautifyJS(text, options)
             resolve text
@@ -44,7 +44,7 @@ module.exports = class JSBeautify extends Beautifier
             beautifyHTML = require("js-beautify").html
             text = beautifyHTML(text, options)
             resolve text
-          when "HTML (Liquid)", "HTML", "XML", "Web Form/Control (C#)", "Web Handler (C#)"
+          when "EJS", "HTML (Liquid)", "HTML", "XML", "Web Form/Control (C#)", "Web Handler (C#)"
             beautifyHTML = require("js-beautify").html
             text = beautifyHTML(text, options)
             @debug("Beautified HTML: #{text}")


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

When i tried to beautify **EJS** or **JSX** with JS Beautify, it wont work, because i forgot to add **EJS** and **JSX** on the **Switch** when i added it to **JS Beautify** options. This will fix the issue.