### PR TITLE
Allow typescript formatter to inherit options from config files

### DIFF
--- a/src/beautifiers/typescript-formatter.coffee
+++ b/src/beautifiers/typescript-formatter.coffee
@@ -8,7 +8,7 @@ module.exports = class TypeScriptFormatter extends Beautifier
     TypeScript: true
   }
 
-  beautify: (text, language, options) ->
+  beautify: (text, language, options, {filePath}) ->
     return new @Promise((resolve, reject) =>
 
       try

--- a/src/beautifiers/typescript-formatter.coffee
+++ b/src/beautifiers/typescript-formatter.coffee
@@ -26,16 +26,15 @@ module.exports = class TypeScriptFormatter extends Beautifier
 
       options.eol = @getDefaultLineEnding('\r\n', '\n', options.end_of_line)
 
-      processData(optionModifiers, formatSettings, (process, settings) => process(filePath, options, settings))
+      processData(optionModifiers, formatSettings, (process, settings) -> process(filePath, options, settings))
         .then((formatSettings) =>
           @verbose('typescript', text, formatSettings)
           result = format('', text, formatSettings)
           @verbose(result)
           return result
         )
-        .then((formatted) =>
-          return processData(postProcessors, formatted, (process, code) => process(filePath, code, options, formatSettings))
-        )
+        .then((formatted) -> processData postProcessors, formatted, (process, code) ->
+          process(filePath, code, options, formatSettings))
     catch e
       return Promise.reject(e)
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Currently the typescript formatter is using `CRLF` line endings on OS X. There appears to be no way to change this configuration (tried `.editorconfig`, `tsconfig.json`, `tslint.json`, `tsfmt.json` and setting the default in Atom, all to no avail)

### Does this close any currently open issues?

Wasn't able to find a matching issue, but with the neutering of the latest `atom-typescript` plugin, better support for typescript here is sorely needed. This should allow `tslint.json`, `tsconfig.json` and `.editorconfig` files to provide formatting options.

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [x] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
