### PR TITLE
Improve PHP-CS-Fixer config file support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+- Fix [#1524](https://github.com/Glavin001/atom-beautify/issues/1524). Add PHP-CS-Fixer config file setting and improve automatic detection of standard config files. See [#1661](https://github.com/Glavin001/atom-beautify/pull/1661)
 - ...
 
 # v0.29.24 (2017-05-06)
@@ -20,7 +21,7 @@
 - Add [clang-format](http://clang.llvm.org/docs/ClangFormat.html) beautifier for C/C++/Obj-C languages.
 - Add [yapf](http://github.com/google/yapf) beautifier for Python.
 - Add [ESLint](https://github.com/eslint/eslint) beautifier for Javascript
-- Closes [#776] (https://github.com/Glavin001/atom-beautify/issues/776) Add support for `collapse-preserve-inline` brace_style for javascript.
+- Closes [#776](https://github.com/Glavin001/atom-beautify/issues/776) Add support for `collapse-preserve-inline` brace_style for javascript.
 - Closes [#786](https://github.com/Glavin001/atom-beautify/issues/786) YAPF configuration files are ignored.
 - Fix phpcbf hanging issue by closing stdin. See [#893](https://github.com/Glavin001/atom-beautify/issues/893)
 - Add warning notification when parsing `.jsbeautifyrc` as JSON or YAML fails. See [#1106](https://github.com/Glavin001/atom-beautify/issues/1106)

--- a/docs/add-languages-and-beautifiers.md
+++ b/docs/add-languages-and-beautifiers.md
@@ -35,7 +35,7 @@ Now your Language is available and can be detected and beautifiers can support i
 2. Implement beautifier:
   - See examples of beautifiers:
     - Prettydiff is a good example of complex options: https://github.com/Glavin001/atom-beautify/blob/master/src/beautifiers/prettydiff.coffee
-    - PHP-CS-Fixer is a good example of a CLI beautifier with arguments: https://github.com/Glavin001/atom-beautify/blob/master/src/beautifiers/php-cs-fixer.coffee#L15-L39
+    - PHP-CS-Fixer is a good example of a CLI beautifier with arguments: https://github.com/Glavin001/atom-beautify/blob/master/src/beautifiers/php-cs-fixer.coffee#L15-L47
   - `options` - the key represents the Language's name. The value could be `true` (supports all options), `false` (supports language, with no options), or an `object` whose keys are option keys and values are complex mappings. If you need to use these, let me know. `true` is probably what you want.
   - The `beautify` function should return a `Promise` (use `@Promise` as shown). The arguments passed are:
     - __`text`__ -  the source code from Atom's Text Editor

--- a/docs/options.md
+++ b/docs/options.md
@@ -9571,6 +9571,7 @@ Specify a configuration file which will override the default name of .perltidyrc
 | `default_beautifier` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `beautify_on_save` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `allow_risky` | :white_check_mark: | :x: | :x: |
+| `cs_fixer_config_file` | :white_check_mark: | :x: | :x: |
 | `cs_fixer_path` | :white_check_mark: | :x: | :x: |
 | `cs_fixer_version` | :white_check_mark: | :x: | :x: |
 | `fixers` | :white_check_mark: | :x: | :x: |
@@ -9655,7 +9656,7 @@ Automatically beautify PHP files on save
 
 **Description**:
 
-allow risky rules to be applied (PHP-CS-Fixer 2 only) (Supported by PHP-CS-Fixer)
+Allow risky rules to be applied (PHP-CS-Fixer 2 only) (Supported by PHP-CS-Fixer)
 
 **Example `.jsbeautifyrc` Configuration**
 
@@ -9663,6 +9664,30 @@ allow risky rules to be applied (PHP-CS-Fixer 2 only) (Supported by PHP-CS-Fixer
 {
     "php": {
         "allow_risky": "no"
+    }
+}
+```
+
+#####  [PHP-CS-Fixer Config File](#php-cs-fixer-config-file) 
+
+**Namespace**: `php`
+
+**Key**: `cs_fixer_config_file`
+
+**Type**: `string`
+
+**Supported Beautifiers**:  [`PHP-CS-Fixer`](#php-cs-fixer) 
+
+**Description**:
+
+Path to php-cs-fixer config file. Will use local `.php_cs` or `.php_cs.dist` if found in the working directory or project root. (Supported by PHP-CS-Fixer)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "php": {
+        "cs_fixer_config_file": ""
     }
 }
 ```
@@ -17409,6 +17434,30 @@ Absolute path to the `php-cs-fixer` CLI executable (Supported by PHP-CS-Fixer)
 }
 ```
 
+#####  [PHP-CS-Fixer Config File](#php-cs-fixer-config-file) 
+
+**Namespace**: `php`
+
+**Key**: `cs_fixer_config_file`
+
+**Type**: `string`
+
+**Supported Beautifiers**:  [`PHP-CS-Fixer`](#php-cs-fixer) 
+
+**Description**:
+
+Path to php-cs-fixer config file. Will use local `.php_cs` or `.php_cs.dist` if found in the working directory or project root. (Supported by PHP-CS-Fixer)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "php": {
+        "cs_fixer_config_file": ""
+    }
+}
+```
+
 #####  [Fixers](#fixers) 
 
 **Namespace**: `php`
@@ -17497,7 +17546,7 @@ Add rule(s). i.e. line_ending,-full_opening_tag,@PSR2 (PHP-CS-Fixer 2 only) (Sup
 
 **Description**:
 
-allow risky rules to be applied (PHP-CS-Fixer 2 only) (Supported by PHP-CS-Fixer)
+Allow risky rules to be applied (PHP-CS-Fixer 2 only) (Supported by PHP-CS-Fixer)
 
 **Example `.jsbeautifyrc` Configuration**
 

--- a/src/languages/php.coffee
+++ b/src/languages/php.coffee
@@ -32,6 +32,11 @@ module.exports = {
       type: 'integer'
       default: 2
       enum: [1, 2]
+    cs_fixer_config_file:
+      title: "PHP-CS-Fixer Config File"
+      type: 'string'
+      default: ""
+      description: "Path to php-cs-fixer config file. Will use local `.php_cs` or `.php_cs.dist` if found in the working directory or project root."
     fixers:
       type: 'string'
       default: ""
@@ -49,7 +54,7 @@ module.exports = {
       type: 'string'
       default: "no"
       enum: ["no", "yes"]
-      description: "allow risky rules to be applied (PHP-CS-Fixer 2 only)"
+      description: "Allow risky rules to be applied (PHP-CS-Fixer 2 only)"
     phpcbf_path:
       title: "PHPCBF Path"
       type: 'string'

--- a/src/options.json
+++ b/src/options.json
@@ -5810,6 +5810,20 @@
         },
         "description": " (Supported by PHP-CS-Fixer)"
       },
+      "cs_fixer_config_file": {
+        "title": "PHP-CS-Fixer Config File",
+        "type": "string",
+        "default": "",
+        "description": "Path to php-cs-fixer config file. Will use local `.php_cs` or `.php_cs.dist` if found in the working directory or project root. (Supported by PHP-CS-Fixer)",
+        "beautifiers": [
+          "PHP-CS-Fixer"
+        ],
+        "key": "cs_fixer_config_file",
+        "language": {
+          "name": "PHP",
+          "namespace": "php"
+        }
+      },
       "fixers": {
         "type": "string",
         "default": "",
@@ -5860,7 +5874,7 @@
           "no",
           "yes"
         ],
-        "description": "allow risky rules to be applied (PHP-CS-Fixer 2 only) (Supported by PHP-CS-Fixer)",
+        "description": "Allow risky rules to be applied (PHP-CS-Fixer 2 only) (Supported by PHP-CS-Fixer)",
         "beautifiers": [
           "PHP-CS-Fixer"
         ],
@@ -9037,7 +9051,7 @@
     "properties": {
       "padding": {
         "type": "integer",
-        "default": null,
+        "default": 0,
         "minimum": 0,
         "description": "The amount of padding to add next to each line. (Supported by align-yaml)",
         "title": "Padding",


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This PR adds a PHP-CS-Fixer setting to specify a custom config file. If no setting is provided, it checks first the working directory then the project root for `.php_cs` and `.php_cs.dist` and uses whichever it finds first.
I also updated the example link to PHP-CS-Fixer source in `add-languages-and-beautifiers.md` to account for the additions, and fixed the capitalization in the "Allow risky rules" setting description.

### Does this close any currently open issues?

[#1524](https://github.com/Glavin001/atom-beautify/issues/1524), part of [#1537](https://github.com/Glavin001/atom-beautify/issues/1537), possibly [#915](https://github.com/Glavin001/atom-beautify/issues/915).

### Any other comments?

This has only been tested on PHP-CS-Fixer version 2.3.1 on OS X, though it's unlikely to behave differently on PHP-CS-Fixer 1.x or Windows.

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [x] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
