### PR TITLE
use tidy-markdown 2.0.3 explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "space-pen": "^5.1.1",
     "strip-json-comments": "^2.0.1",
     "temp": "^0.8.3",
-    "tidy-markdown": "^2.0.3",
+    "tidy-markdown": "2.0.3",
     "typescript": "^1.8.10",
     "typescript-formatter": "^2.3.0",
     "underscore-plus": "^1.6.6",


### PR DESCRIPTION
Because 2.0.5 is broken

Related to #1549 