### PR TITLE
Fix php cs fixer path option except windows

### DIFF
--- a/src/beautifiers/php-cs-fixer.coffee
+++ b/src/beautifiers/php-cs-fixer.coffee
@@ -19,21 +19,22 @@ module.exports = class PHPCSFixer extends Beautifier
 
     configFile = if context? and context.filePath? then @findFile(path.dirname(context.filePath), '.php_cs')
 
-    if @isWindows
-      # Find php-cs-fixer.phar script
-      @Promise.all([
-        @which(options.cs_fixer_path) if options.cs_fixer_path
-        @which('php-cs-fixer')
-      ]).then((paths) =>
-        @debug('php-cs-fixer paths', paths)
-        _ = require 'lodash'
-        # Get first valid, absolute path
-        phpCSFixerPath = _.find(paths, (p) -> p and path.isAbsolute(p) )
-        @verbose('phpCSFixerPath', phpCSFixerPath)
-        @debug('phpCSFixerPath', phpCSFixerPath, paths)
-        # Check if PHP-CS-Fixer path was found
-        if phpCSFixerPath?
-          # Found PHP-CS-Fixer path
+    # Find php-cs-fixer.phar script
+    @Promise.all([
+      @which(options.cs_fixer_path) if options.cs_fixer_path
+      @which('php-cs-fixer')
+    ]).then((paths) =>
+      @debug('php-cs-fixer paths', paths)
+      _ = require 'lodash'
+      # Get first valid, absolute path
+      phpCSFixerPath = _.find(paths, (p) -> p and path.isAbsolute(p) )
+      @verbose('phpCSFixerPath', phpCSFixerPath)
+      @debug('phpCSFixerPath', phpCSFixerPath, paths)
+
+      # Check if PHP-CS-Fixer path was found
+      if phpCSFixerPath?
+        # Found PHP-CS-Fixer path
+        if @isWindows
           @run("php", [
             phpCSFixerPath
             "fix"
@@ -51,30 +52,30 @@ module.exports = class PHPCSFixer extends Beautifier
               @readFile(tempFile)
             )
         else
-          @verbose('php-cs-fixer not found!')
-          # Could not find PHP-CS-Fixer path
-          @Promise.reject(@commandNotFoundError(
-            'php-cs-fixer'
-            {
-            link: "https://github.com/FriendsOfPHP/PHP-CS-Fixer"
-            program: "php-cs-fixer.phar"
-            pathOption: "PHP - CS Fixer Path"
+          @run(phpCSFixerPath, [
+            "fix"
+            "--level=#{options.level}" if options.level
+            "--fixers=#{options.fixers}" if options.fixers
+            "--config-file=#{configFile}" if configFile
+            tempFile = @tempFile("temp", text)
+            ], {
+              ignoreReturnCode: true
+              help: {
+                link: "https://github.com/FriendsOfPHP/PHP-CS-Fixer"
+              }
             })
-          )
-      )
-    else
-      @run("php-cs-fixer", [
-        "fix"
-        "--level=#{options.level}" if options.level
-        "--fixers=#{options.fixers}" if options.fixers
-        "--config-file=#{configFile}" if configFile
-        tempFile = @tempFile("temp", text)
-        ], {
-          ignoreReturnCode: true
-          help: {
-            link: "https://github.com/FriendsOfPHP/PHP-CS-Fixer"
-          }
-        })
-        .then(=>
-          @readFile(tempFile)
+            .then(=>
+              @readFile(tempFile)
+            )
+      else
+        @verbose('php-cs-fixer not found!')
+        # Could not find PHP-CS-Fixer path
+        @Promise.reject(@commandNotFoundError(
+          'php-cs-fixer'
+          {
+          link: "https://github.com/FriendsOfPHP/PHP-CS-Fixer"
+          program: "php-cs-fixer.phar"
+          pathOption: "PHP - CS Fixer Path"
+          })
         )
+    )

--- a/src/beautifiers/php-cs-fixer.coffee
+++ b/src/beautifiers/php-cs-fixer.coffee
@@ -18,6 +18,12 @@ module.exports = class PHPCSFixer extends Beautifier
     @debug('php-cs-fixer', options)
 
     configFile = if context? and context.filePath? then @findFile(path.dirname(context.filePath), '.php_cs')
+    runOptions = {
+      ignoreReturnCode: true
+      help: {
+        link: "https://github.com/FriendsOfPHP/PHP-CS-Fixer"
+      }
+    }
 
     # Find php-cs-fixer.phar script
     @Promise.all([
@@ -42,12 +48,7 @@ module.exports = class PHPCSFixer extends Beautifier
             "--fixers=#{options.fixers}" if options.fixers
             "--config-file=#{configFile}" if configFile
             tempFile = @tempFile("temp", text)
-            ], {
-              ignoreReturnCode: true
-              help: {
-                link: "https://github.com/FriendsOfPHP/PHP-CS-Fixer"
-              }
-            })
+            ], runOptions)
             .then(=>
               @readFile(tempFile)
             )
@@ -58,12 +59,7 @@ module.exports = class PHPCSFixer extends Beautifier
             "--fixers=#{options.fixers}" if options.fixers
             "--config-file=#{configFile}" if configFile
             tempFile = @tempFile("temp", text)
-            ], {
-              ignoreReturnCode: true
-              help: {
-                link: "https://github.com/FriendsOfPHP/PHP-CS-Fixer"
-              }
-            })
+            ], runOptions)
             .then(=>
               @readFile(tempFile)
             )

