### PR TITLE
Fixed issue [#1448] support globally installed cljfmt 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Fix phpcbf hanging issue by closing stdin. See [#893](https://github.com/Glavin001/atom-beautify/issues/893)
 - Add warning notification when parsing `.jsbeautifyrc` as JSON or YAML fails. See [#1106](https://github.com/Glavin001/atom-beautify/issues/1106)
 - Add support for PrettyDiff's *bracepadding* option in JavaScript. See [#1157](https://github.com/Glavin001/atom-beautify/issues/1157)
-- Fixed issue [#1448] supports cljfmt installed globally via npm
+- Fixed issue [#1448] supports cljfmt installed globally via npm (https://github.com/Glavin001/atom-beautify/issues/1448)
 
 # v0.29.0
 - Closes [#447](https://github.com/Glavin001/atom-beautify/issues/447). Improved Handlebars language support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix phpcbf hanging issue by closing stdin. See [#893](https://github.com/Glavin001/atom-beautify/issues/893)
 - Add warning notification when parsing `.jsbeautifyrc` as JSON or YAML fails. See [#1106](https://github.com/Glavin001/atom-beautify/issues/1106)
 - Add support for PrettyDiff's *bracepadding* option in JavaScript. See [#1157](https://github.com/Glavin001/atom-beautify/issues/1157)
+- Fixed issue [#1448] supports cljfmt installed globally via npm
 
 # v0.29.0
 - Closes [#447](https://github.com/Glavin001/atom-beautify/issues/447). Improved Handlebars language support

--- a/package.json
+++ b/package.json
@@ -114,6 +114,10 @@
     {
       "name": "Victor Uriarte",
       "url": "https://github.com/vmuriart"
+    },
+    {
+      "name": "Andy Rusu",
+      "url": "https://github.com/andyrusu"
     }
   ],
   "engines": {

--- a/src/beautifiers/cljfmt/index.coffee
+++ b/src/beautifiers/cljfmt/index.coffee
@@ -13,9 +13,8 @@ module.exports = class Cljfmt extends Beautifier
 
   beautify: (text, language, options) ->
     formatPath = path.resolve(__dirname, "fmt.edn")
-    cljfmt = path.resolve(__dirname, "..", "..", "..", "node_modules/.bin/cljfmt")
     @tempFile("input", text).then((filePath) =>
-      @run(cljfmt, [
+      @run("cljfmt", [
         filePath,
         "--edn=" + formatPath
       ]).then(=>


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Fixed the issue with cljfmt not running.
...

### Does this close any currently open issues?
It closes issue #1448.
...

### Checklist

Check all those that are applicable and complete.

- [ x] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
