### PR TITLE
Fix #1423 - extname is deprecated

### DIFF
--- a/src/beautifiers/index.coffee
+++ b/src/beautifiers/index.coffee
@@ -140,19 +140,31 @@ module.exports = class Beautifiers extends EventEmitter
     ) or beautifiers[0]
     return beautifier
 
-  getLanguage : (grammar, filePath) ->
+  getExtension : (filePath) ->
+    if filePath
+      return path.extname(filePath).substr(1)
+
+  getLanguages : (grammar, filePath) ->
     # Get language
-    fileExtension = path.extname(filePath)
-    # Remove prefix "." (period) in fileExtension
-    fileExtension = fileExtension.substr(1)
-    languages = @languages.getLanguages({grammar, extension: fileExtension})
-    logger.verbose(languages, grammar, fileExtension)
-    # Check if unsupported language
-    if languages.length < 1
-      return null
+    fileExtension = @getExtension(filePath) 
+
+    if fileExtension
+      languages = @languages.getLanguages({grammar, extension: fileExtension})
     else
-      # TODO: select appropriate language
+      languages = @languages.getLanguages({grammar})
+
+    logger.verbose(languages, grammar, fileExtension)
+
+    return languages
+
+  getLanguage : (grammar, filePath) ->
+    languages = @getLanguages(grammar, filePath)
+
+    # Check if unsupported language
+    if languages.length > 0
       language = languages[0]
+
+    return language
 
   getOptionsForLanguage : (allOptions, language) ->
     # Options for Language
@@ -241,15 +253,10 @@ module.exports = class Beautifiers extends EventEmitter
         logger.info('beautify', text, allOptions, grammar, filePath, onSave)
         logger.verbose(allOptions)
 
-        # Get language
-        fileExtension = path.extname(filePath)
-        # Remove prefix "." (period) in fileExtension
-        fileExtension = fileExtension.substr(1)
-        languages = @languages.getLanguages({grammar, extension: fileExtension})
-        logger.verbose(languages, grammar, fileExtension)
+        language = @getLanguage(grammar, filePath)
 
         # Check if unsupported language
-        if languages.length < 1
+        if !language 
           unsupportedGrammar = true
 
           logger.verbose('Unsupported language')
@@ -260,18 +267,13 @@ module.exports = class Beautifiers extends EventEmitter
             # not intended to be beautified
             return resolve( null )
         else
-          # TODO: select appropriate language
-          language = languages[0]
-
           logger.verbose("Language #{language.name} supported")
 
           # Get language config
           langDisabled = atom.config.get("atom-beautify.#{language.namespace}.disabled")
 
-
           # Beautify!
           unsupportedGrammar = false
-
 
           # Check if Language is disabled
           if langDisabled
@@ -370,6 +372,7 @@ module.exports = class Beautifiers extends EventEmitter
           if atom.config.get("atom-beautify.general.muteUnsupportedLanguageErrors")
             return resolve( null )
           else
+            fileExtension = @getExtension(filePath)
             repoBugsUrl = pkg.bugs.url
             title = "Atom Beautify could not find a supported beautifier for this file"
             detail = """


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This fixes the "extname is deprecated" issue.  It happens when you try to beautify a file that is not saved, so when trying to fetch the extension, the code passes a null filename to get the extension, and causes this error.

### Does this close any currently open issues?

This closes #1423

### Any other comments?

No other comments

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
