### PR TITLE
Add PHPCBF Version setting

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -9849,6 +9849,8 @@ Add rule(s). i.e. line_ending,-full_opening_tag,@PSR2 (PHP-CS-Fixer 2 only) (Sup
 
 **Key**: `standard`
 
+**Default**: `PEAR`
+
 **Type**: `string`
 
 **Supported Beautifiers**:  [`PHPCBF`](#phpcbf) 
@@ -9862,7 +9864,7 @@ Standard name Squiz, PSR2, PSR1, PHPCS, PEAR, Zend, MySource... or path to CS ru
 ```json
 {
     "php": {
-        "standard": ""
+        "standard": "PEAR"
     }
 }
 ```
@@ -17568,6 +17570,8 @@ undefined (Supported by PHPCBF)
 
 **Key**: `standard`
 
+**Default**: `PEAR`
+
 **Type**: `string`
 
 **Supported Beautifiers**:  [`PHPCBF`](#phpcbf) 
@@ -17581,7 +17585,7 @@ Standard name Squiz, PSR2, PSR1, PHPCS, PEAR, Zend, MySource... or path to CS ru
 ```json
 {
     "php": {
-        "standard": ""
+        "standard": "PEAR"
     }
 }
 ```

--- a/docs/options.md
+++ b/docs/options.md
@@ -9575,9 +9575,10 @@ Specify a configuration file which will override the default name of .perltidyrc
 | `cs_fixer_version` | :white_check_mark: | :x: | :x: |
 | `fixers` | :white_check_mark: | :x: | :x: |
 | `level` | :white_check_mark: | :x: | :x: |
-| `phpcbf_path` | :white_check_mark: | :x: | :x: |
+| `phpcbf_path` | :x: | :white_check_mark: | :x: |
+| `phpcbf_version` | :x: | :white_check_mark: | :x: |
 | `rules` | :white_check_mark: | :x: | :x: |
-| `standard` | :white_check_mark: | :white_check_mark: | :x: |
+| `standard` | :x: | :white_check_mark: | :x: |
 
 **Description**:
 
@@ -9774,11 +9775,11 @@ By default, all PSR-2 fixers and some additional ones are run. (PHP-CS-Fixer 1 o
 
 **Type**: `string`
 
-**Supported Beautifiers**:  [`PHP-CS-Fixer`](#php-cs-fixer) 
+**Supported Beautifiers**:  [`PHPCBF`](#phpcbf) 
 
 **Description**:
 
-Path to the `phpcbf` CLI executable (Supported by PHP-CS-Fixer)
+Path to the `phpcbf` CLI executable (Supported by PHPCBF)
 
 **Example `.jsbeautifyrc` Configuration**
 
@@ -9786,6 +9787,34 @@ Path to the `phpcbf` CLI executable (Supported by PHP-CS-Fixer)
 {
     "php": {
         "phpcbf_path": ""
+    }
+}
+```
+
+#####  [PHPCBF Version](#phpcbf-version) 
+
+**Namespace**: `php`
+
+**Key**: `phpcbf_version`
+
+**Default**: `2`
+
+**Type**: `integer`
+
+**Enum**:  `1`  `2`  `3` 
+
+**Supported Beautifiers**:  [`PHPCBF`](#phpcbf) 
+
+**Description**:
+
+undefined (Supported by PHPCBF)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "php": {
+        "phpcbf_version": 2
     }
 }
 ```
@@ -9822,11 +9851,11 @@ Add rule(s). i.e. line_ending,-full_opening_tag,@PSR2 (PHP-CS-Fixer 2 only) (Sup
 
 **Type**: `string`
 
-**Supported Beautifiers**:  [`PHP-CS-Fixer`](#php-cs-fixer)  [`PHPCBF`](#phpcbf) 
+**Supported Beautifiers**:  [`PHPCBF`](#phpcbf) 
 
 **Description**:
 
-Standard name Squiz, PSR2, PSR1, PHPCS, PEAR, Zend, MySource... or path to CS rules. Will use local `phpcs.xml`, `phpcs.xml.dist`, `phpcs.ruleset.xml` or `ruleset.xml` if found in the project root. (Supported by PHP-CS-Fixer, PHPCBF)
+Standard name Squiz, PSR2, PSR1, PHPCS, PEAR, Zend, MySource... or path to CS rules. Will use local `phpcs.xml`, `phpcs.xml.dist`, `phpcs.ruleset.xml` or `ruleset.xml` if found in the project root. (Supported by PHPCBF)
 
 **Example `.jsbeautifyrc` Configuration**
 
@@ -17478,6 +17507,9 @@ allow risky rules to be applied (PHP-CS-Fixer 2 only) (Supported by PHP-CS-Fixer
 }
 ```
 
+
+### PHPCBF
+
 #####  [PHPCBF Path](#phpcbf-path) 
 
 **Namespace**: `php`
@@ -17486,11 +17518,11 @@ allow risky rules to be applied (PHP-CS-Fixer 2 only) (Supported by PHP-CS-Fixer
 
 **Type**: `string`
 
-**Supported Beautifiers**:  [`PHP-CS-Fixer`](#php-cs-fixer) 
+**Supported Beautifiers**:  [`PHPCBF`](#phpcbf) 
 
 **Description**:
 
-Path to the `phpcbf` CLI executable (Supported by PHP-CS-Fixer)
+Path to the `phpcbf` CLI executable (Supported by PHPCBF)
 
 **Example `.jsbeautifyrc` Configuration**
 
@@ -17502,32 +17534,33 @@ Path to the `phpcbf` CLI executable (Supported by PHP-CS-Fixer)
 }
 ```
 
-#####  [PHPCBF Standard](#phpcbf-standard) 
+#####  [PHPCBF Version](#phpcbf-version) 
 
 **Namespace**: `php`
 
-**Key**: `standard`
+**Key**: `phpcbf_version`
 
-**Type**: `string`
+**Default**: `2`
 
-**Supported Beautifiers**:  [`PHP-CS-Fixer`](#php-cs-fixer)  [`PHPCBF`](#phpcbf) 
+**Type**: `integer`
+
+**Enum**:  `1`  `2`  `3` 
+
+**Supported Beautifiers**:  [`PHPCBF`](#phpcbf) 
 
 **Description**:
 
-Standard name Squiz, PSR2, PSR1, PHPCS, PEAR, Zend, MySource... or path to CS rules. Will use local `phpcs.xml`, `phpcs.xml.dist`, `phpcs.ruleset.xml` or `ruleset.xml` if found in the project root. (Supported by PHP-CS-Fixer, PHPCBF)
+undefined (Supported by PHPCBF)
 
 **Example `.jsbeautifyrc` Configuration**
 
 ```json
 {
     "php": {
-        "standard": ""
+        "phpcbf_version": 2
     }
 }
 ```
-
-
-### PHPCBF
 
 #####  [PHPCBF Standard](#phpcbf-standard) 
 
@@ -17537,11 +17570,11 @@ Standard name Squiz, PSR2, PSR1, PHPCS, PEAR, Zend, MySource... or path to CS ru
 
 **Type**: `string`
 
-**Supported Beautifiers**:  [`PHP-CS-Fixer`](#php-cs-fixer)  [`PHPCBF`](#phpcbf) 
+**Supported Beautifiers**:  [`PHPCBF`](#phpcbf) 
 
 **Description**:
 
-Standard name Squiz, PSR2, PSR1, PHPCS, PEAR, Zend, MySource... or path to CS rules. Will use local `phpcs.xml`, `phpcs.xml.dist`, `phpcs.ruleset.xml` or `ruleset.xml` if found in the project root. (Supported by PHP-CS-Fixer, PHPCBF)
+Standard name Squiz, PSR2, PSR1, PHPCS, PEAR, Zend, MySource... or path to CS rules. Will use local `phpcs.xml`, `phpcs.xml.dist`, `phpcs.ruleset.xml` or `ruleset.xml` if found in the project root. (Supported by PHPCBF)
 
 **Example `.jsbeautifyrc` Configuration**
 

--- a/src/beautifiers/php-cs-fixer.coffee
+++ b/src/beautifiers/php-cs-fixer.coffee
@@ -13,7 +13,13 @@ module.exports = class PHPCSFixer extends Beautifier
   isPreInstalled: false
 
   options:
-    PHP: true
+    PHP:
+      rules: true
+      cs_fixer_path: true
+      cs_fixer_version: true
+      allow_risky: true
+      level: true
+      fixers: true
 
   beautify: (text, language, options, context) ->
     @debug('php-cs-fixer', options)

--- a/src/beautifiers/phpcbf.coffee
+++ b/src/beautifiers/phpcbf.coffee
@@ -11,12 +11,10 @@ module.exports = class PHPCBF extends Beautifier
   isPreInstalled: false
 
   options: {
-    _:
-      standard: ["standard", (standard) ->
-        if (standard) then \
-          standard else "PEAR"
-      ]
-    PHP: true
+    PHP:
+      phpcbf_path: true
+      phpcbf_version: true
+      standard: true
   }
 
   beautify: (text, language, options) ->
@@ -50,7 +48,7 @@ module.exports = class PHPCBF extends Beautifier
 
           @run(exec, [
             phpcbfPath unless isExec
-            "--no-patch"
+            "--no-patch" unless options.phpcbf_version is 3
             "--standard=#{options.standard}" if options.standard
             tempFile = @tempFile("temp", text)
             ], {

--- a/src/languages/php.coffee
+++ b/src/languages/php.coffee
@@ -55,6 +55,11 @@ module.exports = {
       type: 'string'
       default: ""
       description: "Path to the `phpcbf` CLI executable",
+    phpcbf_version:
+      title: "PHPCBF Version"
+      type: 'integer'
+      default: 2
+      enum: [1, 2, 3]
     standard:
       title: "PHPCBF Standard"
       type: 'string'

--- a/src/languages/php.coffee
+++ b/src/languages/php.coffee
@@ -63,7 +63,7 @@ module.exports = {
     standard:
       title: "PHPCBF Standard"
       type: 'string'
-      default: "",
+      default: "PEAR",
       description: "Standard name Squiz, PSR2, PSR1, PHPCS, PEAR, Zend, MySource... or path to CS rules. Will use local `phpcs.xml`, `phpcs.xml.dist`, `phpcs.ruleset.xml` or `ruleset.xml` if found in the project root."
 
 }

--- a/src/options.json
+++ b/src/options.json
@@ -5874,9 +5874,9 @@
         "title": "PHPCBF Path",
         "type": "string",
         "default": "",
-        "description": "Path to the `phpcbf` CLI executable (Supported by PHP-CS-Fixer)",
+        "description": "Path to the `phpcbf` CLI executable (Supported by PHPCBF)",
         "beautifiers": [
-          "PHP-CS-Fixer"
+          "PHPCBF"
         ],
         "key": "phpcbf_path",
         "language": {
@@ -5884,13 +5884,31 @@
           "namespace": "php"
         }
       },
+      "phpcbf_version": {
+        "title": "PHPCBF Version",
+        "type": "integer",
+        "default": 2,
+        "enum": [
+          1,
+          2,
+          3
+        ],
+        "beautifiers": [
+          "PHPCBF"
+        ],
+        "key": "phpcbf_version",
+        "language": {
+          "name": "PHP",
+          "namespace": "php"
+        },
+        "description": "undefined (Supported by PHPCBF)"
+      },
       "standard": {
         "title": "PHPCBF Standard",
         "type": "string",
         "default": "",
-        "description": "Standard name Squiz, PSR2, PSR1, PHPCS, PEAR, Zend, MySource... or path to CS rules. Will use local `phpcs.xml`, `phpcs.xml.dist`, `phpcs.ruleset.xml` or `ruleset.xml` if found in the project root. (Supported by PHP-CS-Fixer, PHPCBF)",
+        "description": "Standard name Squiz, PSR2, PSR1, PHPCS, PEAR, Zend, MySource... or path to CS rules. Will use local `phpcs.xml`, `phpcs.xml.dist`, `phpcs.ruleset.xml` or `ruleset.xml` if found in the project root. (Supported by PHPCBF)",
         "beautifiers": [
-          "PHP-CS-Fixer",
           "PHPCBF"
         ],
         "key": "standard",

--- a/src/options.json
+++ b/src/options.json
@@ -5906,7 +5906,7 @@
       "standard": {
         "title": "PHPCBF Standard",
         "type": "string",
-        "default": "",
+        "default": "PEAR",
         "description": "Standard name Squiz, PSR2, PSR1, PHPCS, PEAR, Zend, MySource... or path to CS rules. Will use local `phpcs.xml`, `phpcs.xml.dist`, `phpcs.ruleset.xml` or `ruleset.xml` if found in the project root. (Supported by PHPCBF)",
         "beautifiers": [
           "PHPCBF"


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This adds a setting to PHP for the PHPCBF Version.

If the PHPCBF version is 3 than it removes the `--no-patch` flag

### Does this close any currently open issues?

#1643

### Any other comments?

The setting is defaulted to 2 so it doesn't change the current behavior

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
