### PR TITLE
Add more LaTeX extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.29.23 (2016-04-20)
 - See #1607. Add support for PHP-CS-Fixer 1, along with version 2.
 - Closes #1179. Replace atom-beautify.general.analytics option with configuration option
+- Add more LaTeX extensions
 
 # v0.29.3 to v0.29.22 (2016-04-16 to 2017-04-15)
 - Add support for additional wrap attribute options of js-beautify (html): force-aligned and force-expand-multiline.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ See [all supported options in the documentation at  `docs/options.md`](docs/opti
 | JavaScript | `JavaScript` |`.js` | [`ESLint Fixer`](https://github.com/eslint/eslint), [`JS Beautify`](https://github.com/beautify-web/js-beautify) (Default), [`JSCS Fixer`](https://github.com/jscs-dev/node-jscs/), [`Pretty Diff`](https://github.com/prettydiff/prettydiff) |
 | JSON | `JSON` |`.json` | [`JS Beautify`](https://github.com/beautify-web/js-beautify) (Default), [`Pretty Diff`](https://github.com/prettydiff/prettydiff) |
 | JSX | `JSX`, `JavaScript (JSX)`, `Babel ES6 JavaScript`, `JavaScript with JSX` |`.jsx`, `.js` | [`JS Beautify`](https://github.com/beautify-web/js-beautify), [`Pretty Diff`](https://github.com/prettydiff/prettydiff) (Default) |
-| LaTeX | `LaTeX` |`.tex` | [`Latex Beautify`](https://github.com/cmhughes/latexindent.pl) (Default) |
+| LaTeX | `BibTeX`, `LaTeX`, `TeX` |`.bib`, `.tex`, `.sty`, `.cls`, `.dtx`, `.ins`, `.bbx`, `.cbx` | [`Latex Beautify`](https://github.com/cmhughes/latexindent.pl) (Default) |
 | LESS | `LESS` |`.less` | [`CSScomb`](https://github.com/csscomb/csscomb.js), [`Pretty Diff`](https://github.com/prettydiff/prettydiff) (Default) |
 | Lua | `Lua` |`.lua` | [`Lua beautifier`](https://www.perl.org/) (Default) |
 | Markdown | `GitHub Markdown` |`.markdown`, `.md` | [`Remark`](https://github.com/wooorm/remark), [`Tidy Markdown`](https://github.com/slang800/tidy-markdown) (Default) |

--- a/src/languages/latex.coffee
+++ b/src/languages/latex.coffee
@@ -8,14 +8,23 @@ module.exports = {
   Supported Grammars
   ###
   grammars: [
+    "BibTeX"
     "LaTeX"
+    "TeX"
   ]
 
   ###
   Supported extensions
   ###
   extensions: [
+    "bib"
     "tex"
+    "sty"
+    "cls"
+    "dtx"
+    "ins"
+    "bbx"
+    "cbx"
   ]
 
   defaultBeautifier: "Latex Beautify"

--- a/src/options.json
+++ b/src/options.json
@@ -4193,10 +4193,19 @@
       "Latex Beautify"
     ],
     "grammars": [
-      "LaTeX"
+      "BibTeX",
+      "LaTeX",
+      "TeX"
     ],
     "extensions": [
-      "tex"
+      "bib",
+      "tex",
+      "sty",
+      "cls",
+      "dtx",
+      "ins",
+      "bbx",
+      "cbx"
     ],
     "properties": {
       "indent_char": {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Adds LaTeX extensions `.bib`, `.sty`, `.cls`, `.dtx`, `.ins`, `.bbx` and `.cbx`.

### Does this close any currently open issues?

No.

### Any other comments?

No.

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [x] Update `CHANGELOG.md`
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
