### PR TITLE
fix `undefined` when options has no description

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -7074,7 +7074,7 @@ Automatically beautify LaTeX files on save
 
 **Description**:
 
-undefined (Supported by Latex Beautify)
+ (Supported by Latex Beautify)
 
 **Example `.jsbeautifyrc` Configuration**
 
@@ -8945,7 +8945,7 @@ Automatically beautify Nginx files on save
 
 **Description**:
 
-undefined (Supported by Nginx Beautify)
+ (Supported by Nginx Beautify)
 
 **Example `.jsbeautifyrc` Configuration**
 
@@ -9706,7 +9706,7 @@ Absolute path to the `php-cs-fixer` CLI executable (Supported by PHP-CS-Fixer)
 
 **Description**:
 
-undefined (Supported by PHP-CS-Fixer)
+ (Supported by PHP-CS-Fixer)
 
 **Example `.jsbeautifyrc` Configuration**
 
@@ -16757,7 +16757,7 @@ Remove trailing whitespace (Supported by Latex Beautify)
 
 **Description**:
 
-undefined (Supported by Latex Beautify)
+ (Supported by Latex Beautify)
 
 **Example `.jsbeautifyrc` Configuration**
 
@@ -17311,7 +17311,7 @@ Indentation uses tabs, overrides `Indent Size` and `Indent Char` (Supported by N
 
 **Description**:
 
-undefined (Supported by Nginx Beautify)
+ (Supported by Nginx Beautify)
 
 **Example `.jsbeautifyrc` Configuration**
 
@@ -17366,7 +17366,7 @@ Absolute path to the `php-cs-fixer` CLI executable (Supported by PHP-CS-Fixer)
 
 **Description**:
 
-undefined (Supported by PHP-CS-Fixer)
+ (Supported by PHP-CS-Fixer)
 
 **Example `.jsbeautifyrc` Configuration**
 

--- a/script/build-options.js
+++ b/script/build-options.js
@@ -133,9 +133,9 @@ buildOptionsForBeautifiers = function(beautifiers, allLanguages) {
     return _.reduce(languageOptions, (function(result, optionDef, optionName) {
       optionDef.beautifiers = _.uniq(optionDef.beautifiers)
       if (optionDef.beautifiers.length > 0) {
-        optionDef.description = optionDef.description + " (Supported by " + (optionDef.beautifiers.join(', ')) + ")";
+        optionDef.description = (optionDef.description || "") + " (Supported by " + (optionDef.beautifiers.join(', ')) + ")";
       } else {
-        optionDef.description = optionDef.description + " (Not supported by any beautifiers)";
+        optionDef.description = (optionDef.description || "") + " (Not supported by any beautifiers)";
       }
       if (result[optionName] != null) {
         logger.warn("Duplicate option detected: ", optionName, optionDef);

--- a/script/build-options.js
+++ b/script/build-options.js
@@ -322,7 +322,7 @@ buildOptionsForBeautifiers = function(beautifiers, allLanguages) {
       optionDef = ref16[o];
       optionDef.beautifiers = _.uniq(optionDef.beautifiers)
       if (optionDef.beautifiers.length > 0) {
-        optionDef.description = optionDef.description + " (Supported by " + (optionDef.beautifiers.join(', ')) + ")";
+        optionDef.description = (optionDef.description || "") + " (Supported by " + (optionDef.beautifiers.join(', ')) + ")";
       } else {
         unsupportedOptions.push(g + ".properties." + o);
       }

--- a/src/options.json
+++ b/src/options.json
@@ -4301,7 +4301,7 @@
           "name": "LaTeX",
           "namespace": "latex"
         },
-        "description": "undefined (Supported by Latex Beautify)"
+        "description": " (Supported by Latex Beautify)"
       },
       "disabled": {
         "title": "Disable Beautifying Language",
@@ -5420,7 +5420,7 @@
           "name": "Nginx",
           "namespace": "nginx"
         },
-        "description": "undefined (Supported by Nginx Beautify)"
+        "description": " (Supported by Nginx Beautify)"
       },
       "disabled": {
         "title": "Disable Beautifying Language",
@@ -5808,7 +5808,7 @@
           "name": "PHP",
           "namespace": "php"
         },
-        "description": "undefined (Supported by PHP-CS-Fixer)"
+        "description": " (Supported by PHP-CS-Fixer)"
       },
       "fixers": {
         "type": "string",


### PR DESCRIPTION
When an option doesn't have a description `undefined` prefixes the `(Supported by ...)` declaration in the settings

![image](https://cloud.githubusercontent.com/assets/97994/25759344/a6f914d0-3197-11e7-9438-437efc7c1210.png)
