### PR TITLE
Fixed #1613 and #1588. Add EOL, scientific notiation, and adjust whitespace support

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -7633,7 +7633,7 @@ Maximum amount of characters per line (0 = disable) (Supported by Pretty Diff)
 | `disabled` | :white_check_mark: |
 | `default_beautifier` | :white_check_mark: |
 | `beautify_on_save` | :white_check_mark: |
-| `do_not_change_whitespace` | :white_check_mark: |
+| `end_of_line` | :white_check_mark: |
 
 **Description**:
 
@@ -7694,26 +7694,30 @@ Automatically beautify Lua files on save
 2. Go into *Packages* and search for "*Atom Beautify*" package.
 3. Find the option "*Beautify On Save*" and change it to your desired configuration.
 
-#####  [Do not change whitespace](#do-not-change-whitespace) 
+#####  [End of line](#end-of-line) 
 
 **Namespace**: `lua`
 
-**Key**: `do_not_change_whitespace`
+**Key**: `end_of_line`
 
-**Type**: `boolean`
+**Default**: `System Default`
+
+**Type**: `string`
+
+**Enum**:  `CRLF`  `LF`  `System Default` 
 
 **Supported Beautifiers**:  [`Lua beautifier`](#lua-beautifier) 
 
 **Description**:
 
-do not adjust whitespace (Supported by Lua beautifier)
+Override EOL from line-ending-selector (Supported by Lua beautifier)
 
 **Example `.jsbeautifyrc` Configuration**
 
 ```json
 {
     "lua": {
-        "do_not_change_whitespace": false
+        "end_of_line": "System Default"
     }
 }
 ```
@@ -16802,26 +16806,30 @@ undefined (Supported by Latex Beautify)
 
 ### Lua beautifier
 
-#####  [Do not change whitespace](#do-not-change-whitespace) 
+#####  [End of line](#end-of-line) 
 
 **Namespace**: `lua`
 
-**Key**: `do_not_change_whitespace`
+**Key**: `end_of_line`
 
-**Type**: `boolean`
+**Default**: `System Default`
+
+**Type**: `string`
+
+**Enum**:  `CRLF`  `LF`  `System Default` 
 
 **Supported Beautifiers**:  [`Lua beautifier`](#lua-beautifier) 
 
 **Description**:
 
-do not adjust whitespace (Supported by Lua beautifier)
+Override EOL from line-ending-selector (Supported by Lua beautifier)
 
 **Example `.jsbeautifyrc` Configuration**
 
 ```json
 {
     "lua": {
-        "do_not_change_whitespace": false
+        "end_of_line": "System Default"
     }
 }
 ```

--- a/docs/options.md
+++ b/docs/options.md
@@ -7633,6 +7633,7 @@ Maximum amount of characters per line (0 = disable) (Supported by Pretty Diff)
 | `disabled` | :white_check_mark: |
 | `default_beautifier` | :white_check_mark: |
 | `beautify_on_save` | :white_check_mark: |
+| `do_not_change_whitespace` | :white_check_mark: |
 
 **Description**:
 
@@ -7692,6 +7693,30 @@ Automatically beautify Lua files on save
 *Edit > Preferences (Linux)*, *Atom > Preferences (OS X)*, or *File > Preferences (Windows)*.
 2. Go into *Packages* and search for "*Atom Beautify*" package.
 3. Find the option "*Beautify On Save*" and change it to your desired configuration.
+
+#####  [Do not change whitespace](#do-not-change-whitespace) 
+
+**Namespace**: `lua`
+
+**Key**: `do_not_change_whitespace`
+
+**Type**: `boolean`
+
+**Supported Beautifiers**:  [`Lua beautifier`](#lua-beautifier) 
+
+**Description**:
+
+do not adjust whitespace (Supported by Lua beautifier)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "lua": {
+        "do_not_change_whitespace": false
+    }
+}
+```
 
 ####  [Markdown](#markdown) 
 
@@ -16770,6 +16795,33 @@ undefined (Supported by Latex Beautify)
             "bmatrix",
             "pmatrix"
         ]
+    }
+}
+```
+
+
+### Lua beautifier
+
+#####  [Do not change whitespace](#do-not-change-whitespace) 
+
+**Namespace**: `lua`
+
+**Key**: `do_not_change_whitespace`
+
+**Type**: `boolean`
+
+**Supported Beautifiers**:  [`Lua beautifier`](#lua-beautifier) 
+
+**Description**:
+
+do not adjust whitespace (Supported by Lua beautifier)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "lua": {
+        "do_not_change_whitespace": false
     }
 }
 ```

--- a/examples/simple-jsbeautifyrc/lua/expected/test.lua
+++ b/examples/simple-jsbeautifyrc/lua/expected/test.lua
@@ -2,6 +2,7 @@
 -- and return a closure which can be used for continuing the sort.
 local a = 'a  b   c'
 local b = '12345678'
+local x = 1.99e-07
 local c = 'a  b   c' + 'a  b   c'
 local t = {
   a = 1,

--- a/examples/simple-jsbeautifyrc/lua/original/test.lua
+++ b/examples/simple-jsbeautifyrc/lua/original/test.lua
@@ -2,6 +2,7 @@
 -- and return a closure which can be used for continuing the sort.
 local a= 'a  b   c'
 local b ='12345678'
+local x = 1.99e-07
 local     c           =               'a  b   c'          +'a  b   c'
 local t = {
 a = 1,

--- a/src/beautifiers/lua-beautifier/beautifier.coffee
+++ b/src/beautifiers/lua-beautifier/beautifier.coffee
@@ -8,7 +8,8 @@ adjust_space = (line) ->
   # replace all whitespaces inside the string with one space, WARNING: the whitespaces in string will be replace too!
   line = line.replace /\s?(==|>=|<=|~=|[=><\+\*\/])\s?/g, ' $1 '
   # add whitespace around the operator
-  line = line.replace /([^=|\-|(|\s])\s?\-\s?([^\-|\[])/g, '$1 - $2'
+  line = line.replace /([^=e\-\(\s])\s?\-\s?([^\-\[])/g, '$1 - $2'
+  line = line.replace /([^\d])e\s?\-\s?([^\-\[])/g, '$1e - $2'
   # just format minus, not for -- or negative number or commentary.
   line = line.replace /,([^\s])/g, ', $1'
   # adjust ','
@@ -25,7 +26,8 @@ adjust_space = (line) ->
 DEFAULT_WARN_FN = (msg) ->
   console.log('WARNING:', msg)
 
-module.exports = (str, indent, warn_fn) ->
+module.exports = (str, indent, warn_fn, opts = {}) ->
+  do_not_change_whitespace = !!opts?.do_not_change_whitespace
   indent = indent or DEFAULT_INDENT
   warn_fn = if typeof warn_fn == 'function' then warn_fn else DEFAULT_WARN_FN
   indent = ' '.repeat(indent) if Number.isInteger(indent)
@@ -45,7 +47,7 @@ module.exports = (str, indent, warn_fn) ->
           arr = line.split(/\]=*\]/, 2)
           comment = arr[0]
           code = arr[1]
-          line = comment + ']' + '='.repeat($template - 1) + ']' + adjust_space(code)
+          line = comment + ']' + '='.repeat($template - 1) + ']' + if do_not_change_whitespace then code else adjust_space(code)
           $template = 0
         $template = 0
       else
@@ -56,7 +58,7 @@ module.exports = (str, indent, warn_fn) ->
     if !$template_flag
       line = line.trim()
       # remote all spaces on both ends
-      line = adjust_space(line)
+      line = if do_not_change_whitespace then line else adjust_space(line)
     if !line.length
       return ''
     raw_line = line

--- a/src/beautifiers/lua-beautifier/beautifier.coffee
+++ b/src/beautifiers/lua-beautifier/beautifier.coffee
@@ -27,7 +27,6 @@ DEFAULT_WARN_FN = (msg) ->
   console.log('WARNING:', msg)
 
 module.exports = (str, indent, warn_fn, opts = {}) ->
-  do_not_change_whitespace = !!opts?.do_not_change_whitespace
   eol = opts?.eol or '\n'
   indent = indent or DEFAULT_INDENT
   warn_fn = if typeof warn_fn == 'function' then warn_fn else DEFAULT_WARN_FN
@@ -48,7 +47,7 @@ module.exports = (str, indent, warn_fn, opts = {}) ->
           arr = line.split(/\]=*\]/, 2)
           comment = arr[0]
           code = arr[1]
-          line = comment + ']' + '='.repeat($template - 1) + ']' + if do_not_change_whitespace then code else adjust_space(code)
+          line = comment + ']' + '='.repeat($template - 1) + ']' + adjust_space(code)
           $template = 0
         $template = 0
       else
@@ -59,7 +58,7 @@ module.exports = (str, indent, warn_fn, opts = {}) ->
     if !$template_flag
       line = line.trim()
       # remote all spaces on both ends
-      line = if do_not_change_whitespace then line else adjust_space(line)
+      line = adjust_space(line)
     if !line.length
       return ''
     raw_line = line

--- a/src/beautifiers/lua-beautifier/beautifier.coffee
+++ b/src/beautifiers/lua-beautifier/beautifier.coffee
@@ -28,6 +28,7 @@ DEFAULT_WARN_FN = (msg) ->
 
 module.exports = (str, indent, warn_fn, opts = {}) ->
   do_not_change_whitespace = !!opts?.do_not_change_whitespace
+  eol = opts?.eol or '\n'
   indent = indent or DEFAULT_INDENT
   warn_fn = if typeof warn_fn == 'function' then warn_fn else DEFAULT_WARN_FN
   indent = ' '.repeat(indent) if Number.isInteger(indent)
@@ -102,4 +103,4 @@ module.exports = (str, indent, warn_fn, opts = {}) ->
     new_line or undefined
 
   warn_fn 'positive indentation at the end' if $currIndent > 0
-  new_code.join '\n'
+  new_code.join eol

--- a/src/beautifiers/lua-beautifier/index.coffee
+++ b/src/beautifiers/lua-beautifier/index.coffee
@@ -18,6 +18,6 @@ module.exports = class Lua extends Beautifier
   beautify: (text, language, options) ->
     new @Promise (resolve, reject) ->
       try
-        resolve format text, options.indent_char.repeat options.indent_size
+        resolve format text, options.indent_char.repeat(options.indent_size), @warn, options
       catch error
         reject error

--- a/src/beautifiers/lua-beautifier/index.coffee
+++ b/src/beautifiers/lua-beautifier/index.coffee
@@ -16,6 +16,7 @@ module.exports = class Lua extends Beautifier
   }
 
   beautify: (text, language, options) ->
+    options.eol = @getDefaultLineEnding('\r\n','\n',options.end_of_line)
     new @Promise (resolve, reject) ->
       try
         resolve format text, options.indent_char.repeat(options.indent_size), @warn, options

--- a/src/languages/lua.coffee
+++ b/src/languages/lua.coffee
@@ -20,8 +20,9 @@ module.exports = {
   defaultBeautifier: "Lua beautifier"
 
   options:
-    do_not_change_whitespace:
-      type: 'boolean'
-      default: false
-      description: "do not adjust whitespace"
+    end_of_line:
+      type: 'string'
+      default: "System Default"
+      enum: ["CRLF","LF","System Default"]
+      description: "Override EOL from line-ending-selector"
 }

--- a/src/languages/lua.coffee
+++ b/src/languages/lua.coffee
@@ -19,4 +19,9 @@ module.exports = {
 
   defaultBeautifier: "Lua beautifier"
 
+  options:
+    do_not_change_whitespace:
+      type: 'boolean'
+      default: false
+      description: "do not adjust whitespace"
 }

--- a/src/options.json
+++ b/src/options.json
@@ -4567,6 +4567,20 @@
       "lua"
     ],
     "properties": {
+      "do_not_change_whitespace": {
+        "type": "boolean",
+        "default": false,
+        "description": "do not adjust whitespace (Supported by Lua beautifier)",
+        "title": "Do not change whitespace",
+        "beautifiers": [
+          "Lua beautifier"
+        ],
+        "key": "do_not_change_whitespace",
+        "language": {
+          "name": "Lua",
+          "namespace": "lua"
+        }
+      },
       "disabled": {
         "title": "Disable Beautifying Language",
         "order": -3,

--- a/src/options.json
+++ b/src/options.json
@@ -4567,15 +4567,20 @@
       "lua"
     ],
     "properties": {
-      "do_not_change_whitespace": {
-        "type": "boolean",
-        "default": false,
-        "description": "do not adjust whitespace (Supported by Lua beautifier)",
-        "title": "Do not change whitespace",
+      "end_of_line": {
+        "type": "string",
+        "default": "System Default",
+        "enum": [
+          "CRLF",
+          "LF",
+          "System Default"
+        ],
+        "description": "Override EOL from line-ending-selector (Supported by Lua beautifier)",
+        "title": "End of line",
         "beautifiers": [
           "Lua beautifier"
         ],
-        "key": "do_not_change_whitespace",
+        "key": "end_of_line",
         "language": {
           "name": "Lua",
           "namespace": "lua"


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
- add scientific notation support
- add EOL support
- add option to control whether adjust whitespace

### Does this close any currently open issues?
#1613 and #1588

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [ ] Update `CHANGELOG.md`
- [x] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