--- a/src/beautifiers/php-cs-fixer.coffee
+++ b/src/beautifiers/php-cs-fixer.coffee
@@ -18,6 +18,12 @@ module.exports = class PHPCSFixer extends Beautifier
     @debug('php-cs-fixer', options)
 
     configFile = if context? and context.filePath? then @findFile(path.dirname(context.filePath), '.php_cs')
+    phpCsFixerOptions = [
+      "fix"
+      "--level=#{options.level}" if options.level
+      "--fixers=#{options.fixers}" if options.fixers
+      "--config-file=#{configFile}" if configFile
+    ]
     runOptions = {
       ignoreReturnCode: true
       help: {
@@ -40,26 +46,15 @@ module.exports = class PHPCSFixer extends Beautifier
       # Check if PHP-CS-Fixer path was found
       if phpCSFixerPath?
         # Found PHP-CS-Fixer path
+        tempFile = @tempFile("temp", text)
+
         if @isWindows
-          @run("php", [
-            phpCSFixerPath
-            "fix"
-            "--level=#{options.level}" if options.level
-            "--fixers=#{options.fixers}" if options.fixers
-            "--config-file=#{configFile}" if configFile
-            tempFile = @tempFile("temp", text)
-            ], runOptions)
+          @run("php", [phpCSFixerPath, phpCsFixerOptions, tempFile], runOptions)
             .then(=>
               @readFile(tempFile)
             )
         else
-          @run(phpCSFixerPath, [
-            "fix"
-            "--level=#{options.level}" if options.level
-            "--fixers=#{options.fixers}" if options.fixers
-            "--config-file=#{configFile}" if configFile
-            tempFile = @tempFile("temp", text)
-            ], runOptions)
+          @run(phpCSFixerPath, [phpCsFixerOptions, tempFile], runOptions)
             .then(=>
               @readFile(tempFile)
             )

--- a/src/beautifiers/php-cs-fixer.coffee
+++ b/src/beautifiers/php-cs-fixer.coffee
@@ -64,9 +64,9 @@ module.exports = class PHPCSFixer extends Beautifier
         @Promise.reject(@commandNotFoundError(
           'php-cs-fixer'
           {
-          link: "https://github.com/FriendsOfPHP/PHP-CS-Fixer"
-          program: "php-cs-fixer.phar"
-          pathOption: "PHP - CS Fixer Path"
+            link: "https://github.com/FriendsOfPHP/PHP-CS-Fixer"
+            program: "php-cs-fixer.phar"
+            pathOption: "PHP - CS Fixer Path"
           })
         )
     )


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

`PHP-CS-Fixer Path` option is not enable except Windows. So fixed.

### Does this close any currently open issues?

No, it doesn't.

### Any other comments?

And few refactored.

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
