### PR TITLE
php-cs-fixer allow risky option

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -9654,7 +9654,7 @@ Automatically beautify PHP files on save
 
 **Description**:
 
-allow risky rules to be applied! (Supported by PHP-CS-Fixer)
+allow risky rules to be applied (PHP-CS-Fixer 2 only) (Supported by PHP-CS-Fixer)
 
 **Example `.jsbeautifyrc` Configuration**
 
@@ -17466,7 +17466,7 @@ Add rule(s). i.e. line_ending,-full_opening_tag,@PSR2 (PHP-CS-Fixer 2 only) (Sup
 
 **Description**:
 
-allow risky rules to be applied! (Supported by PHP-CS-Fixer)
+allow risky rules to be applied (PHP-CS-Fixer 2 only) (Supported by PHP-CS-Fixer)
 
 **Example `.jsbeautifyrc` Configuration**
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -9570,6 +9570,7 @@ Specify a configuration file which will override the default name of .perltidyrc
 | `disabled` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `default_beautifier` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `beautify_on_save` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `allow_risky` | :white_check_mark: | :x: | :x: |
 | `cs_fixer_path` | :white_check_mark: | :x: | :x: |
 | `cs_fixer_version` | :white_check_mark: | :x: | :x: |
 | `fixers` | :white_check_mark: | :x: | :x: |
@@ -9636,6 +9637,34 @@ Automatically beautify PHP files on save
 *Edit > Preferences (Linux)*, *Atom > Preferences (OS X)*, or *File > Preferences (Windows)*.
 2. Go into *Packages* and search for "*Atom Beautify*" package.
 3. Find the option "*Beautify On Save*" and change it to your desired configuration.
+
+#####  [Allow risky rules](#allow-risky-rules) 
+
+**Namespace**: `php`
+
+**Key**: `allow_risky`
+
+**Default**: `no`
+
+**Type**: `string`
+
+**Enum**:  `no`  `yes` 
+
+**Supported Beautifiers**:  [`PHP-CS-Fixer`](#php-cs-fixer) 
+
+**Description**:
+
+allow risky rules to be applied! (Supported by PHP-CS-Fixer)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "php": {
+        "allow_risky": "no"
+    }
+}
+```
 
 #####  [PHP-CS-Fixer Path](#php-cs-fixer-path) 
 
@@ -17417,6 +17446,34 @@ Add rule(s). i.e. line_ending,-full_opening_tag,@PSR2 (PHP-CS-Fixer 2 only) (Sup
 {
     "php": {
         "rules": ""
+    }
+}
+```
+
+#####  [Allow risky rules](#allow-risky-rules) 
+
+**Namespace**: `php`
+
+**Key**: `allow_risky`
+
+**Default**: `no`
+
+**Type**: `string`
+
+**Enum**:  `no`  `yes` 
+
+**Supported Beautifiers**:  [`PHP-CS-Fixer`](#php-cs-fixer) 
+
+**Description**:
+
+allow risky rules to be applied! (Supported by PHP-CS-Fixer)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "php": {
+        "allow_risky": "no"
     }
 }
 ```

--- a/src/beautifiers/php-cs-fixer.coffee
+++ b/src/beautifiers/php-cs-fixer.coffee
@@ -24,6 +24,7 @@ module.exports = class PHPCSFixer extends Beautifier
       "fix"
       "--rules=#{options.rules}" if options.rules
       "--config=#{configFile}" if configFile
+      "--allow-risky=#{options.allowRisky}" if options.allowRisky
       "--using-cache=no"
     ]
     if version is 1

--- a/src/beautifiers/php-cs-fixer.coffee
+++ b/src/beautifiers/php-cs-fixer.coffee
@@ -24,7 +24,7 @@ module.exports = class PHPCSFixer extends Beautifier
       "fix"
       "--rules=#{options.rules}" if options.rules
       "--config=#{configFile}" if configFile
-      "--allow-risky=#{options.allowRisky}" if options.allowRisky
+      "--allow-risky=#{options.allow_risky}" if options.allow_risky
       "--using-cache=no"
     ]
     if version is 1

--- a/src/languages/php.coffee
+++ b/src/languages/php.coffee
@@ -49,7 +49,7 @@ module.exports = {
       type: 'string'
       default: "no"
       enum: ["no", "yes"]
-      description: "allow risky rules to be applied!"
+      description: "allow risky rules to be applied (PHP-CS-Fixer 2 only)"
     phpcbf_path:
       title: "PHPCBF Path"
       type: 'string'

--- a/src/languages/php.coffee
+++ b/src/languages/php.coffee
@@ -44,6 +44,12 @@ module.exports = {
       type: 'string'
       default: ""
       description: "Add rule(s). i.e. line_ending,-full_opening_tag,@PSR2 (PHP-CS-Fixer 2 only)"
+    allow_risky:
+      title: "Allow risky rules"
+      type: 'string'
+      default: "no"
+      enum: ["no", "yes"]
+      description: "allow risky rules to be applied!"
     phpcbf_path:
       title: "PHPCBF Path"
       type: 'string'

--- a/src/options.json
+++ b/src/options.json
@@ -5860,7 +5860,7 @@
           "no",
           "yes"
         ],
-        "description": "allow risky rules to be applied! (Supported by PHP-CS-Fixer)",
+        "description": "allow risky rules to be applied (PHP-CS-Fixer 2 only) (Supported by PHP-CS-Fixer)",
         "beautifiers": [
           "PHP-CS-Fixer"
         ],

--- a/src/options.json
+++ b/src/options.json
@@ -5852,6 +5852,24 @@
           "namespace": "php"
         }
       },
+      "allow_risky": {
+        "title": "Allow risky rules",
+        "type": "string",
+        "default": "no",
+        "enum": [
+          "no",
+          "yes"
+        ],
+        "beautifiers": [
+          "PHP-CS-Fixer"
+        ],
+        "key": "allow_risky",
+        "language": {
+          "name": "PHP",
+          "namespace": "php"
+        },
+        "description": "allow risky rules to be applied!"
+      },
       "phpcbf_path": {
         "title": "PHPCBF Path",
         "type": "string",

--- a/src/options.json
+++ b/src/options.json
@@ -5860,6 +5860,7 @@
           "no",
           "yes"
         ],
+        "description": "allow risky rules to be applied! (Supported by PHP-CS-Fixer)",
         "beautifiers": [
           "PHP-CS-Fixer"
         ],
@@ -5867,8 +5868,7 @@
         "language": {
           "name": "PHP",
           "namespace": "php"
-        },
-        "description": "allow risky rules to be applied!"
+        }
       },
       "phpcbf_path": {
         "title": "PHPCBF Path",


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Adds an option for allow-risky in php-cs-fixer so you can apply risky rules if you want to.

### Does this close any currently open issues?

I am not sure.

### Any other comments?

none.

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [ ] Added examples for testing to [examples/ directory](examples/)
- [x] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
