### PR TITLE
vue section mark right

### DIFF
--- a/src/beautifiers/vue-beautifier.coffee
+++ b/src/beautifiers/vue-beautifier.coffee
@@ -11,7 +11,7 @@ module.exports = class VueBeautifier extends Beautifier
 
   beautify: (text, language, options) ->
     return new @Promise((resolve, reject) ->
-      regexp = /(<(template|script|style)[^>]*>)((\s|\S)*?)<\/\2>/gi
+      regexp = /(^<(template|script|style)[^>]*>)((\s|\S)*?)^<\/\2>/gim
 
       resolve(text.replace(regexp, (match, begin, type, text) ->
         lang = /lang\s*=\s*['"](\w+)["']/.exec(begin)?[1]


### PR DESCRIPTION
objective
-------------
only `<template><script><style>` at beginning of line will mark sections of vue file

before
-------------

with src/beautifiers/vue-beautifier.coffee as now

```coffee
beautify: (text, language, options) ->
  return new @Promise((resolve, reject) ->
    regexp = /(<(template|script|style)[^>]*>)((\s|\S)*?)<\/\2>/gi
```

will format vue code as bad

```vue
<template>
<div>
  <template>
</template>
  </div>
</template>

<script>
var str = '<script>
</script>'
</script>
```

after
--------

with src/beautifiers/vue-beautifier.coffee as now

```coffee
beautify: (text, language, options) ->
  return new @Promise((resolve, reject) ->
    regexp = /(^<(template|script|style)[^>]*>)((\s|\S)*?)^<\/\2>/gim
```

will format vue code as right

```javascript
<template>
<div>
  <template> </template>
</div>
</template>

<script>
var str = '<script></script>'
</script>
```
