### PR TITLE
add .php extension to temp files

### DIFF
--- a/src/beautifiers/phpcbf.coffee
+++ b/src/beautifiers/phpcbf.coffee
@@ -50,7 +50,7 @@ module.exports = class PHPCBF extends Beautifier
             phpcbfPath unless isExec
             "--no-patch" unless options.phpcbf_version is 3
             "--standard=#{options.standard}" if options.standard
-            tempFile = @tempFile("temp", text)
+            tempFile = @tempFile("temp", text, ".php")
             ], {
               ignoreReturnCode: true
               help: {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Adds `.php` extension to the temp file that is created for PHPCBF

### Any other comments?

PHPCBF v3.0 will filter out and files without the `.php` extension by default. Alternatively we could tell it not to filter out the files but i felt adding the `.php` extension is easier and will help reduce errors in the future.

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
