### PR TITLE
Allow specifying a config path for latexindent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.29.23 (2016-04-20)
 - See #1607. Add support for PHP-CS-Fixer 1, along with version 2.
 - Closes #1179. Replace atom-beautify.general.analytics option with configuration option
+- Allow specifying a config path for latexindent
 
 # v0.29.3 to v0.29.22 (2016-04-16 to 2017-04-15)
 - Add support for additional wrap attribute options of js-beautify (html): force-aligned and force-expand-multiline.

--- a/docs/options.md
+++ b/docs/options.md
@@ -6993,13 +6993,7 @@ Wrap lines at next opportunity after N characters (Supported by JS Beautify, Pre
 | `disabled` | :white_check_mark: |
 | `default_beautifier` | :white_check_mark: |
 | `beautify_on_save` | :white_check_mark: |
-| `align_columns_in_environments` | :white_check_mark: |
-| `always_look_for_split_braces` | :white_check_mark: |
-| `always_look_for_split_brackets` | :white_check_mark: |
-| `indent_char` | :white_check_mark: |
-| `indent_preamble` | :white_check_mark: |
-| `indent_with_tabs` | :white_check_mark: |
-| `remove_trailing_whitespace` | :white_check_mark: |
+| `configPath` | :white_check_mark: |
 
 **Description**:
 
@@ -7060,94 +7054,11 @@ Automatically beautify LaTeX files on save
 2. Go into *Packages* and search for "*Atom Beautify*" package.
 3. Find the option "*Beautify On Save*" and change it to your desired configuration.
 
-#####  [Align columns in environments](#align-columns-in-environments) 
+#####  [Config Path](#config-path) 
 
 **Namespace**: `latex`
 
-**Key**: `align_columns_in_environments`
-
-**Default**: `tabular,matrix,bmatrix,pmatrix`
-
-**Type**: `array`
-
-**Supported Beautifiers**:  [`Latex Beautify`](#latex-beautify) 
-
-**Description**:
-
-undefined (Supported by Latex Beautify)
-
-**Example `.jsbeautifyrc` Configuration**
-
-```json
-{
-    "latex": {
-        "align_columns_in_environments": [
-            "tabular",
-            "matrix",
-            "bmatrix",
-            "pmatrix"
-        ]
-    }
-}
-```
-
-#####  [Always look for split braces](#always-look-for-split-braces) 
-
-**Namespace**: `latex`
-
-**Key**: `always_look_for_split_braces`
-
-**Default**: `true`
-
-**Type**: `boolean`
-
-**Supported Beautifiers**:  [`Latex Beautify`](#latex-beautify) 
-
-**Description**:
-
-If `latexindent` should look for commands that split braces across lines (Supported by Latex Beautify)
-
-**Example `.jsbeautifyrc` Configuration**
-
-```json
-{
-    "latex": {
-        "always_look_for_split_braces": true
-    }
-}
-```
-
-#####  [Always look for split brackets](#always-look-for-split-brackets) 
-
-**Namespace**: `latex`
-
-**Key**: `always_look_for_split_brackets`
-
-**Type**: `boolean`
-
-**Supported Beautifiers**:  [`Latex Beautify`](#latex-beautify) 
-
-**Description**:
-
-If `latexindent` should look for commands that split brackets across lines (Supported by Latex Beautify)
-
-**Example `.jsbeautifyrc` Configuration**
-
-```json
-{
-    "latex": {
-        "always_look_for_split_brackets": false
-    }
-}
-```
-
-#####  [Indent char](#indent-char) 
-
-**Namespace**: `latex`
-
-**Key**: `indent_char`
-
-**Default**: ` `
+**Key**: `configPath`
 
 **Type**: `string`
 
@@ -7155,86 +7066,14 @@ If `latexindent` should look for commands that split brackets across lines (Supp
 
 **Description**:
 
-Indentation character (Supported by Latex Beautify)
+Path to latexindent config file. i.e. localSettings.yaml (Supported by Latex Beautify)
 
 **Example `.jsbeautifyrc` Configuration**
 
 ```json
 {
     "latex": {
-        "indent_char": " "
-    }
-}
-```
-
-#####  [Indent preamble](#indent-preamble) 
-
-**Namespace**: `latex`
-
-**Key**: `indent_preamble`
-
-**Type**: `boolean`
-
-**Supported Beautifiers**:  [`Latex Beautify`](#latex-beautify) 
-
-**Description**:
-
-Indent the preable (Supported by Latex Beautify)
-
-**Example `.jsbeautifyrc` Configuration**
-
-```json
-{
-    "latex": {
-        "indent_preamble": false
-    }
-}
-```
-
-#####  [Indent with tabs](#indent-with-tabs) 
-
-**Namespace**: `latex`
-
-**Key**: `indent_with_tabs`
-
-**Type**: `boolean`
-
-**Supported Beautifiers**:  [`Latex Beautify`](#latex-beautify) 
-
-**Description**:
-
-Indentation uses tabs, overrides `Indent Size` and `Indent Char` (Supported by Latex Beautify)
-
-**Example `.jsbeautifyrc` Configuration**
-
-```json
-{
-    "latex": {
-        "indent_with_tabs": false
-    }
-}
-```
-
-#####  [Remove trailing whitespace](#remove-trailing-whitespace) 
-
-**Namespace**: `latex`
-
-**Key**: `remove_trailing_whitespace`
-
-**Type**: `boolean`
-
-**Supported Beautifiers**:  [`Latex Beautify`](#latex-beautify) 
-
-**Description**:
-
-Remove trailing whitespace (Supported by Latex Beautify)
-
-**Example `.jsbeautifyrc` Configuration**
-
-```json
-{
-    "latex": {
-        "remove_trailing_whitespace": false
+        "configPath": ""
     }
 }
 ```
@@ -16595,13 +16434,11 @@ Support e4x/jsx syntax (Supported by JS Beautify)
 
 ### Latex Beautify
 
-#####  [Indent char](#indent-char) 
+#####  [Config Path](#config-path) 
 
 **Namespace**: `latex`
 
-**Key**: `indent_char`
-
-**Default**: ` `
+**Key**: `configPath`
 
 **Type**: `string`
 
@@ -16609,167 +16446,14 @@ Support e4x/jsx syntax (Supported by JS Beautify)
 
 **Description**:
 
-Indentation character (Supported by Latex Beautify)
+Path to latexindent config file. i.e. localSettings.yaml (Supported by Latex Beautify)
 
 **Example `.jsbeautifyrc` Configuration**
 
 ```json
 {
     "latex": {
-        "indent_char": " "
-    }
-}
-```
-
-#####  [Indent with tabs](#indent-with-tabs) 
-
-**Namespace**: `latex`
-
-**Key**: `indent_with_tabs`
-
-**Type**: `boolean`
-
-**Supported Beautifiers**:  [`Latex Beautify`](#latex-beautify) 
-
-**Description**:
-
-Indentation uses tabs, overrides `Indent Size` and `Indent Char` (Supported by Latex Beautify)
-
-**Example `.jsbeautifyrc` Configuration**
-
-```json
-{
-    "latex": {
-        "indent_with_tabs": false
-    }
-}
-```
-
-#####  [Indent preamble](#indent-preamble) 
-
-**Namespace**: `latex`
-
-**Key**: `indent_preamble`
-
-**Type**: `boolean`
-
-**Supported Beautifiers**:  [`Latex Beautify`](#latex-beautify) 
-
-**Description**:
-
-Indent the preable (Supported by Latex Beautify)
-
-**Example `.jsbeautifyrc` Configuration**
-
-```json
-{
-    "latex": {
-        "indent_preamble": false
-    }
-}
-```
-
-#####  [Always look for split braces](#always-look-for-split-braces) 
-
-**Namespace**: `latex`
-
-**Key**: `always_look_for_split_braces`
-
-**Default**: `true`
-
-**Type**: `boolean`
-
-**Supported Beautifiers**:  [`Latex Beautify`](#latex-beautify) 
-
-**Description**:
-
-If `latexindent` should look for commands that split braces across lines (Supported by Latex Beautify)
-
-**Example `.jsbeautifyrc` Configuration**
-
-```json
-{
-    "latex": {
-        "always_look_for_split_braces": true
-    }
-}
-```
-
-#####  [Always look for split brackets](#always-look-for-split-brackets) 
-
-**Namespace**: `latex`
-
-**Key**: `always_look_for_split_brackets`
-
-**Type**: `boolean`
-
-**Supported Beautifiers**:  [`Latex Beautify`](#latex-beautify) 
-
-**Description**:
-
-If `latexindent` should look for commands that split brackets across lines (Supported by Latex Beautify)
-
-**Example `.jsbeautifyrc` Configuration**
-
-```json
-{
-    "latex": {
-        "always_look_for_split_brackets": false
-    }
-}
-```
-
-#####  [Remove trailing whitespace](#remove-trailing-whitespace) 
-
-**Namespace**: `latex`
-
-**Key**: `remove_trailing_whitespace`
-
-**Type**: `boolean`
-
-**Supported Beautifiers**:  [`Latex Beautify`](#latex-beautify) 
-
-**Description**:
-
-Remove trailing whitespace (Supported by Latex Beautify)
-
-**Example `.jsbeautifyrc` Configuration**
-
-```json
-{
-    "latex": {
-        "remove_trailing_whitespace": false
-    }
-}
-```
-
-#####  [Align columns in environments](#align-columns-in-environments) 
-
-**Namespace**: `latex`
-
-**Key**: `align_columns_in_environments`
-
-**Default**: `tabular,matrix,bmatrix,pmatrix`
-
-**Type**: `array`
-
-**Supported Beautifiers**:  [`Latex Beautify`](#latex-beautify) 
-
-**Description**:
-
-undefined (Supported by Latex Beautify)
-
-**Example `.jsbeautifyrc` Configuration**
-
-```json
-{
-    "latex": {
-        "align_columns_in_environments": [
-            "tabular",
-            "matrix",
-            "bmatrix",
-            "pmatrix"
-        ]
+        "configPath": ""
     }
 }
 ```

--- a/src/languages/latex.coffee
+++ b/src/languages/latex.coffee
@@ -24,32 +24,8 @@ module.exports = {
 
   ###
   options:
-    indent_char:
+    configPath:
       type: 'string'
-      default: null
-      description: "Indentation character"
-    indent_with_tabs:
-      type: 'boolean'
-      default: null
-      description: "Indentation uses tabs, overrides `Indent Size` and `Indent Char`"
-    indent_preamble:
-      type: 'boolean'
-      default: false
-      description: "Indent the preable"
-    always_look_for_split_braces:
-      type: 'boolean'
-      default: true
-      description: "If `latexindent` should look for commands that split braces across lines"
-    always_look_for_split_brackets:
-      type: 'boolean'
-      default: false
-      description: "If `latexindent` should look for commands that split brackets across lines"
-    remove_trailing_whitespace:
-      type: 'boolean'
-      default: false
-      description: "Remove trailing whitespace"
-    align_columns_in_environments:
-      type: 'array'
-      default:["tabular", "matrix", "bmatrix", "pmatrix"]
-      decription: "Aligns columns by the alignment tabs for environments specified"
+      default: ""
+      description: "Path to latexindent config file. i.e. localSettings.yaml"
 }

--- a/src/options.json
+++ b/src/options.json
@@ -4199,109 +4199,19 @@
       "tex"
     ],
     "properties": {
-      "indent_char": {
+      "configPath": {
         "type": "string",
-        "default": null,
-        "description": "Indentation character (Supported by Latex Beautify)",
-        "title": "Indent char",
+        "default": "",
+        "description": "Path to latexindent config file. i.e. localSettings.yaml (Supported by Latex Beautify)",
+        "title": "Config Path",
         "beautifiers": [
           "Latex Beautify"
         ],
-        "key": "indent_char",
+        "key": "configPath",
         "language": {
           "name": "LaTeX",
           "namespace": "latex"
         }
-      },
-      "indent_with_tabs": {
-        "type": "boolean",
-        "default": null,
-        "description": "Indentation uses tabs, overrides `Indent Size` and `Indent Char` (Supported by Latex Beautify)",
-        "title": "Indent with tabs",
-        "beautifiers": [
-          "Latex Beautify"
-        ],
-        "key": "indent_with_tabs",
-        "language": {
-          "name": "LaTeX",
-          "namespace": "latex"
-        }
-      },
-      "indent_preamble": {
-        "type": "boolean",
-        "default": false,
-        "description": "Indent the preable (Supported by Latex Beautify)",
-        "title": "Indent preamble",
-        "beautifiers": [
-          "Latex Beautify"
-        ],
-        "key": "indent_preamble",
-        "language": {
-          "name": "LaTeX",
-          "namespace": "latex"
-        }
-      },
-      "always_look_for_split_braces": {
-        "type": "boolean",
-        "default": true,
-        "description": "If `latexindent` should look for commands that split braces across lines (Supported by Latex Beautify)",
-        "title": "Always look for split braces",
-        "beautifiers": [
-          "Latex Beautify"
-        ],
-        "key": "always_look_for_split_braces",
-        "language": {
-          "name": "LaTeX",
-          "namespace": "latex"
-        }
-      },
-      "always_look_for_split_brackets": {
-        "type": "boolean",
-        "default": false,
-        "description": "If `latexindent` should look for commands that split brackets across lines (Supported by Latex Beautify)",
-        "title": "Always look for split brackets",
-        "beautifiers": [
-          "Latex Beautify"
-        ],
-        "key": "always_look_for_split_brackets",
-        "language": {
-          "name": "LaTeX",
-          "namespace": "latex"
-        }
-      },
-      "remove_trailing_whitespace": {
-        "type": "boolean",
-        "default": false,
-        "description": "Remove trailing whitespace (Supported by Latex Beautify)",
-        "title": "Remove trailing whitespace",
-        "beautifiers": [
-          "Latex Beautify"
-        ],
-        "key": "remove_trailing_whitespace",
-        "language": {
-          "name": "LaTeX",
-          "namespace": "latex"
-        }
-      },
-      "align_columns_in_environments": {
-        "type": "array",
-        "default": [
-          "tabular",
-          "matrix",
-          "bmatrix",
-          "pmatrix"
-        ],
-        "decription": "Aligns columns by the alignment tabs for environments specified",
-        "title": "Align columns in environments",
-        "beautifiers": [
-          "Latex Beautify"
-        ],
-        "key": "align_columns_in_environments",
-        "language": {
-          "name": "LaTeX",
-          "namespace": "latex"
-        },
-        "description": "undefined (Supported by Latex Beautify)"
       },
       "disabled": {
         "title": "Disable Beautifying Language",


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This commit removes the latexindent options that atom-beautify handled. Users must now maintain a localSettings.yaml (or otherwise named) file to specify latexindent options. This method is preferable to having atom-beautify handle the options because first, users can commit their settings to their VCS, thus allowing all contributors to format their code the same way, and second, atom-beautify will no longer need to support any options latexindent might add in the future.

### Does this close any currently open issues?

No.

### Any other comments?

No.

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [x] Update `CHANGELOG.md`
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
