### PR TITLE
injecting prettydiff2.x into Atom Beautify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 npm-debug.log
-node_modules
+node_modules/*
+!node_modules/prettydiff

--- a/node_modules/prettydiff/.prettydiffrc
+++ b/node_modules/prettydiff/.prettydiffrc
@@ -1,0 +1,45 @@
+//JSON format is supported, so please feel free to replace the contents of this file with JSON
+//http://prettydiff.com/.prettydiffrc
+//Options are passed in as "option".  You can define the options directly:
+//
+//option.mode = "minify";
+//
+//Instead, you can also define the values using logic:
+//
+//if (option.mode === "beautify" || option.lang === "auto") {
+//    option.wrap = 120;
+//}
+(function prettydiffrc_init() {
+    "use strict";
+    var prettydiffrc = function prettydiffrc(option) {
+        //       edit below this line
+
+
+
+
+
+
+
+        //       edit above this line
+        return option;
+    };
+
+    if (typeof module === "object" && typeof module.parent === "object") {
+        //commonjs and nodejs support
+        module.exports = prettydiffrc;
+    } else if ((typeof define === "object" || typeof define === "function") && (typeof ace !== "object" || ace.prettydiffid === undefined)) {
+        //requirejs support
+        define(function requirejs(require, module) {
+            module.exports = prettydiffrc;
+            //worthless if block to appease RequireJS and JSLint
+            if (typeof require === "number") {
+                return require;
+            }
+            return function requirejs_prettydiffrc_module(x) {
+                prettydiffrc(x);
+            };
+        });
+    } else {
+        global.prettydiff.prettydiffrc = prettydiffrc;
+    }
+}());

--- a/node_modules/prettydiff/README.md
+++ b/node_modules/prettydiff/README.md
@@ -1,0 +1,157 @@
+Try it online at [http://prettydiff.com/](http://prettydiff.com/).
+
+# ![Pretty Diff logo](http://prettydiff.com/images/pdlogoxs.svg) Pretty Diff
+
+[![Travis CI Build](https://travis-ci.org/prettydiff/prettydiff.svg)](https://travis-ci.org/prettydiff/prettydiff)
+[![AppVeyor Build](https://ci.appveyor.com/api/projects/status/github/prettydiff/prettydiff?branch=master&svg=true)](https://ci.appveyor.com/project/prettydiff/prettydiff)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/prettydiff/prettydiff?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Twitter Tweets](https://img.shields.io/twitter/url/http/prettydiff.com.svg?style=social)](https://twitter.com/intent/tweet?text=Handy%20web%20development%20tool:%20%20url=http%3A%2F%2Fprettydiff.com)
+
+## Summary
+
+[Download](http://prettydiff.com/downloads/prettydiff) with [biddle](https://github.com/prettydiff/biddle)
+
+Language aware code comparison tool for several web based languages. It also beautifies, minifies, and a few other things.
+
+## Benefits - see [overview page](http://prettydiff.com/overview.xhtml) for more details
+
+* ES6 / ES2015 ready
+* [React JSX format support](http://prettydiff.com/guide/react_jsx.xhtml)
+* LESS, SCSS (Sass), and CSS support
+* Separate support for XML and HTML
+* [Recursive command line directory diff](http://prettydiff.com/guide/diffcli.xhtml)
+* [JavaScript scope in colors](http://prettydiff.com/guide/jshtml.xhtml)
+* [Supports presets for popular styleguides](http://prettydiff.com/guide/styleguide.xhtml)
+* [Markup beautification with optional opt out](http://prettydiff.com/guide/tag_ignore.xhtml)
+* [JavaScript auto correction](http://prettydiff.com/guide/jscorrect.xhtml)
+* [Supports a ton of options](http://prettydiff.com/documentation.php#function_properties)
+* [Default beautifier](https://atom.io/packages/atom-beautify/) for several languages in [Atom.io](https://atom.io/)
+
+## Executing Pretty Diff
+
+### Run with Node.js / CommonJS / RequireJS
+
+A Node.js command line utility is provided by api/node-local.js.  This file can execute in the following modes:
+
+* auto - Determine if the resource is text, a file, or a directory and process as such (except that directories are processed with the subdirectory option)
+* screen - code input is on the command line and output is to the command line
+* filescreen - code input is in a file and the output is to the command line
+* file - the input and the output reside in files
+* directory - everything in a directory is processed into a specified output directory except ".", "..", and subdirectories
+* subdirectory - process the entire directory tree
+
+#### Execute in the context of a NodeJS application
+
+Add this code to your application
+
+```javascript
+var prettydiff = require("prettydiff"),
+    args       = {
+        source: "asdf",
+        diff  : "asdd",
+        lang  : "text"
+    },
+    output     = prettydiff(args);
+```
+
+#### Execute in the browser as a vanilla or RequireJS app
+
+Please see the [barebones code samples](test/barebones)
+
+#### Execute from the command line
+
+Run in windows
+
+```shell
+node api/node-local.js source:"c:\myDirectory" readmethod:"subdirectory" diff:"c:\myOtherDirectory"
+```
+
+Run in Linux and OSX
+
+```shell
+node api/node-local.js source:"myDirectory" mode:"beautify" readmethod:"subdirectory" output:"path/to/outputDirectory"
+```
+
+To see a *man* page provide no arguments or these: help, man, manual
+
+```shell
+node api/node-local.js h
+node api/node-local.js help
+node api/node-local.js man
+node api/node-local.js manual
+```
+
+To see only the version number supply only *v* or *version* as an argument:
+
+```shell
+node api/node-local.js v
+node api/node-local.js version
+```
+
+To see a list of current settings on the console supply *list* as an argument:
+
+```shell
+node api/node-local.js l
+node api/node-local.js list
+```
+
+#### Set configurations with a **.prettydiffrc** file.
+
+Pretty Diff will first look for a .prettydiffrc file from the current directory in the command prompt. If the .prettydiffrc is not present in the current directory it will then look for it in the application's directory.
+
+The .prettydiffrc first checks for JSON format. This allows a simple means of defining options in a file. It also allows a [JavaScript application format](http://prettydiff.com/.prettydiffrc) so that options can be set conditionally.
+
+### Run in a web browser with api/dom.js
+
+Please feel free to use index.xhtml file to supplement dom.js.  Otherwise, dom.js requires supplemental assistance to map DOM nodes from an HTML source.  dom.js is fault tolerant so nodes mapped to the supplied index.xhtml don't need to be supported from custom HTML.
+
+To run Pretty Diff using dom.js include the following two script tags and bind the global.prettydiff.pd.recycle() function to the executing event.  Please refer to index.xhtml for an HTML example and documentation.xhtml for option and execution information.
+
+```html
+<script src="lib/global.js" type="application/javascript"></script>
+<script src="lib/language.js" type="application/javascript"></script>
+<script src="lib/options.js" type="application/javascript"></script>
+<script src="lib/finalFile.js" type="application/javascript"></script>
+<script src="lib/safeSort.js" type="application/javascript"></script>
+<script src="ace/ace.js" type="application/javascript"></script> **(optional)**
+<script src="api/dom.js" type="application/javascript"></script>
+<script src="lib/csspretty.js" type="application/javascript"></script>
+<script src="lib/csvpretty.js" type="application/javascript"></script>
+<script src="lib/diffview.js" type="application/javascript"></script>
+<script src="lib/jspretty.js" type="application/javascript"></script>
+<script src="lib/markuppretty.js" type="application/javascript"></script>
+<script src="prettydiff.js" type="application/javascript"></script>
+```
+
+### Execute with vanilla JS
+
+```javascript
+var global = {},
+    args   = {
+        source: "asdf",
+        diff  : "asdd",
+        lang  : "text"
+    },
+    output = prettydiff(args);
+```
+
+### Run Pretty Diff in [Atom](https://atom.io/) code editor with the [atom-beautify](https://atom.io/packages/atom-beautify) package.
+
+### Run the unit tests
+
+```shell
+cd prettydiff
+node test/lint.js
+```
+
+## License:
+
+This project is mostly written by and managed by Austin Cheney and licensed under CC0 as of version 2.1.17.  Please see license.txt for license langauge.
+
+## Acknowledgements
+
+ * Harry Whitfield - http://g6auc.me.uk/
+  - JS Pretty QA
+  - JS Pretty widget
+ * Andreas Greuel - https://plus.google.com/105958105635636993368/posts
+  - diffview.js QA

--- a/node_modules/prettydiff/api/node-local.js
+++ b/node_modules/prettydiff/api/node-local.js
@@ -1,0 +1,1395 @@
+/*prettydiff.com topcoms: true, insize: 4, inchar: " ", vertical: true */
+/*jshint laxbreak: true*/
+/*jslint node: true*/
+/***********************************************************************
+ node-local is written by Austin Cheney on 6 Nov 2012.
+
+ Please see the license.txt file associated with the Pretty Diff
+ application for license information.
+ **********************************************************************/
+/*
+
+http://prettydiff.com/
+
+Command line API for Prettydiff for local execution only.  This API is
+not intended for execution as a service on a remote server.
+
+Arguments entered from the command line are separated by spaces and
+values are separated from argument names by a colon.  For safety
+argument values should always be quoted.
+
+Examples:
+
+> node node-local.js source:"c:\mydirectory\myfile.js" readmethod:"file" diff:"c:\myotherfile.js"
+> node node-local.js source:"c:\mydirectory\myfile.js" mode:"beautify" readmethod:"file" output:"c:\output\otherfile.js"
+> node node-local.js source:"../package.json" mode:"beautify" readmethod:"filescreen"
+
+Manage with biddle
+
+> biddle install http://prettydiff.com/downloads/prettydiff/prettydiff_latest.zip
+> biddle global prettydiff
+> prettydiff source:"c:\mydirectory\myfile.js" readmethod:"file" diff:"c:\myotherfile.js"
+
+*/
+//schema for global.prettydiff.meta
+//lang - array, language detection
+//time - string, proctime (total execution time minus visual rendering)
+//insize - number, input size
+//outsize - number, output size
+//difftotal - number, difference count
+//difflines - number, difference lines
+(function pdNodeLocal() {
+    "use strict";
+    var startTime      = process.hrtime(),
+        node           = {
+            fs   : require("fs"),
+            http : require("http"),
+            https: require("https"),
+            path : require("path")
+        },
+        localPath      = (process.cwd() === "/" || (/^([a-z]:\\)$/).test(process.cwd()) === true)
+            ? __dirname.replace(/(api)$/, "")
+            : "../",
+        cwd            = (process.cwd() === "/")
+            ? __dirname
+            : process.cwd(),
+        options        = {},
+        diffCount      = [
+            0, 0, 0, 0, 0
+        ],
+        method         = "auto",
+        langauto       = false,
+        prettydiff     = function pdNodeLocal__prettydiff() {
+            var lang       = (function pdNodeLocal__prettydiff_lang() {
+                    if (langauto === true) {
+                        options.lang = "auto";
+                    }
+                    return options.lang;
+                }()),
+                pdresponse = global.prettydiff.prettydiff(options),
+                data       = (options.nodeasync === true)
+                    ? (options.mode === "parse" && method !== "screen" && method !== "filescreen" && options.parseFormat !== "htmltable")
+                        ? JSON.stringify(pdresponse[0])
+                        : pdresponse[0]
+                    : (options.mode === "parse" && method !== "screen" && method !== "filescreen" && options.parseFormat !== "htmltable")
+                        ? JSON.stringify(pdresponse)
+                        : pdresponse,
+                meta       = (options.nodeasync === true)
+                    ? pdresponse[1]
+                    : global.prettydiff.meta;
+            if (options.nodeerror === true) {
+                console.log(meta.error);
+            }
+            diffCount[0] = diffCount[0] + meta.difftotal;
+            if (meta.difftotal > 0) {
+                diffCount[1] = diffCount[1] + 1;
+            }
+            diffCount[2] = diffCount[2] + 1;
+            diffCount[3] = diffCount[3] + meta.insize;
+            diffCount[4] = diffCount[4] + meta.outsize;
+            if (options.diffcli === true) {
+                return pdresponse;
+            }
+            if (typeof pdresponse === "string") {
+                pdresponse = pdresponse.replace(/(\s+)$/, "");
+            }
+            if (meta.error !== "") {
+                global.prettydiff.finalFile.order[9] = "<p><strong>Error:</strong> " + meta.error + "</p>";
+            }
+            if (options.mode === "diff" || options.mode === "analysis" || (options.mode === "parse" && options.parseFormat === "htmltable")) {
+                global.prettydiff.finalFile.order[7]  = options.color;
+                global.prettydiff.finalFile.order[10] = data;
+                if (options.jsscope !== "none" && options.mode === "beautify" && (options.lang === "javascript" || options.lang === "auto")) {
+                    global.prettydiff.finalFile.order[12] = global.prettydiff.finalFile.script.beautify;
+                } else if (options.mode === "diff") {
+                    global.prettydiff.finalFile.order[12] = global.prettydiff.finalFile.script.diff;
+                }
+                return global.prettydiff.finalFile.order.join("");
+            }
+            if (lang === null) {
+                return lang;
+            }
+            return data;
+        },
+        sfiledump      = [],
+        dfiledump      = [],
+        sState         = [],
+        dState         = [],
+        clidata        = [
+            [], [], []
+        ],
+        lf             = "\n",
+        dir            = [
+            0, 0, 0
+        ],
+        address        = {
+            dabspath: "",
+            dorgpath: "",
+            oabspath: "",
+            oorgpath: "",
+            sabspath: "",
+            sorgpath: ""
+        },
+        help           = false,
+        total          = [
+            0, 0
+        ],
+        colors         = {
+            del     : {
+                charEnd  : "\u001B[22m",
+                charStart: "\u001B[1m",
+                lineEnd  : "\u001B[39m",
+                lineStart: "\u001B[31m"
+            },
+            filepath: {
+                end  : "\u001B[39m",
+                start: "\u001B[36m"
+            },
+            ins     : {
+                charEnd  : "\u001B[22m",
+                charStart: "\u001B[1m",
+                lineEnd  : "\u001B[39m",
+                lineStart: "\u001B[32m"
+            }
+        },
+        enderflag      = false,
+
+        //ending messaging with stats
+        ender          = function pdNodeLocal__ender() {
+            var plural = (function pdNodeLocal__ender_plural() {
+                    var a   = 0,
+                        len = diffCount.length,
+                        arr = [];
+                    for (a = 0; a < len; a = a + 1) {
+                        if (diffCount[a] === 1) {
+                            arr.push("");
+                        } else {
+                            arr.push("s");
+                        }
+                    }
+                    if (clidata[1].length === 1) {
+                        arr.push("");
+                    } else {
+                        arr.push("s");
+                    }
+                    if (clidata[0].length === 1) {
+                        arr.push("");
+                    } else {
+                        arr.push("s");
+                    }
+                    return arr;
+                }()),
+                log    = [],
+                time   = 0;
+            if (enderflag === true) {
+                return;
+            }
+            if (options.endquietly !== "log" && options.summaryonly === false && options.diffcli === false && (method === "filescreen" || method === "screen")) {
+                return;
+            }
+
+            // indexes of diffCount array
+            //* 0 - total number of differences
+            //* 1 - the number of files containing those differences
+            //* 2 - total file count (not counting (sub)directories)
+            //* 3 - total input size (in characters from all files)
+            //* 4 - total output size (in characters from all files)
+            if ((method !== "directory" && method !== "subdirectory") || sfiledump.length === 1) {
+                plural[1] = "";
+            }
+            if (options.diffcli === true && options.mode === "diff") {
+                if (options.summaryonly === true && options.readmethod !== "screen" && clidata[2].length > 0) {
+                    log.push(lf + "Files changed:" + lf);
+                    log.push(colors.filepath.start);
+                    log.push(clidata[2].join(lf));
+                    log.push(colors.filepath.end);
+                    log.push(lf + lf);
+                }
+                if (clidata[0].length > 0) {
+                    log.push(lf + "Files deleted:" + lf);
+                    log.push(colors.del.lineStart);
+                    log.push(clidata[0].join(lf));
+                    log.push(colors.del.lineEnd);
+                    log.push(lf + lf);
+                }
+                if (clidata[1].length > 0) {
+                    log.push(lf + "Files inserted:" + lf);
+                    log.push(colors.ins.lineStart);
+                    log.push(clidata[1].join(lf));
+                    log.push(colors.ins.lineEnd);
+                    log.push(lf + lf);
+                }
+            }
+            log.push(lf + "Pretty Diff ");
+            if (options.mode === "diff") {
+                if (method !== "directory" && method !== "subdirectory") {
+                    log.push("found ");
+                    log.push(diffCount[0]);
+                    if (diffCount[1] < 0) {
+                        log.push("+");
+                    }
+                    log.push(" difference");
+                    log.push(plural[0]);
+                    log.push(". ");
+                } else {
+                    log.push("found ");
+                    log.push(diffCount[0]);
+                    log.push(" difference");
+                    log.push(plural[0]);
+                    log.push(" in ");
+                    log.push(diffCount[1]);
+                    log.push(" file");
+                    log.push(plural[1]);
+                    log.push(" out of ");
+                }
+            } else if (options.mode === "beautify") {
+                log.push("beautified ");
+            } else if (options.mode === "minify") {
+                log.push("minified ");
+            } else if (options.mode === "parse") {
+                log.push("parsed ");
+            }
+            if (options.mode !== "diff" || method === "directory" || method === "subdirectory") {
+                log.push(diffCount[2]);
+                log.push(" file");
+                log.push(plural[2]);
+                log.push(". ");
+            }
+            if (options.mode === "diff" && (method === "directory" || method === "subdirectory")) {
+                log.push(clidata[1].length);
+                log.push(" file");
+                log.push(plural[2]);
+                log.push(" added. ");
+                log.push(clidata[0].length);
+                log.push(" file");
+                log.push(plural[3]);
+                log.push(" deleted. Executed in ");
+            } else {
+                log.push("Executed in ");
+            }
+            time = (function pdNodeLocal_ender_time() {
+                var endtime = process.hrtime(),
+                    dtime   = [endtime[0] - startTime[0], endtime[1] - startTime[1]],
+                    strTime = "";
+                if (dtime[1] === 0) {
+                    return dtime[0] + "";
+                }
+                if (dtime[1] < 0) {
+                    dtime[1] = ((1000000000 + endtime[1]) - startTime[1]);
+                }
+                strTime = dtime[1] + "";
+                if (strTime.length < 9) {
+                    do {
+                        strTime = strTime + 0;
+                    } while (strTime.length < 9);
+                } else if (strTime.length > 9) {
+                    strTime = strTime.slice(0, 9);
+                }
+                return dtime[0] + "." + strTime;
+            }());
+            log.push(time);
+            log.push(" second");
+            if (time !== 1) {
+                log.push("s");
+            }
+            log.push("." + lf);
+            console.log(log.join(""));
+            enderflag = true;
+        },
+
+        //write output to a file executed from fileComplete
+        fileWrite      = function pdNodeLocal__fileWrite(data) {
+            var dirs     = data
+                    .localpath
+                    .split(node.path.sep),
+                suffix   = (options.mode === "diff")
+                    ? "-diff.html"
+                    : "-report.html",
+                filename = dirs[dirs.length - 1],
+                count    = 1,
+                writing  = function pdNodeLocal__fileWrite_writing(ending, dataA) {
+                    if (dataA.binary === true) {
+                        //binary
+                        node
+                            .fs
+                            .writeFile(dataA.finalpath, dataA.file, function pdNodeLocal__fileWrite_writing_writeFileBinary(err) {
+                                if (err !== null) {
+                                    console.log(lf + "Error writing binary output." + lf);
+                                    console.log(err);
+                                }
+                                total[1] = total[1] + 1;
+                                if (total[1] === total[0]) {
+                                    ender();
+                                }
+                            });
+                    } else if (dataA.file === "") {
+                        //empty files
+                        node
+                            .fs
+                            .writeFile(dataA.finalpath + ending, "", function pdNodeLocal__fileWrite_writing_writeFileEmpty(err) {
+                                if (err !== null) {
+                                    console.log(lf + "Error writing empty output." + lf);
+                                    console.log(err);
+                                } else if (method === "file" && options.endquietly !== "quiet") {
+                                    console.log(lf + "Empty file successfully written to file.");
+                                }
+                                total[1] = total[1] + 1;
+                                if (total[1] === total[0]) {
+                                    ender();
+                                }
+                            });
+                    } else {
+                        node
+                            .fs
+                            .writeFile(dataA.finalpath + ending, dataA.file, function pdNodeLocal__fileWrite_writing_writeFileText(err) {
+                                if (err !== null) {
+                                    console.log(lf + "Error writing file output." + lf);
+                                    console.log(err);
+                                } else if (method === "file" && options.endquietly !== "quiet") {
+                                    if (ending.indexOf("-report") === 0) {
+                                        console.log(lf + "Report successfully written to file.");
+                                    } else {
+                                        console.log(lf + "File successfully written.");
+                                    }
+                                }
+                                total[1] = total[1] + 1;
+                                if (total[1] === total[0]) {
+                                    ender();
+                                }
+                            });
+                    }
+                },
+                files    = function pdNodeLocal__fileWrite_files(dataB) {
+                    if (dataB.binary === true) {
+                        writing("", dataB);
+                    } else if (options.mode === "diff" || options.mode === "analysis" || (options.mode === "beautify" && options.jsscope !== "none")) {
+                        writing(suffix, dataB);
+                    } else {
+                        writing("", dataB);
+                    }
+                },
+                newdir   = function pdNodeLocal__fileWrite_newdir(dataC) {
+                    node
+                        .fs
+                        .mkdir(address.oabspath + dirs.slice(0, count).join(node.path.sep), function pdNodeLocal__fileWrite_newdir_callback() {
+                            count = count + 1;
+                            if (count < dirs.length) {
+                                pdNodeLocal__fileWrite_newdir(dataC);
+                            } else {
+                                files(dataC);
+                            }
+                        });
+                };
+            options.source = sfiledump[data.index];
+            if (options.mode === "diff") {
+                if (method === "file") {
+                    data.finalpath = options.output;
+                } else {
+                    data.finalpath = address.oabspath + dirs.join("__") + "__" + filename;
+                }
+                options.diff   = dfiledump[data.index];
+            } else if (method === "file") {
+                data.finalpath = options.output;
+            } else {
+                data.finalpath = address.oabspath + dirs.join(node.path.sep);
+            }
+            if (data.binary === true) {
+                if (dirs.length > 1 && options.mode !== "diff") {
+                    newdir(data);
+                } else {
+                    files(data);
+                }
+                return;
+            }
+            data.file = prettydiff();
+            if (global.prettydiff.meta.error !== "") {
+                if (data.last === true) {
+                    ender();
+                }
+                console.log("Error with file: " + data.localpath);
+                console.log(global.prettydiff.meta.error);
+                console.log("");
+            }
+            if (dirs.length > 1 && options.mode !== "diff") {
+                newdir(data);
+            } else {
+                files(data);
+            }
+        },
+
+        //write output to terminal for diffcli option
+        cliWrite       = function pdNodeLocal__cliWrite(output, itempath, last) {
+            var a      = 0,
+                plural = "",
+                pdlen  = output.length;
+            if (options.summaryonly === true) {
+                clidata[2].push(itempath);
+                if (method === "screen" || method === "filescreen") {
+                    return ender();
+                }
+            } else {
+                if (diffCount[0] !== 1) {
+                    plural = "s";
+                }
+                if (options.readmethod === "screen" || (options.readmethod === "auto" && method === "screen")) {
+                    console.log(lf + "Screen input with " + diffCount[0] + " difference" + plural);
+                }
+                for (a = 0; a < pdlen; a = a + 1) {
+                    if (output[a].indexOf("\u001b[36m") === 0 && itempath !== "") {
+                        console.log("\u001b[36m" + itempath + "\u001b[39m");
+                    }
+                    console.log(output[a]);
+                }
+            }
+            if (last === true) {
+                ender();
+            }
+        },
+
+        //write output to screen executed from fileComplete
+        screenWrite    = function pdNodeLocal__screenWrite() {
+            var report = [];
+            if (options.mode === "diff" && options.diffcli === true) {
+                return cliWrite(prettydiff(), "", false);
+            }
+            if (options.mode === "diff") {
+                return console.log(prettydiff());
+            }
+            if (options.jsscope !== "none" && options.mode === "beautify" && (options.lang === "javascript" || options.lang === "auto")) {
+                return console.log(prettydiff());
+            }
+            report = prettydiff();
+            if (options.mode === "parse" && options.parseFormat !== "htmltable") {
+                report = JSON.stringify(report);
+            }
+            total[1] = total[1] + 1;
+            console.log(report);
+            if (total[0] === total[1] || options.readmethod === "screen" || options.readmethod === "auto") {
+                ender();
+            }
+        },
+
+        //generate the diff output for CLI from files
+        cliFile        = function pdNodeLocal__cliFile(data) {
+            options.source = sfiledump[data.index];
+            options.diff   = dfiledump[data.index];
+            if (options.source.indexOf("undefined") === 0) {
+                options.source = options
+                    .source
+                    .replace("undefined", "");
+            }
+            if (options.diff.indexOf("undefined") === 0) {
+                options.diff = options
+                    .diff
+                    .replace("undefined", "");
+            }
+            if (typeof options.context !== "number" || options.context < 0) {
+                console.log(lf + colors.filepath.start + data.localpath + colors.filepath.end);
+            }
+            cliWrite(prettydiff(), data.localpath, data.last);
+        },
+
+        // is a file read operation complete? executed from readLocalFile executed from
+        // readHttpFile
+        fileComplete   = function pdNodeLocal__fileComplete(data) {
+            var totalCalc = function pdNodeLocal__fileComplete_totalCalc() {
+                total[1] = total[1] + 1;
+                if (total[1] === total[0]) {
+                    ender();
+                }
+            };
+            if (data.binary === true) {
+                total[0] = total[0] - 1;
+            }
+            if (options.mode !== "diff" || (options.mode === "diff" && data.type === "diff")) {
+                total[0] = total[0] + 1;
+            }
+            if (data.type === "diff") {
+                dfiledump[data.index] = data.file;
+                dState[data.index]    = true;
+            } else {
+                sfiledump[data.index] = data.file;
+                sState[data.index]    = true;
+            }
+            if (data.index !== sfiledump.length - 1) {
+                data.last = false;
+            }
+            if (sState[data.index] === true && ((options.mode === "diff" && dState[data.index] === true) || options.mode !== "diff")) {
+                if (options.mode === "diff" && sfiledump[data.index] !== dfiledump[data.index]) {
+                    if (dfiledump[data.index] === "" || dfiledump[data.index] === "\n") {
+                        total[1]     = total[1] + 1;
+                        console.log("Diff file at " + data.localpath + " is \u001B[31mempty\u001B[39m but the source file is not.");
+                        if (total[0] === total[1]) {
+                            ender();
+                        }
+                    } else if (sfiledump[data.index] === "" || sfiledump[data.index] === "\n") {
+                        total[1]     = total[1] + 1;
+                        console.log("Source file at " + data.localpath + " is \u001B[31mempty\u001B[39m but the diff file is not.");
+                        if (total[0] === total[1]) {
+                            ender();
+                        }
+                    } else if (options.diffcli === true) {
+                        cliFile(data);
+                    } else if (method === "filescreen") {
+                        options.diff   = dfiledump[data.index];
+                        options.source = sfiledump[data.index];
+                        screenWrite();
+                    } else if (method === "file" || method === "directory" || method === "subdirectory") {
+                        fileWrite(data);
+                    }
+                    sState[data.index] = false;
+                    if (options.mode === "diff") {
+                        dState[data.index] = false;
+                    }
+                } else if (options.mode !== "diff" && (method === "file" || method === "directory" || method === "subdirectory")) {
+                    fileWrite(data);
+                } else if (options.mode !== "diff" && (method === "screen" || method === "filescreen")) {
+                    options.source = data.file;
+                    screenWrite();
+                } else {
+                    totalCalc();
+                }
+            }
+        },
+
+        //read from a binary file
+        readBinaryFile = function pdNodeLocal__readBinaryFile(data) {
+            node
+                .fs
+                .open(data.absolutepath, "r", function pdNodeLocal__readBinaryFile_open(err, fd) {
+                    var buff = new Buffer(data.size);
+                    if (err !== null) {
+                        return pdNodeLocal__readBinaryFile(data);
+                    }
+                    node
+                        .fs
+                        .read(fd, buff, 0, data.size, 0, function pdNodeLocal__readBinaryFile_open_read(erra, bytesRead, buffer) {
+                            if (erra !== null) {
+                                return pdNodeLocal__readBinaryFile(data);
+                            }
+                            if (bytesRead > 0) {
+                                data.file = buffer;
+                            }
+                            fileComplete(data);
+                        });
+                });
+        },
+
+        //read from a file and determine if text
+        readLocalFile  = function pdNodeLocal__readLocalFile(data) {
+            var open = function pdNodeLocal__readLocalFile_open() {
+                node
+                    .fs
+                    .open(data.absolutepath, "r", function pdNodeLocal__readLocalFile_open_callback(err, fd) {
+                        var msize = (data.size < 100)
+                                ? data.size
+                                : 100,
+                            buff  = new Buffer(msize);
+                        if (err !== null) {
+                            return pdNodeLocal__readLocalFile(data);
+                        }
+                        node
+                            .fs
+                            .read(fd, buff, 0, msize, 1, function pdNodeLocal__readLocalFile_open_callback_read(erra, bytes, buffer) {
+                                if (erra !== null) {
+                                    return pdNodeLocal__readLocalFile(data);
+                                }
+                                var bstring = buffer.toString("utf8", 0, buffer.length);
+                                bstring = bstring.slice(2, bstring.length - 2);
+                                if ((/[\u0002-\u0008]|[\u000e-\u001f]/).test(bstring) === true) {
+                                    data.binary = true;
+                                    readBinaryFile(data);
+                                } else {
+                                    data.binary = false;
+                                    node
+                                        .fs
+                                        .readFile(data.absolutepath, {
+                                            encoding: "utf8"
+                                        }, function pdNodeLocal__readLocalFile_open_callback_read_readFile(errb, dump) {
+                                            if (errb !== null && errb !== undefined) {
+                                                return pdNodeLocal__readLocalFile(data);
+                                            }
+                                            if (data.file === undefined) {
+                                                data.file = "";
+                                            }
+                                            data.file = data.file + dump;
+                                            fileComplete(data);
+                                            return bytes;
+                                        });
+                                }
+                            });
+                    });
+            };
+            if (data.size === undefined) {
+                node
+                    .fs
+                    .stat(data.absolutepath, function pdNodeLocal__readLocalFile_stat(errx, stat) {
+                        if (errx !== null) {
+                            if ((typeof errx === "string" && errx.indexOf("no such file or directory") > 0) || (typeof errx === "object" && errx.code === "ENOENT")) {
+                                return console.log(errx);
+                            }
+                            return pdNodeLocal__readLocalFile(data);
+                        }
+                        data.size = stat.size;
+                        if (data.size > 0) {
+                            open();
+                        } else {
+                            data.binary = false;
+                            data.file   = "";
+                            fileComplete(data);
+                        }
+                    });
+            } else {
+                if (data.size > 0) {
+                    open();
+                } else {
+                    data.binary = false;
+                    fileComplete(data);
+                }
+            }
+        },
+
+        //resolve file contents from a web address executed from init
+        readHttpFile   = function pdNodeLocal__readHttpFile(data) {
+            var file     = "",
+                protocol = data.absolutepath.indexOf("s://"),
+                callback = function pdNodeLocal__readHttpFile_callback(res) {
+                    res.setEncoding("utf8");
+                    res.on("data", function pdNodeLocal__readHttpFile_callback_response(chunk) {
+                        file = file + chunk;
+                    });
+                    res.on("end", function pdNodeLocal__readHttpFile_callback_end() {
+                        data.file = file;
+                        if (data.type === "diff") {
+                            dfiledump[data.index] = file;
+                        } else {
+                            sfiledump[data.index] = file;
+                        }
+                        fileComplete(data);
+                    });
+                    res.on("error", function pdNodeLocal__readHttpFile_callback_error(error) {
+                        console.log("Error downloading file via HTTP:");
+                        console.log("");
+                        console.log(error);
+                    });
+                };
+            if (protocol > 0 && protocol < 10) {
+                node
+                    .https
+                    .get(data.absolutepath, callback);
+            } else {
+                node
+                    .http
+                    .get(data.absolutepath, callback);
+            }
+        },
+
+        //gather files in directory and sub directories executed from init
+        directory      = function pdNodeLocal__directory() {
+            // the following four are necessary because you can walk a directory tree from a
+            // relative path but you cannot read file contents with a relative path in node
+            // at this time
+            var sfiles  = {
+                    abspath    : [],
+                    count      : 0,
+                    directories: 1,
+                    filepath   : [],
+                    total      : 0
+                },
+                dfiles  = {
+                    abspath    : [],
+                    count      : 0,
+                    directories: 1,
+                    filepath   : [],
+                    total      : 0
+                },
+                readDir = function pdNodeLocal__directory_readDir(start, listtype) {
+                    node
+                        .fs
+                        .stat(start, function pdNodeLocal__directory_readDir_stat(erra, stat) {
+                            var item    = {},
+                                dirtest = function pdNodeLocal__directory_readDir_stat_dirtest(itempath) {
+                                    var pusher     = function pdNodeLocal__directory_readDir_stat_dirtest_pusher(itempath) {
+                                            if (listtype === "diff") {
+                                                dfiles
+                                                    .filepath
+                                                    .push([
+                                                        itempath.replace(address.dabspath + node.path.sep, ""),
+                                                        itempath
+                                                    ]);
+                                            } else if (listtype === "source") {
+                                                sfiles
+                                                    .filepath
+                                                    .push([
+                                                        itempath.replace(address.sabspath + node.path.sep, ""),
+                                                        itempath
+                                                    ]);
+                                            }
+                                            item.count = item.count + 1;
+                                        },
+                                        preprocess = function pdNodeLocal__directory_readDir_stat_dirtest_stat_preprocess() {
+                                            var b      = 0,
+                                                length = (options.mode === "diff")
+                                                    ? Math.min(sfiles.filepath.length, dfiles.filepath.length)
+                                                    : sfiles.filepath.length,
+                                                end    = false,
+                                                sizer  = function pdNodeLocal__directory_readDir_stat_dirtest_stat_preprocess_sizer(index, type, filename, finalone) {
+                                                    node
+                                                        .fs
+                                                        .stat(filename[1], function pdNodeLocal__directory_readDir_stat_dirtest_stat_preprocess_sizer_stat(errc, statb) {
+                                                            var filesize = 0;
+                                                            if (errc === null) {
+                                                                filesize = statb.size;
+                                                            }
+                                                            readLocalFile({
+                                                                absolutepath: filename[1],
+                                                                index       : index,
+                                                                last        : finalone,
+                                                                localpath   : filename[0],
+                                                                size        : filesize,
+                                                                type        : type
+                                                            });
+                                                        });
+                                                },
+                                                sorter = function pdNodeLocal__directory_readDir_stat_dirtest_stat_preprocess_sorter(a, b) {
+                                                    if (a[0] < b[0]) {
+                                                        return -1;
+                                                    }
+                                                    return 1;
+                                                };
+                                            sfiles
+                                                .filepath
+                                                .sort(sorter);
+                                            if (options.mode === "diff") {
+                                                dfiles
+                                                    .filepath
+                                                    .sort(sorter);
+                                                for (b = 0; b < length; b = b + 1) {
+                                                    dState.push(false);
+                                                    sState.push(false);
+                                                    sfiledump.push("");
+                                                    dfiledump.push("");
+                                                    if (sfiles.filepath[b][0] === dfiles.filepath[b][0]) {
+                                                        if (b === length - 1) {
+                                                            end = true;
+                                                        }
+                                                        sizer(b, "diff", dfiles.filepath[b], end);
+                                                        sizer(b, "source", sfiles.filepath[b], end);
+                                                    } else {
+                                                        if (sfiles.filepath[b][0] < dfiles.filepath[b][0]) {
+                                                            if (options.diffcli === true) {
+                                                                clidata[0].push(sfiles.filepath[b][0]);
+                                                            }
+                                                            if (length === dfiles.filepath.length) {
+                                                                length = length + 1;
+                                                            }
+                                                            dfiles
+                                                                .filepath
+                                                                .splice(b, 0, "");
+                                                        } else if (dfiles.filepath[b][0] < sfiles.filepath[b][0]) {
+                                                            if (options.diffcli === true) {
+                                                                clidata[1].push(dfiles.filepath[b][0]);
+                                                            }
+                                                            if (length === sfiles.filepath.length) {
+                                                                length = length + 1;
+                                                            }
+                                                            sfiles
+                                                                .filepath
+                                                                .splice(b, 0, "");
+                                                        }
+                                                        if (b === length - 1) {
+                                                            ender();
+                                                        }
+                                                    }
+                                                }
+                                            } else {
+                                                if (options.output !== "") {
+                                                    for (b = 0; b < length; b = b + 1) {
+                                                        if (b === length - 1) {
+                                                            end = true;
+                                                        }
+                                                        if (sfiles.filepath[b] !== undefined) {
+                                                            sizer(b, "source", sfiles.filepath[b], end);
+                                                        }
+                                                    }
+                                                } else {
+                                                    ender();
+                                                }
+                                            }
+                                        };
+                                    if (itempath === "") {
+                                        preprocess();
+                                    } else {
+                                        node
+                                            .fs
+                                            .stat(itempath, function pdNodeLocal__directory_readDir_stat_dirtest_stat(errb, stata) {
+                                                if (errb !== null) {
+                                                    return console.log(errb);
+                                                }
+                                                if (stata.isDirectory() === true) {
+                                                    if (method === "subdirectory") {
+                                                        item.directories = item.directories + 1;
+                                                        pdNodeLocal__directory_readDir(itempath, listtype);
+                                                        item.count = item.count + 1;
+                                                    }
+                                                    if (method === "directory") {
+                                                        item.total       = item.total - 1;
+                                                        item.directories = 0;
+                                                    }
+                                                } else if (stata.isFile() === true) {
+                                                    pusher(itempath);
+                                                } else {
+                                                    if (listtype === "diff") {
+                                                        dfiles.total = dfiles.total - 1;
+                                                    } else {
+                                                        sfiles.total = sfiles.total - 1;
+                                                    }
+                                                    console.log(itempath + lf + "is an unsupported type");
+                                                }
+                                                if (options.mode === "diff" && sfiles.count === sfiles.total && dfiles.count === dfiles.total && sfiles.directories === 0 && dfiles.directories === 0)  {
+                                                    return preprocess();
+                                                }
+                                                if (options.mode !== "diff" && item.directories === 0 && item.count === item.total) {
+                                                    return preprocess();
+                                                }
+                                            });
+                                    }
+                                };
+                            if (erra !== null) {
+                                return console.log(erra);
+                            }
+                            if (stat.isDirectory() === true) {
+                                node
+                                    .fs
+                                    .readdir(start, function pdNodeLocal__directory_readDir_stat_readdir(errd, files) {
+                                        var x         = 0,
+                                            filetotal = files.length;
+                                        if (errd !== null || filetotal === 0) {
+                                            if (method === "subdirectory") {
+                                                if (listtype === "diff") {
+                                                    dfiles.directories = dfiles.directories - 1;
+                                                } else {
+                                                    sfiles.directories = sfiles.directories - 1;
+                                                }
+                                            }
+                                            if (errd !== null) {
+                                                return console.log(errd);
+                                            }
+                                            if ((options.mode === "diff" && sfiles.count === sfiles.total && dfiles.count === dfiles.total && sfiles.directories === 0 && dfiles.directories === 0) || (options.mode !== "diff" && sfiles.directories === 0 && sfiles.count === sfiles.total)) {
+                                                dirtest("");
+                                            }
+                                            return;
+                                        }
+                                        if (listtype === "diff") {
+                                            item = dfiles;
+                                        } else {
+                                            item = sfiles;
+                                        }
+                                        item.total = item.total + filetotal;
+                                        for (x = 0; x < filetotal; x = x + 1) {
+                                            if (x === filetotal - 1) {
+                                                item.directories = item.directories - 1;
+                                                dirtest(start + node.path.sep + files[x]);
+                                            } else {
+                                                dirtest(start + node.path.sep + files[x]);
+                                            }
+                                        }
+                                    });
+                            } else {
+                                return console.log("path: " + start + " is not a directory");
+                            }
+                        });
+                };
+            readDir(address.sabspath, "source");
+            if (options.mode === "diff") {
+                readDir(address.dabspath, "diff");
+            }
+        };
+
+    global.prettydiff              = {};
+    global.prettydiff.language     = require(localPath + "lib/language.js");
+    global.prettydiff.safeSort     = require(localPath + "lib/safeSort.js");
+    global.prettydiff.options      = require(localPath + "lib/options.js");
+    global.prettydiff.csspretty    = require(localPath + "lib/csspretty.js");
+    global.prettydiff.csvpretty    = require(localPath + "lib/csvpretty.js");
+    global.prettydiff.diffview     = require(localPath + "lib/diffview.js");
+    global.prettydiff.finalFile    = require(localPath + "lib/finalFile.js");
+    global.prettydiff.jspretty     = require(localPath + "lib/jspretty.js");
+    global.prettydiff.markuppretty = require(localPath + "lib/markuppretty.js");
+    global.prettydiff.prettydiff   = require(localPath + "prettydiff.js");
+    options                        = global.prettydiff.options;
+
+    //defaults for the options
+    (function pdNodeLocal__start() {
+        var argument  = process
+                .argv
+                .slice(2),
+            opreturn  = [],
+            alphasort = false,
+            outready  = false,
+            pdrcpath  = __dirname.replace(/(api)$/, "") + ".prettydiffrc",
+            pathslash = function pdNodeLocal__start_pathslash(name, x) {
+                var y        = x.indexOf("://"),
+                    z        = "",
+                    itempath = "",
+                    ind      = "",
+                    odirs    = [],
+                    olen     = 0,
+                    basepath = "",
+                    makeout  = function pdNodeLocal__start_pathslash_makeout() {
+                        basepath = basepath + odirs[olen];
+                        basepath = basepath.replace(/(\/|\\)+$/, "") + node.path.sep;
+                        node
+                            .fs
+                            .mkdir(basepath, function pdNodeLocal__start_pathslash_makeout_mkdir(err) {
+                                if (err !== undefined && err !== null && err.code !== "EEXIST") {
+                                    console.log(err);
+                                    outready = true;
+                                } else if (olen < odirs.length) {
+                                    olen = olen + 1;
+                                    if (olen < odirs.length) {
+                                        pdNodeLocal__start_pathslash_makeout();
+                                    } else {
+                                        outready = true;
+                                    }
+                                } else {
+                                    outready = true;
+                                }
+                            });
+                    },
+                    abspath  = function pdNodeLocal__start_pathslash_abspath() {
+                        var tree  = cwd.split(node.path.sep),
+                            ups   = [],
+                            uplen = 0;
+                        if (itempath.indexOf("..") === 0) {
+                            ups   = itempath
+                                .replace(/\.\.\//g, ".." + node.path.sep)
+                                .split(".." + node.path.sep);
+                            uplen = ups.length;
+                            do {
+                                uplen = uplen - 1;
+                                tree.pop();
+                            } while (uplen > 1);
+                            return tree.join(node.path.sep) + node.path.sep + ups[ups.length - 1];
+                        }
+                        if ((/^([a-z]:(\\|\/))/).test(itempath) === true || itempath.indexOf(node.path.sep) === 0) {
+                            return itempath;
+                        }
+                        return node.path.join(cwd, itempath);
+                    };
+                if (name === "diff") {
+                    ind = 0;
+                }
+                if (name === "output") {
+                    ind = 1;
+                }
+                if (name === "source") {
+                    ind = 2;
+                }
+                if (x.indexOf("http://") === 0 || x.indexOf("https://") === 0) {
+                    dir[ind] = 3;
+                    return x;
+                }
+                if (y < 0) {
+                    itempath = x.replace(/\\/g, "/");
+                } else {
+                    z        = x.slice(0, y);
+                    x        = x.slice(y + 3);
+                    itempath = z + "://" + x.replace(/\\/g, "/");
+                }
+                node
+                    .fs
+                    .stat(itempath, function pdNodeLocal__start_pathslash_stat(err, stat) {
+                        if (err !== null) {
+                            dir[ind] = -1;
+                            return "";
+                        }
+                        if (stat.isDirectory() === true) {
+                            dir[ind] = 1;
+                        } else if (stat.isFile() === true) {
+                            dir[ind] = 2;
+                            if (name === "output") {
+                                outready = true;
+                            }
+                        } else {
+                            dir[ind] = -1;
+                            if (name === "output") {
+                                outready = true;
+                            }
+                        }
+                    });
+                if (name === "diff") {
+                    address.dabspath = abspath();
+                    address.dorgpath = itempath;
+                }
+                if (name === "output") {
+                    if (method === "file") {
+                        outready = true;
+                    } else if (x === ".") {
+                        address.oabspath = cwd;
+                        address.oorgpath = cwd;
+                        outready         = true;
+                    } else {
+                        itempath         = itempath.replace(/\//g, node.path.sep);
+                        address.oabspath = abspath();
+                        address.oorgpath = itempath;
+                        if (address.oabspath.charAt(address.oabspath.length - 1) !== node.path.sep) {
+                            address.oabspath = address.oabspath + node.path.sep;
+                        }
+                        basepath = address
+                            .oabspath
+                            .replace(node.path.sep + address.oorgpath, "");
+                        odirs    = address
+                            .oorgpath
+                            .split(node.path.sep);
+                        if (odirs[0] === "..") {
+                            (function pdNodeLocal__start_pathslash_stat() {
+                                var abs = node
+                                        .path
+                                        .resolve()
+                                        .split(node.path.sep),
+                                    a   = 0;
+                                do {
+                                    a = a + 1;
+                                } while (odirs[a] === "..");
+                                odirs.splice(0, a);
+                                abs.splice(0, a);
+                                do {
+                                    odirs.splice(0, 0, abs.pop());
+                                } while (abs.length > 0);
+                                if (node.path.sep === "/") {
+                                    odirs.splice(0, 0, "");
+                                }
+                            }());
+                        }
+                        if (options.readmethod === "file") {
+                            odirs.pop();
+                        }
+                        makeout();
+                    }
+                }
+                if (name === "source") {
+                    address.sabspath = abspath();
+                    address.sorgpath = itempath;
+                }
+                return itempath;
+            };
+        opreturn = options.functions.node(argument);
+        help     = opreturn[0];
+        langauto = opreturn[1];
+        if (options.diff !== "") {
+            options.diff = pathslash("diff", options.diff);
+        }
+        if (options.output !== "") {
+            options.output = pathslash("output", options.output);
+        }
+        if (options.source !== "") {
+            options.source = pathslash("source", options.source);
+        }
+        method = options.readmethod;
+        options.api = "none";
+        if (options.output === "") {
+            outready = true;
+        }
+        if (options.endquietly === "quiet") {
+            enderflag = true;
+        }
+        if (options.crlf === true) {
+            lf = "\r\n";
+        }
+
+        node
+            .fs
+            .stat(pdrcpath, function pdNodeLocal__start_stat(err, stats) {
+                var init = function pdNodeLocal__start_stat_init() {
+                    var state   = false,
+                        cliflag = false,
+                        status  = function pdNodeLocal__start_stat_init_status() {
+                            var tempaddy = "";
+                            // status codes
+                            //* -1 is not file or directory
+                            //* 0 is status pending
+                            //* 1 is directory
+                            //* 2 is file 3 is file via http/s
+                            //
+                            //* dir[0] - diff
+                            //* dir[1] - output
+                            //* dir[2] - source
+                            if (dir[2] === 0) {
+                                return;
+                            }
+                            if (method === "auto") {
+                                if (dir[2] === 1) {
+                                    method = "subdirectory";
+                                } else if (dir[2] > 1) {
+                                    if (options.output === "") {
+                                        method = "filescreen";
+                                    } else {
+                                        if (options.output === "" && options.mode !== "diff") {
+                                            console.log("");
+                                            console.log("\u001B[91mNo output option is specified, so no files written.\u001B[39m");
+                                            console.log("");
+                                        }
+                                        method = "file";
+                                        if (options.output === "") {
+                                            return console.log("Error: 'readmethod' is value 'file' and argument 'output' is empty");
+                                        }
+                                    }
+                                } else if (dir[2] < 0) {
+                                    method = "screen";
+                                }
+                            }
+                            if (dir[2] < 0) {
+                                state = true;
+                                if (options.readmethod === "screen" && options.mode !== "diff") {
+                                    return screenWrite();
+                                }
+                                if (options.readmethod !== "screen") {
+                                    if (options.readmethod === "auto") {
+                                        method = "screen";
+                                        if (options.mode !== "diff") {
+                                            return screenWrite();
+                                        }
+                                    } else {
+                                        return console.log("source is not a directory or file");
+                                    }
+                                }
+                            }
+                            if (dir[2] === 1 && method !== "directory" && method !== "subdirectory") {
+                                state = true;
+                                return console.log("source is a directory but readmethod option is not 'auto', 'directory', or 'subd" +
+                                        "irectory'");
+                            }
+                            if (dir[2] > 1) {
+                                if (method === "directory" || method === "subdirectory") {
+                                    state = true;
+                                    return console.log("source is a file but readmethod option is 'directory' or 'subdirectory'");
+                                }
+                                if (method === "screen") {
+                                    method = "filescreen";
+                                }
+                            }
+                            if (options.mode === "diff") {
+                                if (dir[0] === 0 || dir[2] === 0) {
+                                    return;
+                                }
+                                if (dir[0] < 0) {
+                                    state = true;
+                                    if (options.readmethod === "auto" || (dir[2] < 0 && options.readmethod === "screen")) {
+                                        if (options.readmethod === "auto" && method === "screen" && cliflag === true && options.diffcli === false) {
+                                            options.diffcli = false;
+                                        }
+                                        if (options.diffcli === true) {
+                                            return cliWrite(prettydiff(), "", false);
+                                        }
+                                        return screenWrite();
+                                    }
+                                    return console.log("diff is not a directory or file");
+                                }
+                                if (dir[0] === 1 && method !== "directory" && method !== "subdirectory") {
+                                    state = true;
+                                    return console.log("diff is a directory but readmethod option is not 'directory' or 'subdirectory'");
+                                }
+                                if (dir[0] > 2 && (method === "directory" || method === "subdirectory")) {
+                                    state = true;
+                                    return console.log("diff is a file but readmethod option is 'directory' or 'subdirectory'");
+                                }
+                                if (dir[0] > 1 && method === "screen") {
+                                    method = "filescreen";
+                                }
+                                if (dir[0] > 1 && dir[2] > 1 && (method === "file" || method === "filescreen")) {
+                                    state = true;
+                                    dState.push(false);
+                                    sState.push(false);
+                                    if (dir[0] === 3) {
+                                        readHttpFile({absolutepath: options.diff, index: 0, last: true, localpath: options.diff, type: "diff"});
+                                    } else {
+                                        tempaddy = options
+                                            .diff
+                                            .replace(/(\/|\\)/g, node.path.sep);
+                                        readLocalFile({absolutepath: tempaddy, index: 0, last: true, localpath: tempaddy, type: "diff"});
+                                    }
+                                    if (dir[2] === 3) {
+                                        readHttpFile({absolutepath: options.source, index: 0, last: true, localpath: options.source, type: "source"});
+                                    } else {
+                                        tempaddy = options
+                                            .source
+                                            .replace(/(\/|\\)/g, node.path.sep);
+                                        readLocalFile({absolutepath: tempaddy, index: 0, last: true, localpath: tempaddy, type: "source"});
+                                    }
+                                    return;
+                                }
+                                if (dir[0] === 1 && dir[2] === 1 && (method === "directory" || method === "subdirectory")) {
+                                    state = true;
+                                    options.nodeasync = true;
+                                    return directory();
+                                }
+                            } else {
+                                if (dir[2] > 1 && (method === "file" || method === "filescreen")) {
+                                    state = true;
+                                    sState.push(false);
+                                    if (dir[2] === 3) {
+                                        readHttpFile({absolutepath: options.source, index: 0, last: true, localpath: options.source, type: "source"});
+                                    } else {
+                                        readLocalFile({absolutepath: options.source, index: 0, last: true, localpath: options.source, type: "source"});
+                                    }
+                                    return;
+                                }
+                                if (dir[2] === 1 && (method === "directory" || method === "subdirectory")) {
+                                    state = true;
+                                    options.nodeasync = true;
+                                    return directory();
+                                }
+                            }
+                        },
+                        delay   = function pdNodeLocal__start_stat_init_delay() {
+                            if (state === false || outready === false) {
+                                status();
+                                setTimeout(function pdNodeLocal__start_stat_init_delay_setTimeout() {
+                                    pdNodeLocal__start_stat_init_delay();
+                                }, 50);
+                            }
+                        };
+                    if (alphasort === true) {
+                        options.objsort = "all";
+                    }
+                    if (options.mode !== "diff") {
+                        options.diffcli     = false;
+                        options.summaryonly = false;
+                    }
+                    if (options.summaryonly === true) {
+                        options.diffcli = true;
+                    }
+
+                    if (help === true) {
+                        return console.log(options.functions.consolePrint());
+                    }
+                    if (help === true && options.version === true) {
+                        return console.log(options.functions.versionString);
+                    }
+                    if (options.listoptions === true) {
+                        (function pdNodeLocal__start_stat_init_listoptions() {
+                            var sample = JSON.stringify(options),
+                                mode   = options.mode,
+                                source = options.source,
+                                vert   = options.vertical;
+                            options.mode     = "beautify";
+                            options.source   = sample;
+                            options.vertical = "all";
+                            sample           = global.prettydiff.prettydiff(options);
+                            console.log("");
+                            console.log(colors.filepath.start + "Current option settings:" + colors.filepath.end);
+                            console.log(sample.slice(1, sample.length - 1));
+                            options.mode     = mode;
+                            options.source   = source;
+                            options.vertical = vert;
+                        }());
+                        if (help === true) {
+                            return;
+                        }
+                    }
+                    if (options.source === "") {
+                        return console.log("Error: 'source' argument is empty");
+                    }
+                    if (options.mode === "diff" && options.diff === "") {
+                        return console.log("Error: 'diff' argument is empty");
+                    }
+                    if ((options.output === "" || options.summaryonly === true) && options.mode === "diff") {
+                        if (options.readmethod !== "screen") {
+                            if (options.readmethod === "auto") {
+                                cliflag = true;
+                            } else {
+                                options.diffcli = true;
+                            }
+                        }
+                        if (process.argv.join(" ").indexOf(" context:") === -1) {
+                            options.context = 2;
+                        }
+                    }
+                    if (method === "file" && options.output === "" && options.summaryonly === false && options.diffcli === false) {
+                        return console.log("Error: 'readmethod' is value 'file' and argument 'output' is empty");
+                    }
+                    if (dir[2] === 0 || outready === false || (options.mode === "diff" && dir[0] === 0)) {
+                        delay();
+                    } else {
+                        status();
+                    }
+                };
+
+                if (err !== null) {
+                    init();
+                } else if (stats.isFile() === true) {
+                    node
+                        .fs
+                        .readFile(pdrcpath, {
+                            encoding: "utf8"
+                        }, function pdNodeLocal__start_stat_readFile(error, data) {
+                            var s       = options.source,
+                                dd      = options.diff,
+                                o       = options.output,
+                                h       = false,
+                                pdrc    = {},
+                                pdkeys  = [],
+                                b       = 0,
+                                eachkey = function pdNodeLocal__start_stat_readFile_eachkey(val) {
+                                    if (val !== "help" && val !== "version" && val !== "v" && val !== "man" && val !== "manual") {
+                                        b = b + 1;
+                                        if (options[val] !== undefined) {
+                                            options[val] = pdrc[val];
+                                            if (val === "help" && pdrc[val] === true) {
+                                                h = true;
+                                                b = b - 1;
+                                            }
+                                        }
+                                    }
+                                };
+                            if (error !== null && error !== undefined) {
+                                return init();
+                            }
+                            if ((/^(\s*\{)/).test(data) === true && (/(\}\s*)$/).test(data) === true) {
+                                pdrc   = JSON.parse(data);
+                                pdkeys = Object.keys(pdrc);
+                                b      = 0;
+                                pdkeys.forEach(eachkey);
+                                if (b > 0 && h === false) {
+                                    help = false;
+                                }
+                                method = options.readmethod;
+                                if (s !== options.source) {
+                                     pathslash("source", options.source);
+                                }
+                                if (dd !== options.diff) {
+                                    pathslash("diff", options.diff);
+                                }
+                                if (o !== options.output) {
+                                    pathslash("output", options.output);
+                                }
+                                init();
+                            } else {
+                                global.prettydiff.prettydiffrc = require(pdrcpath);
+                                if (global.prettydiff.prettydiffrc !== undefined) {
+                                    options = global.prettydiff.prettydiffrc(options);
+                                    method  = options.readmethod;
+                                    if (s !== options.source) {
+                                        pathslash("source", options.source);
+                                    }
+                                    if (dd !== options.diff) {
+                                        pathslash("diff", options.diff);
+                                    }
+                                    if (o !== options.output) {
+                                        pathslash("output", options.output);
+                                    }
+                                    help = false;
+                                    if (options.version === false && options.listoptions === false && (process.argv.length < 3 || options.source === undefined || options.source === "")) {
+                                        help = true;
+                                    }
+                                    init();
+                                }
+                            }
+                        });
+                } else {
+                    init();
+                }
+            });
+    }());
+}());

--- a/node_modules/prettydiff/bin/prettydiff
+++ b/node_modules/prettydiff/bin/prettydiff
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../api/node-local');

--- a/node_modules/prettydiff/lib/csspretty.js
+++ b/node_modules/prettydiff/lib/csspretty.js
@@ -1,0 +1,2244 @@
+/*prettydiff.com topcoms:true,insize:4,inchar:" ",vertical:true */
+/*jshint laxbreak: true*/
+/*global ace, define, global, module*/
+/***********************************************************************
+ csspretty is written by Austin Cheney on 7 Aug 2014.
+
+ Please see the license.txt file associated with the Pretty Diff
+ application for license information.
+
+ **********************************************************************/
+/*
+ This application beautifies CSS code as well as SCSS (Sass) and LESS
+ variants. This application was written with extension in mind using the
+ same array based architecture used for the markuppretty and jspretty
+ libraries.  The architecture focuses on separation of roles.  The first
+ area of the application reads the code and writes an array of tokens.
+ The second area is the algorithm that determines what white space and
+ indentation should be applied.  The final area is a report on the
+ analysis of the code.
+ -----------------------------------------------------------------------
+ */
+(function () {
+    "use strict";
+    var csspretty = function csspretty_(options) {
+        var token      = [],
+            types      = [],
+            lines      = [],
+            depth      = [],
+            begin      = [],
+            uri        = [],
+            colors     = [],
+            output     = "",
+            endline    = false,
+            objsortop  = false,
+            verticalop = false,
+            colorNames = {
+                aliceblue           : 0.9288006825347457,
+                antiquewhite        : 0.8464695170775405,
+                aqua                : 0.7874,
+                aquamarine          : 0.8078549208338043,
+                azure               : 0.9726526495416643,
+                beige               : 0.8988459998705021,
+                bisque              : 0.8073232737297876,
+                black               : 0,
+                blanchedalmond      : 0.8508443960815607,
+                blue                : 0.0722,
+                blueviolet          : 0.12622014321946043,
+                brown               : 0.09822428787651079,
+                burlywood           : 0.5155984453389335,
+                cadetblue           : 0.29424681085422044,
+                chartreuse          : 0.7603202590262282,
+                chocolate           : 0.23898526114557292,
+                coral               : 0.3701793087292368,
+                cornflowerblue      : 0.30318641994179363,
+                cornsilk            : 0.9356211037296492,
+                crimson             : 0.16042199953025577,
+                cyan                : 0.7874,
+                darkblue            : 0.018640801980939217,
+                darkcyan            : 0.2032931783904645,
+                darkgoldenrod       : 0.27264703559992554,
+                darkgray            : 0.39675523072562674,
+                darkgreen           : 0.09114342904757505,
+                darkgrey            : 0.39675523072562674,
+                darkkhaki           : 0.45747326349994155,
+                darkmagenta         : 0.07353047651207048,
+                darkolivegreen      : 0.12651920884889156,
+                darkorange          : 0.40016167026523863,
+                darkorchid          : 0.1341314217485677,
+                darkred             : 0.05488967453113126,
+                darksalmon          : 0.4054147156338075,
+                darkseagreen        : 0.43789249325969054,
+                darkslateblue       : 0.06579284622798763,
+                darkslategray       : 0.06760815192804355,
+                darkslategrey       : 0.06760815192804355,
+                darkturquoise       : 0.4874606277449034,
+                darkviolet          : 0.10999048339343433,
+                deeppink            : 0.2386689582827583,
+                deepskyblue         : 0.444816033955754,
+                dimgray             : 0.14126329114027164,
+                dimgrey             : 0.14126329114027164,
+                dodgerblue          : 0.2744253699145608,
+                firebrick           : 0.10724525535015225,
+                floralwhite         : 0.9592248482500424,
+                forestgreen         : 0.18920812076002244,
+                fuchsia             : 0.2848,
+                gainsboro           : 0.7156935005064806,
+                ghostwhite          : 0.9431126188632283,
+                gold                : 0.6986087742815887,
+                goldenrod           : 0.41919977809568404,
+                gray                : 0.21586050011389915,
+                green               : 0.15438342968146068,
+                greenyellow         : 0.8060947261145331,
+                grey                : 0.21586050011389915,
+                honeydew            : 0.9633653555478173,
+                hotpink             : 0.3465843816971475,
+                indianred           : 0.21406134963884,
+                indigo              : 0.031075614863369846,
+                ivory               : 0.9907127060061531,
+                khaki               : 0.7701234339412052,
+                lavendar            : 0.8031875051452125,
+                lavendarblush       : 0.9017274863104644,
+                lawngreen           : 0.7390589312496334,
+                lemonchiffon        : 0.9403899224562171,
+                lightblue           : 0.6370914128080659,
+                lightcoral          : 0.35522120733134843,
+                lightcyan           : 0.9458729349482863,
+                lightgoldenrodyellow: 0.9334835101829635,
+                lightgray           : 0.651405637419824,
+                lightgreen          : 0.6909197995686475,
+                lightgrey           : 0.651405637419824,
+                lightpink           : 0.5856615273489745,
+                lightsalmon         : 0.47806752252059587,
+                lightseagreen       : 0.3505014511704197,
+                lightskyblue        : 0.5619563761833096,
+                lightslategray      : 0.23830165007286924,
+                lightslategrey      : 0.23830165007286924,
+                lightyellow         : 0.9816181839288161,
+                lime                : 0.7152,
+                limegreen           : 0.44571042246097864,
+                linen               : 0.8835734098437936,
+                magenta             : 0.2848,
+                maroon              : 0.04589194232421496,
+                mediumaquamarine    : 0.4938970331080111,
+                mediumblue          : 0.04407778021232784,
+                mediumorchid        : 0.21639251153773428,
+                mediumpurple        : 0.22905858091648004,
+                mediumseagreen      : 0.34393112338131226,
+                mediumslateblue     : 0.20284629471622434,
+                mediumspringgreen   : 0.7070430819418444,
+                mediumturquois      : 0.5133827926447991,
+                mediumvioletred     : 0.14371899849357186,
+                midnightblue        : 0.020717866350860484,
+                mintcream           : 0.9783460494758793,
+                mistyrose           : 0.8218304785918541,
+                moccasin            : 0.8008300099156694,
+                navajowhite         : 0.7651968234278562,
+                navy                : 0.015585128108223519,
+                oldlace             : 0.9190063340554899,
+                olive               : 0.20027537200567563,
+                olivedrab           : 0.2259315095192918,
+                orange              : 0.48170267036309605,
+                orangered           : 0.2551624375341641,
+                orchid              : 0.3134880676143873,
+                palegoldenrod       : 0.7879264788761452,
+                palegreen           : 0.7793675900635259,
+                paleturquoise       : 0.764360779217138,
+                palevioletred       : 0.2875499411788909,
+                papayawhip          : 0.8779710019983541,
+                peachpuff           : 0.7490558987825108,
+                peru                : 0.3011307487793569,
+                pink                : 0.6327107070246611,
+                plum                : 0.4573422158796909,
+                powderblue          : 0.6825458650060524,
+                purple              : 0.061477070432438476,
+                red                 : 0.2126,
+                rosyblue            : 0.3231945764940708,
+                royalblue           : 0.16663210743188323,
+                saddlebrown         : 0.09792228502052071,
+                salmon              : 0.3697724152759545,
+                sandybrown          : 0.46628543696283414,
+                seagreen            : 0.1973419970627483,
+                seashell            : 0.927378622069223,
+                sienna              : 0.13697631337097677,
+                silver              : 0.527115125705813,
+                skyblue             : 0.5529166851818412,
+                slateblue           : 0.14784278062136097,
+                slategray           : 0.20896704076536138,
+                slategrey           : 0.20896704076536138,
+                slightsteelblue     : 0.5398388828466575,
+                snow                : 0.9653334183484877,
+                springgreen         : 0.7305230606852947,
+                steelblue           : 0.20562642207624846,
+                tan                 : 0.48237604163921527,
+                teal                : 0.1699685577896842,
+                thistle             : 0.5681840109373312,
+                tomato              : 0.3063861271941505,
+                turquoise           : 0.5895536427577983,
+                violet              : 0.40315452986676303,
+                wheat               : 0.7490970282048214,
+                white               : 1,
+                whitesmoke          : 0.913098651793419,
+                yellow              : 0.9278,
+                yellowgreen         : 0.5076295720870697
+            },
+            stats      = {
+                braces    : 0,
+                colon     : 0,
+                comments  : {
+                    chars: 0,
+                    count: 0
+                },
+                properties: {
+                    chars: 0,
+                    count: 0
+                },
+                selectors : {
+                    chars: 0,
+                    count: 0
+                },
+                semi      : 0,
+                space     : 0,
+                values    : {
+                    chars: 0,
+                    count: 0
+                },
+                variables : {
+                    chars: 0,
+                    count: 0
+                }
+            },
+            lf         = (options.crlf === true || options.crlf === "true")
+                ? "\r\n"
+                : "\n";
+        (function csspretty__options() {
+            objsortop      = (
+                options.objsort === true || options.objsort === "true" || options.objsort === "all" || options.objsort === "css"
+            );
+            verticalop     = (
+                options.compressedcss === false && (options.vertical === true || options.vertical === "true" || options.vertical === "all" || options.vertical === "css")
+            );
+            options.source = (
+                typeof options.source === "string" && options.source.length > 0
+            )
+                ? options
+                    .source
+                    .replace(/\r\n?/g, "\n") + " "
+                : "Error: no source code supplied to csspretty!";
+        }());
+        if (typeof options.source !== "string" || options.source === "" || (/^(\s+)$/).test(options.source) === true) {
+            if (options.nodeasync === true) {
+                return [options.source, "Error: no source supplied to csspretty."];
+            }
+            if (global.prettydiff.meta === undefined) {
+                global.prettydiff.meta = {};
+            }
+            global.prettydiff.meta.error = options.source;
+            return options.source;
+        }
+        (function csspretty__tokenize() {
+            var a          = 0,
+                b          = options
+                    .source
+                    .split(""),
+                len        = options.source.length,
+                ltype      = "",
+                itemsize   = 0,
+                space      = "",
+                endtest    = false,
+                struct     = [0],
+                mapper     = [],
+                structval  = "root",
+                nosort     = [],
+                esctest    = function csspretty__tokenize_esctest(xx) {
+                    var yy = xx;
+                    do {
+                        xx = xx - 1;
+                    } while (xx > 0 && b[xx] === "\\");
+                    if ((yy - xx) % 2 === 0) {
+                        return true;
+                    }
+                    return false;
+                },
+                // Since I am already identifying value types this is a good place to do some
+                // quick analysis and clean up on certain value conditions. These things are
+                // being corrected:
+                //  * fractional values missing a leading 0 are    provided a leading 0
+                // * 0 values with a dimension indicator    (px, em) have the dimension
+                // indicator    removed
+                //  * eliminate unnecessary leading 0s
+                //  * url values that are not quoted are wrapped    in double quote characters
+                // * color values are set to lowercase and    reduced from 6 to 3 digits if
+                // appropriate
+                value      = function csspretty__tokenize_item_value(val, font) {
+                    var x         = val.split(""),
+                        leng      = x.length,
+                        cc        = 0,
+                        dd        = 0,
+                        items     = [],
+                        block     = "",
+                        values    = [],
+                        qchar     = "",
+                        qreg      = {},
+                        colorPush = function csspretty__tokenize_item_value_colorPush(value) {
+                            var vl = value.toLowerCase();
+                            if ((/^(#[0-9a-f]{3,6})$/).test(vl) === true) {
+                                colors.push(value);
+                            } else if ((/^(rgba?\()/).test(vl) === true) {
+                                colors.push(value);
+                            } else if (colorNames[vl] !== undefined) {
+                                colors.push(value);
+                            }
+                            return value;
+                        };
+                    if (options.quoteConvert === "double") {
+                        qchar = "\"";
+                    } else if (options.quoteConvert === "single") {
+                        qchar = "'";
+                    }
+                    // this loop identifies containment so that tokens/sub-tokens are correctly
+                    // taken
+                    for (cc = 0; cc < leng; cc = cc + 1) {
+                        items.push(x[cc]);
+                        if (block === "") {
+                            if (x[cc] === "\"") {
+                                block = "\"";
+                                dd    = dd + 1;
+                            } else if (x[cc] === "'") {
+                                block = "'";
+                                dd    = dd + 1;
+                            } else if (x[cc] === "(") {
+                                block = ")";
+                                dd    = dd + 1;
+                            } else if (x[cc] === "[") {
+                                block = "]";
+                                dd    = dd + 1;
+                            }
+                        } else if ((x[cc] === "(" && block === ")") || (x[cc] === "[" && block === "]")) {
+                            dd = dd + 1;
+                        } else if (x[cc] === block) {
+                            dd = dd - 1;
+                            if (dd === 0) {
+                                block = "";
+                            }
+                        }
+                        if (block === "" && x[cc] === " ") {
+                            items.pop();
+                            values.push(colorPush(items.join("")));
+                            items = [];
+                        }
+                    }
+                    values.push(colorPush(items.join("")));
+                    leng = values.length;
+                    //This is where the rules mentioned above are applied
+                    for (cc = 0; cc < leng; cc = cc + 1) {
+                        if (options.noleadzero === false && (/^(\.\d)/).test(values[cc]) === true) {
+                            values[cc] = "0" + values[cc];
+                        } else if (options.noleadzero === true && (/^(0+\.)/).test(values[cc])) {
+                            values[cc] = values[cc].replace(/^(0+\.)/, ".");
+                        } else if ((/^(0+([a-z]{2,3}|%))$/).test(values[cc]) === true) {
+                            values[cc] = "0";
+                        } else if ((/^(0+)/).test(values[cc]) === true) {
+                            values[cc] = values[cc].replace(/0+/, "0");
+                            if ((/\d/).test(values[cc].charAt(1)) === true) {
+                                values[cc] = values[cc].substr(1);
+                            }
+                        } else if ((/^url\((?!\$)/).test(values[cc]) === true && values[cc].charAt(values[cc].length - 1) === ")") {
+                            block = values[cc].charAt(values[cc].indexOf("url(") + 4);
+                            if (block !== "@" && block !== "{" && block !== "<") {
+                                if (qchar === "") {
+                                    values[cc] = values[cc]
+                                        .replace(/url\(\s*('|")?/, "url(\"")
+                                        .replace(/(('|")?\s*\))$/, "\")");
+                                } else {
+                                    values[cc] = values[cc]
+                                        .replace(/url\(\s*('|")?/, "url(" + qchar)
+                                        .replace(/(('|")?\s*\))$/, qchar + ")");
+                                }
+                            }
+                        } else if (font === true) {
+                            if (qchar === "'") {
+                                values[cc] = values[cc].replace(/"/g, "'");
+                            } else {
+                                values[cc] = values[cc].replace(/'/g, "\"");
+                            }
+                        } else if (font === false && qchar !== "" && ((qchar === "\"" && values[cc].charAt(0) === "'" && values[cc].charAt(values[cc].length - 1) === "'") || (qchar === "'" && values[cc].charAt(0) === "\"" && values[cc].charAt(values[cc].length - 1) === "\""))) {
+                            qreg       = new RegExp(qchar, "g");
+                            values[cc] = qchar + values[cc]
+                                .slice(1, values[cc].length - 1)
+                                .replace(qreg, "\\" + qchar) + qchar;
+                        }
+                    }
+                    return values.join(" ");
+                },
+                //map location of empty lines for beautification
+                spacer     = function csspretty__tokenize_space(end) {
+                    var slen = space
+                            .split(lf)
+                            .length - 1,
+                        val  = 0;
+                    if (token.length === 0 && slen > 0) {
+                        slen = slen + 1;
+                    }
+                    if (slen > 0 && options.preserve > 0) {
+                        if (slen > options.preserve) {
+                            val = options.preserve + 1;
+                        } else {
+                            val = slen;
+                        }
+                    } else if (space.length > 1) {
+                        val = 1;
+                    } else if (slen === 0 && types[types.length - 1] === "comment" && types[types.length - 2] !== "comment") {
+                        types[types.length - 1] = "comment-inline";
+                    }
+                    if (slen > 1 && end === true && options.preserve > 0) {
+                        endline = true;
+                        space   = "";
+                        return val;
+                    }
+                    space = "";
+                    return val;
+                },
+                //sort parsed properties intelligently
+                objSort    = function csspretty__tokenize_objSort() {
+                    var cc        = 0,
+                        dd        = 0,
+                        ee        = 0,
+                        startlen  = token.length - 1,
+                        end       = startlen,
+                        keys      = [],
+                        keylen    = 0,
+                        keyend    = 0,
+                        start     = 0,
+                        sort      = function csspretty__tokenize_objSort_sort(x, y) {
+                            var xx = x[0],
+                                yy = y[0];
+                            if (types[xx] === "comment" || types[xx] === "comment-inline") {
+                                do {
+                                    xx = xx + 1;
+                                } while (
+                                    xx < startlen && (types[xx] === "comment" || types[xx] === "comment-inline")
+                                );
+                            }
+                            if (types[yy] === "comment" || types[yy] === "comment-inline") {
+                                do {
+                                    yy = yy + 1;
+                                } while (
+                                    yy < startlen && (types[yy] === "comment" || types[yy] === "comment-inline")
+                                );
+                            }
+                            if (types[xx] < types[yy]) {
+                                return -1;
+                            }
+                            if (types[xx] === types[yy] && token[xx].toLowerCase() < token[yy].toLowerCase()) {
+                                return -1;
+                            }
+                            return 1;
+                        },
+                        semiTest  = true,
+                        pairToken = [],
+                        pairTypes = [],
+                        pairLines = [],
+                        pairDepth = [],
+                        pairBegin = [];
+                    if (types[end] === "comment" || types[end] === "comment-inline") {
+                        do {
+                            end = end - 1;
+                        } while (
+                            end > 0 && (types[end] === "comment" || types[end] === "comment-inline")
+                        );
+                    }
+                    for (cc = startlen; cc > -1; cc = cc - 1) {
+                        if (types[cc] === "end") {
+                            dd = dd + 1;
+                        }
+                        if (types[cc] === "start") {
+                            dd = dd - 1;
+                        }
+                        if (dd === 0) {
+                            if ((types[cc] === "property" || types[cc] === "selector" || types[cc] === "propvar") && types[cc - 1] !== "property" && types[cc - 1] !== "selector") {
+                                start = cc;
+                                if (types[end + 1] === "comment-inline") {
+                                    end = end + 1;
+                                }
+                                if (types[start - 1] === "comment") {
+                                    do {
+                                        start = start - 1;
+                                    } while (start > -1 && types[start - 1] === "comment");
+                                }
+                                keys.push([
+                                    start, end + 1,
+                                    false
+                                ]);
+                                end = start - 1;
+                            }
+                        }
+                        if (dd < 0 && cc < startlen) {
+                            if (keys.length > 1 && (types[cc - 1] === "selector" || types[cc - 1] === "propvar" || (types[cc - 2] === "propvar" && types[cc - 1] === "value") || token[cc - 1] === "=" || token[cc - 1] === ":" || token[cc - 1] === "[" || token[cc - 1] === "{" || (token[cc - 1] === "," && structval !== "map") || cc === 0)) {
+                                if (structval === "map" && token[token.length - 1] !== ",") {
+                                    token.push(",");
+                                    types.push("semi");
+                                    lines.push(0);
+                                    depth.push(depth[depth.length - 1]);
+                                    begin.push(begin[begin.length - 1]);
+                                    keys[0][1] = keys[0][1] + 1;
+                                }
+                                keys.sort(sort);
+                                keylen   = keys.length;
+                                semiTest = false;
+                                for (dd = 0; dd < keylen; dd = dd + 1) {
+                                    keyend = keys[dd][1];
+                                    for (ee = keys[dd][0]; ee < keyend; ee = ee + 1) {
+                                        pairToken.push(token[ee]);
+                                        pairTypes.push(types[ee]);
+                                        pairLines.push(lines[ee]);
+                                        pairDepth.push(depth[ee]);
+                                        pairBegin.push(begin[ee]);
+                                        if ((token[ee] === ";" && structval === "block") || (token[ee] === "," && structval === "map") || token[ee] === "}") {
+                                            semiTest = true;
+                                        } else if ((structval === "block" && token[ee] !== ";") && (structval === "map" && token[ee] !== ",") && token[ee] !== "}" && types[ee] !== "comment" && types[ee] !== "comment-inline") {
+                                            semiTest = false;
+                                        }
+                                    }
+                                    if (semiTest === false) {
+                                        ee = pairTypes.length - 1;
+                                        if (pairTypes[ee] === "comment" || pairTypes[ee] === "comment-inline") {
+                                            do {
+                                                ee = ee - 1;
+                                            } while (
+                                                ee > 0 && (pairTypes[ee] === "comment" || pairTypes[ee] === "comment-inline")
+                                            );
+                                        }
+                                        ee = ee + 1;
+                                        if (structval === "map") {
+                                            pairToken.splice(ee, 0, ",");
+                                        } else {
+                                            pairToken.splice(ee, 0, ";");
+                                        }
+                                        pairTypes.splice(ee, 0, "semi");
+                                        pairDepth.splice(ee, 0, pairDepth[ee]);
+                                        pairBegin.splice(ee, 0, pairBegin[ee]);
+                                        if (pairLines[ee - 1] > 0) {
+                                            pairLines[ee - 1] = 0;
+                                            pairLines.splice(ee, 0, 1);
+                                        } else {
+                                            pairLines.splice(ee, 0, 0);
+                                        }
+                                    }
+                                }
+                                ee = pairTypes.length - 1;
+                                if (pairTypes[ee] === "comment" || pairTypes[ee] === "comment-inline") {
+                                    do {
+                                        ee = ee - 1;
+                                    } while (
+                                        ee > 0 && (pairTypes[ee] === "comment" || pairTypes[ee] === "comment-inline")
+                                    );
+                                }
+                                keylen = token.length - (cc + 1);
+                                token.splice(cc + 1, keylen);
+                                types.splice(cc + 1, keylen);
+                                lines.splice(cc + 1, keylen);
+                                depth.splice(cc + 1, keylen);
+                                begin.splice(cc + 1, keylen);
+                                token = token.concat(pairToken);
+                                types = types.concat(pairTypes);
+                                lines = lines.concat(pairLines);
+                                depth = depth.concat(pairDepth);
+                                begin = begin.concat(pairBegin);
+                                if (structval === "map") {
+                                    cc = token.length - 1;
+                                    if (types[cc].indexOf("comment") === 0) {
+                                        do {
+                                            cc = cc - 1;
+                                        } while (types[cc].indexOf("comment") === 0);
+                                    }
+                                    if (token[cc] === ",") {
+                                        token.splice(cc, 1);
+                                        types.splice(cc, 1);
+                                        lines.splice(cc, 1);
+                                        depth.splice(cc, 1);
+                                        begin.splice(cc, 1);
+                                    }
+                                }
+                            }
+                            return;
+                        }
+                    }
+                },
+                //the generic token builder
+                buildtoken = function csspretty__tokenize_build() {
+                    var aa         = 0,
+                        bb         = 0,
+                        out        = [],
+                        block      = [],
+                        outy       = "",
+                        mappy      = 0,
+                        comma      = (
+                            token.length > 0 && token[token.length - 1].charAt(token[token.length - 1].length - 1) === ","
+                        ),
+                        linev      = spacer(false),
+                        spacestart = function () {
+                            if ((/\s/).test(b[aa + 1]) === true) {
+                                do {
+                                    aa = aa + 1;
+                                } while ((/\s/).test(b[aa + 1]) === true);
+                            }
+                        };
+                    //this loop accounts for grouping mechanisms
+                    for (aa = a; aa < len; aa = aa + 1) {
+                        out.push(b[aa]);
+                        if (b[aa - 1] !== "\\" || esctest(aa) === false) {
+                            if (b[aa] === "\"" && block[block.length - 1] !== "'") {
+                                if (block[block.length - 1] === "\"") {
+                                    block.pop();
+                                } else {
+                                    block.push("\"");
+                                }
+                            } else if (b[aa] === "'" && block[block.length - 1] !== "\"") {
+                                if (block[block.length - 1] === "'") {
+                                    block.pop();
+                                } else {
+                                    block.push("'");
+                                }
+                            } else if (block[block.length - 1] !== "\"" && block[block.length - 1] !== "'") {
+                                if (b[aa] === "(") {
+                                    mappy = mappy + 1;
+                                    block.push(")");
+                                    spacestart();
+                                } else if (b[aa] === "[") {
+                                    block.push("]");
+                                    spacestart();
+                                } else if (b[aa] === "#" && b[aa + 1] === "{") {
+                                    out.push("{");
+                                    aa = aa + 1;
+                                    block.push("}");
+                                    spacestart();
+                                } else if (b[aa] === block[block.length - 1]) {
+                                    block.pop();
+                                    if ((/\s/).test(out[out.length - 2]) === true) {
+                                        out.pop();
+                                        do {
+                                            out.pop();
+                                        } while ((/\s/).test(out[out.length - 1]) === true);
+                                        out.push(b[aa]);
+                                    }
+                                }
+                            }
+                        }
+                        if (structval === "map" && block.length === 0 && (b[aa + 1] === "," || b[aa + 1] === ")")) {
+                            if (b[aa + 1] === ")" && token[token.length - 1] === "(") {
+                                token.pop();
+                                types.pop();
+                                lines.pop();
+                                depth.pop();
+                                begin.pop();
+                                struct.pop();
+                                structval = depth[depth.length - 1];
+                                out       = ["("];
+                                aa        = a - 1;
+                            } else {
+                                break;
+                            }
+                        }
+                        if (b[aa + 1] === ":") {
+                            bb = aa;
+                            if ((/\s/).test(b[bb]) === true) {
+                                do {
+                                    bb = bb - 1;
+                                } while ((/\s/).test(b[bb]) === true);
+                            }
+                            outy = b
+                                .slice(bb - 6, bb + 1)
+                                .join("");
+                            if (outy.indexOf("filter") === outy.length - 6 || outy.indexOf("progid") === outy.length - 6) {
+                                outy = "filter";
+                            }
+                        }
+                        if (block.length === 0 && ((b[aa + 1] === ";" && esctest(aa + 1) === false) || (b[aa + 1] === ":" && b[aa] !== ":" && b[aa + 2] !== ":" && outy !== "filter" && outy !== "progid") || b[aa + 1] === "}" || b[aa + 1] === "{" || (b[aa + 1] === "/" && (b[aa + 2] === "*" || b[aa + 2] === "/")))) {
+                            bb = out.length - 1;
+                            if ((/\s/).test(out[bb]) === true) {
+                                do {
+                                    bb = bb - 1;
+                                    aa = aa - 1;
+                                    out.pop();
+                                } while ((/\s/).test(out[bb]) === true);
+                            }
+                            break;
+                        }
+                        if (out[0] === "@" && block.length === 0 && (b[aa + 1] === "\"" || b[aa + 1] === "'")) {
+                            break;
+                        }
+                    }
+                    a        = aa;
+                    itemsize = out.length;
+                    if (structval === "map" && out[0] === "(") {
+                        mapper[mapper.length - 1] = mapper[mapper.length - 1] - 1;
+                    }
+                    if (comma === true && structval !== "map" && types[types.length - 1] !== "comment" && types[types.length - 1] !== "comment-inline") {
+                        token[token.length - 1] = token[token.length - 1] + out
+                            .join("")
+                            .replace(/\s+/g, " ")
+                            .replace(/^\s/, "")
+                            .replace(/\s$/, "");
+                        return;
+                    }
+                    token.push(
+                        out.join("").replace(/\s+/g, " ").replace(/^\s/, "").replace(/\s$/, "")
+                    );
+                    begin.push(struct[struct.length - 1]);
+                    depth.push(structval);
+                    lines.push(linev);
+                    if (token[token.length - 1].indexOf("extend(") === 0) {
+                        ltype = "pseudo";
+                        types.push("pseudo");
+                    } else if ("\"'".indexOf(token[token.length - 1].charAt(0)) > -1 && types[types.length - 1] === "propvar") {
+                        ltype = "item";
+                        types.push("value");
+                    } else if (out[0] === "@" || out[0] === "$") {
+                        if (types[types.length - 1] === "colon" && (types[types.length - 2] === "property" || types[types.length - 2] === "propvar")) {
+                            ltype = "value";
+                            types.push("value");
+                        } else {
+                            ltype = "propvar";
+                            types.push("propvar");
+                            outy = token[token.length - 1];
+                            aa   = outy.indexOf("(");
+                            if (outy.charAt(outy.length - 1) === ")" && aa > 0) {
+                                outy                    = outy.slice(aa + 1, outy.length - 1);
+                                token[token.length - 1] = token[token.length - 1].slice(0, aa + 1) + value(
+                                    outy,
+                                    false
+                                ) + ")";
+                            }
+                        }
+                    } else {
+                        ltype = "item";
+                        types.push("item");
+                    }
+                },
+                // Some tokens receive a generic type named 'item' because their type is unknown
+                // until we know the following syntax.  This function replaces the type 'item'
+                // with something more specific.
+                item       = function csspretty__tokenize_item(type) {
+                    var aa    = types.length,
+                        bb    = 0,
+                        coms  = [],
+                        tokel = (token.length > 1)
+                            ? token[token.length - 2]
+                            : "",
+                        toked = tokel.slice(tokel.length - 2);
+                    //backtrack through immediately prior comments to find the correct token
+                    if (ltype === "comment" || ltype === "comment-inline") {
+                        do {
+                            aa    = aa - 1;
+                            ltype = types[aa];
+                            coms.push(token[aa]);
+                        } while (aa > 0 && (ltype === "comment" || ltype === "comment-inline"));
+                    } else {
+                        aa = aa - 1;
+                    }
+                    //if the last non-comment type is 'item' then id it
+                    if (ltype === "item" && types[aa].indexOf("external") < 0) {
+                        if (type === "start") {
+                            stats.selectors.count = stats.selectors.count + 1;
+                            stats.selectors.chars = stats.selectors.chars + itemsize;
+                            if (types[aa - 1] !== "comment" && types[aa - 1] !== "comment-inline" && types[aa - 1] !== "end" && types[aa - 1] !== "start" && types[aa - 1] !== "semi" && types[aa - 1] !== undefined && types[aa - 1].indexOf("external") < 0) {
+                                (function csspretty__tokenize_item_selparts() {
+                                    var parts = [],
+                                        cc    = aa,
+                                        dd    = 0;
+                                    do {
+                                        parts.push(token[cc]);
+                                        if (lines[cc] > 0 && token[cc] === ":" && token[cc - 1] !== ":") {
+                                            parts.push(" ");
+                                        } else if (token[cc] !== ":") {
+                                            parts.push(" ");
+                                        }
+                                        cc = cc - 1;
+                                    } while (
+                                        cc > -1 && types[cc] !== "comment" && types[cc] !== "comment-inline" && types[cc] !== "end" && types[cc] !== "start" && types[cc] !== "semi" && types[cc] !== undefined
+                                    );
+                                    parts.reverse();
+                                    cc = cc + 1;
+                                    dd = aa - cc;
+                                    token.splice(cc, dd);
+                                    types.splice(cc, dd);
+                                    lines.splice(cc, dd);
+                                    depth.splice(cc, dd);
+                                    begin.splice(cc, dd);
+                                    aa        = aa - dd;
+                                    token[aa] = parts
+                                        .join("")
+                                        .replace(/:\u0020/g, ":")
+                                        .replace(/(\s*,\s*)/g, ",");
+                                }());
+                            } else {
+                                token[aa] = token[aa].replace(/(\s*,\s*)/g, ",");
+                            }
+                            if (options.compressedcss === true) {
+                                token[aa] = token[aa]
+                                    .replace(/\s*&/, " &")
+                                    .replace(/\s*>\s*/g, ">")
+                                    .replace(/:\s+/g, ":")
+                                    .replace(/^(\s+)/, "")
+                                    .replace(/(\s+)$/, "");
+                            } else {
+                                token[aa] = token[aa]
+                                    .replace(/\s*&/, " &")
+                                    .replace(/\s*>\s*/g, " > ")
+                                    .replace(/:\s+/g, ": ")
+                                    .replace(/^(\s+)/, "")
+                                    .replace(/(\s+)$/, "");
+                            }
+                            (function csspretty__tokenize_item_selectorsort() {
+                                var y    = 0,
+                                    slen = token[aa].length,
+                                    z    = "",
+                                    mark = 0,
+                                    list = [];
+                                for (y = 0; y < slen; y = y + 1) {
+                                    if (z === "" && token[aa].charAt(y) === ",") {
+                                        list.push(token[aa].slice(mark, y));
+                                        mark = y + 1;
+                                    } else if (token[aa].charAt(y) === "\"" || token[aa].charAt(y) === "'" || token[aa].charAt(y) === "(" || token[aa].charAt(y) === "{") {
+                                        z = token[aa].charAt(y);
+                                    } else if (token[aa].charAt(y) === z && (z === "\"" || z === "''")) {
+                                        z = "";
+                                    } else if (token[aa].charAt(y) === ")" && z === "(") {
+                                        z = "";
+                                    } else if (token[aa].charAt(y) === "}" && z === "{") {
+                                        z = "";
+                                    }
+                                }
+                                list.push(token[aa].slice(mark, y));
+                                list.sort();
+                                token[aa] = list.join(",").replace(/^(\s+)/, "");
+                            }());
+                            types[aa] = "selector";
+                            ltype     = "selector";
+                        } else if (type === "end") {
+                            types[aa] = "value";
+                            ltype     = "value";
+                            if (options.mode !== "diff") {
+                                token[aa] = token[aa].replace(/\s*!\s+important/, " !important");
+                                if (options.quoteConvert !== "none" && (token[aa - 2] === "font" || token[aa - 2] === "font-family")) {
+                                    token[aa] = value(token[aa], true);
+                                } else {
+                                    token[aa] = value(token[aa], false);
+                                }
+                            }
+                            //take comments out until the 'item' is found and then put the comments back
+                            if (options.mode === "beautify" || options.mode === "parse" || (options.mode === "diff" && options.diffcomments === true)) {
+                                if (token[token.length - 2] === "{") {
+                                    types[types.length - 1] = "propvar";
+                                    stats.values.count      = stats.values.count - 1;
+                                    stats.values.chars      = stats.values.chars - itemsize;
+                                    stats.variables.count   = stats.variables.count + 1;
+                                    stats.variables.chars   = stats.variables.chars + itemsize;
+                                } else if (structval === "block") {
+                                    if (coms.length > 0 && ltype !== "semi" && ltype !== "end" && ltype !== "start") {
+                                        aa = coms.length - 1;
+                                        do {
+                                            token.pop();
+                                            types.pop();
+                                            lines.pop();
+                                            depth.pop();
+                                            begin.pop();
+                                            aa = aa - 1;
+                                        } while (aa > 0);
+                                        if (options.mode === "diff") {
+                                            token.push("x;");
+                                        } else {
+                                            token.push(";");
+                                        }
+                                        depth.push(structval);
+                                        begin.push(struct[struct.length - 1]);
+                                        types.push("semi");
+                                        lines.push(spacer(false));
+                                        bb = coms.length - 1;
+                                        do {
+                                            token.push(coms[aa]);
+                                            if (coms[aa].indexOf("//") === 0 && lines[lines.length - 1] === 0) {
+                                                types.push("comment-inline");
+                                            } else {
+                                                types.push("comment");
+                                            }
+                                            depth.push(structval);
+                                            begin.push(struct[struct.length - 1]);
+                                            lines.push(0);
+                                            aa = aa + 1;
+                                        } while (aa < bb);
+                                    } else {
+                                        if (options.mode === "diff") {
+                                            token.push("x;");
+                                        } else {
+                                            token.push(";");
+                                        }
+                                        depth.push(structval);
+                                        begin.push(struct[struct.length - 1]);
+                                        types.push("semi");
+                                        lines.push(spacer(false));
+                                    }
+                                }
+                            }
+                            stats.values.count = stats.values.count + 1;
+                            stats.values.chars = stats.values.chars + itemsize;
+                        } else if (type === "semi") {
+                            if (types[aa - 1] === "colon") {
+                                stats.values.count = stats.values.count + 1;
+                                stats.values.chars = stats.values.chars + itemsize;
+                                types[aa]          = "value";
+                                ltype              = "value";
+                                if (options.mode !== "diff") {
+                                    token[aa] = token[aa].replace(/\s*!\s+important/, " !important");
+                                    if (options.quoteConvert !== "none" && (token[aa - 2] === "font" || token[aa - 2] === "font-family")) {
+                                        token[aa] = value(token[aa], true);
+                                    } else {
+                                        token[aa] = value(token[aa], false);
+                                    }
+                                }
+                            } else {
+                                //properties without values are considered variables
+                                if (types[aa] !== "value") {
+                                    if (types[aa] === "item" && types[aa - 1] === "value" && (toked === "}}" || toked === "?>" || toked === "->" || toked === "%}" || toked === "%>")) {
+                                        if (isNaN(token[token.length - 1]) === true) {
+                                            token[token.length - 2] = tokel + token.pop();
+                                        } else {
+                                            token[token.length - 2] = tokel + " " + token.pop();
+                                        }
+                                        types.pop();
+                                        return;
+                                    }
+                                    types[aa] = "propvar";
+                                    ltype     = "propvar";
+                                }
+                                if (token[aa].indexOf("\"") > 0) {
+                                    bb        = token[aa].indexOf("\"");
+                                    a         = a - (token[aa].length - bb);
+                                    token[aa] = token[aa].slice(0, bb);
+                                    buildtoken();
+                                } else if (token[aa].indexOf("'") > 0) {
+                                    bb        = token[aa].indexOf("'");
+                                    a         = a - (token[aa].length - bb);
+                                    token[aa] = token[aa].slice(0, bb);
+                                    buildtoken();
+                                } else if ((/\s/).test(token[aa]) === true) {
+                                    bb = token[aa]
+                                        .replace(/\s/, " ")
+                                        .indexOf(" ");
+                                    if (bb < token[aa].indexOf("(") && bb < token[aa].indexOf("[")) {
+                                        a         = a - (token[aa].length - bb);
+                                        token[aa] = token[aa].slice(0, bb);
+                                        buildtoken();
+                                    }
+                                }
+                                stats.variables.count = stats.variables.count + 1;
+                                stats.variables.chars = stats.variables.chars + itemsize;
+                            }
+                        } else if (type === "colon") {
+                            types[aa]              = "property";
+                            ltype                  = "property";
+                            stats.properties.count = stats.properties.count + 1;
+                            stats.properties.chars = stats.properties.chars + itemsize;
+                        } else if (token[aa].charAt(0) === "@" && ((types[aa - 2] !== "propvar" && types[aa - 2] !== "property") || types[aa - 1] === "semi")) {
+                            types[aa] = "propvar";
+                            ltype     = "propvar";
+                        }
+                    }
+                },
+                external   = function csspretty__tokenize_external(open, end) {
+                    var store  = [],
+                        quote  = "",
+                        name   = "",
+                        endlen = 0,
+                        start  = open.length,
+                        linev  = spacer(false),
+                        exit   = function csspretty__tokenize_external_exit(typename) {
+                            var endtype = types[types.length - 2];
+                            if (ltype === "item") {
+                                if (endtype === "colon") {
+                                    types[types.length - 1] = "value";
+                                } else {
+                                    item(endtype);
+                                }
+                            }
+                            types.push(typename);
+                        };
+                    nosort[nosort.length - 1] = true;
+                    for (a = a; a < len; a = a + 1) {
+                        store.push(b[a]);
+                        if (quote === "") {
+                            if (b[a] === "\"") {
+                                quote = "\"";
+                            } else if (b[a] === "'") {
+                                quote = "'";
+                            } else if (b[a] === "/") {
+                                if (b[a + 1] === "/") {
+                                    quote = "/";
+                                } else if (b[a + 1] === "*") {
+                                    quote = "*";
+                                }
+                            } else if (b[a + 1] === end.charAt(0)) {
+                                do {
+                                    endlen = endlen + 1;
+                                    a      = a + 1;
+                                    store.push(b[a]);
+                                } while (a < len && endlen < end.length && b[a + 1] === end.charAt(endlen));
+                                if (endlen === end.length) {
+                                    quote = store.join("");
+                                    if ((/\s/).test(quote.charAt(start)) === true) {
+                                        do {
+                                            start = start + 1;
+                                        } while ((/\s/).test(quote.charAt(start)) === true);
+                                    }
+                                    endlen = start;
+                                    do {
+                                        endlen = endlen + 1;
+                                    } while (endlen < end.length && (/\s/).test(quote.charAt(endlen)) === false);
+                                    if (endlen === quote.length) {
+                                        endlen = endlen - end.length;
+                                    }
+                                    if (open === "{%") {
+                                        if (quote.indexOf("{%-") === 0) {
+                                            quote = quote
+                                                .replace(/^(\{%-\s*)/, "{%- ")
+                                                .replace(/(\s*-%\})$/, " -%}");
+                                            name  = quote.slice(4);
+                                        } else {
+                                            quote = quote
+                                                .replace(/^(\{%\s*)/, "{% ")
+                                                .replace(/(\s*%\})$/, " %}");
+                                            name  = quote.slice(3);
+                                        }
+                                    }
+                                    if (open === "{{") {
+                                        quote = quote
+                                            .replace(/^(\{\{\s+)/, "{{")
+                                            .replace(/(\s+\}\})$/, "}}");
+                                    }
+                                    if (ltype === "item" && types[types.length - 2] === "colon" && (types[types.length - 3] === "property" || types[types.length - 3] === "propvar")) {
+                                        ltype                   = "value";
+                                        types[types.length - 1] = "value";
+                                        if (isNaN(token[token.length - 1]) === true && token[token.length - 1].charAt(token[token.length - 1].length - 1) !== ")") {
+                                            token[token.length - 1] = token[token.length - 1] + quote;
+                                        } else {
+                                            token[token.length - 1] = token[token.length - 1] + " " + quote;
+                                        }
+                                        return;
+                                    }
+                                    lines.push(linev);
+                                    token.push(quote);
+                                    begin.push(struct[struct.length - 1]);
+                                    depth.push(structval);
+                                    if (open === "{%") {
+                                        name = name.slice(0, name.indexOf(" "));
+                                        if (name.indexOf("(") > 0) {
+                                            name = name.slice(0, name.indexOf("("));
+                                        }
+                                        store = [
+                                            "autoescape",
+                                            "block",
+                                            "capture",
+                                            "case",
+                                            "comment",
+                                            "embed",
+                                            "filter",
+                                            "for",
+                                            "form",
+                                            "if",
+                                            "macro",
+                                            "paginate",
+                                            "raw",
+                                            "sandbox",
+                                            "spaceless",
+                                            "tablerow",
+                                            "unless",
+                                            "verbatim"
+                                        ];
+                                        if (name === "else" || name === "elseif" || name === "when" || name === "elif") {
+                                            return exit("external_else");
+                                        }
+                                        for (endlen = store.length - 1; endlen > -1; endlen = endlen - 1) {
+                                            if (name === store[endlen]) {
+                                                return exit("external_start");
+                                            }
+                                            if (name === "end" + store[endlen]) {
+                                                return exit("external_end");
+                                            }
+                                        }
+                                    } else if (open === "{{") {
+                                        name   = quote.slice(2);
+                                        endlen = name.length;
+                                        start  = 0;
+                                        do {
+                                            start = start + 1;
+                                        } while (
+                                            start < endlen && (/\s/).test(name.charAt(start)) === false && name.charAt(start) !== "("
+                                        );
+                                        name = name.slice(0, start);
+                                        if (name.charAt(name.length - 2) === "}") {
+                                            name = name.slice(0, name.length - 2);
+                                        }
+                                        if (name === "end") {
+                                            return exit("external_end");
+                                        }
+                                        if (name === "block" || name === "define" || name === "form" || name === "if" || name === "range" || name === "with") {
+                                            return exit("external_start");
+                                        }
+                                    }
+                                    return exit("external");
+                                }
+                                endlen = 0;
+                            }
+                        } else if (quote === b[a]) {
+                            if (quote === "\"" || quote === "'") {
+                                quote = "";
+                            } else if (quote === "/" && (b[a] === "\r" || b[a] === "\n")) {
+                                quote = "";
+                            } else if (quote === "*" && b[a + 1] === "/") {
+                                quote = "";
+                            }
+                        }
+                    }
+                },
+                //finds comments include those JS looking '//' comments
+                comment    = function csspretty__tokenize_comment(inline) {
+                    var aa        = 0,
+                        bb        = 0,
+                        out       = [b[a]],
+                        type      = "comment",
+                        extra     = "",
+                        spareType = [],
+                        spareToke = [],
+                        spareLine = [],
+                        spareBegn = [],
+                        spareDept = [],
+                        linev     = spacer(false);
+                    type = (inline === true && linev === 0)
+                        ? "comment-inline"
+                        : "comment";
+                    for (aa = a + 1; aa < len; aa = aa + 1) {
+                        out.push(b[aa]);
+                        if ((inline === false && b[aa - 1] === "*" && b[aa] === "/") || (inline === true && (b[aa + 1] === "\n" || b[aa + 1] === "\r"))) {
+                            break;
+                        }
+                    }
+                    if (ltype === "item") {
+                        bb = aa;
+                        do {
+                            bb = bb + 1;
+                            if (b[bb] === "/") {
+                                if (b[bb + 1] === "*" || b[bb + 1] === "/") {
+                                    extra = b[bb + 1];
+                                } else if (b[bb - 1] === "*" && extra === "*") {
+                                    extra = "";
+                                    bb    = bb + 1;
+                                }
+                            } else if ((b[bb] === "\n" || b[bb] === "\r") && extra === "/") {
+                                extra = "";
+                                bb    = bb + 1;
+                            }
+                        } while (
+                            bb < len && ((extra === "" && (/\s/).test(b[bb]) === true) || extra !== "")
+                        );
+                        if (b[bb] === "{") {
+                            item("start");
+                        } else if (b[bb] === "}") {
+                            item("end");
+                        } else if (b[bb] === ";") {
+                            item("semi");
+                        } else if (b[bb] === ":") {
+                            item("colon");
+                        } else {
+                            item();
+                        }
+                    }
+                    a                    = aa;
+                    stats.comments.count = stats.comments.count + 1;
+                    stats.comments.chars = stats.comments.chars + out.length;
+                    if (options.mode === "minify") {
+                        out.push(lf);
+                    }
+                    if (options.mode === "beautify" || options.mode === "parse" || (options.mode === "diff" && options.diffcomments === true) || (options.mode === "minify" && options.topcoms === true)) {
+                        if (token.length > 0 && (ltype === "selector" || ltype === "propvar") && types[types.length - 1] !== "comment" && types[types.length - 1] !== "comment-inline") {
+                            spareToke.push(token[token.length - 1]);
+                            token.pop();
+                            types.pop();
+                            lines.pop();
+                            begin.pop();
+                            depth.pop();
+                            begin.push(struct[struct.length - 1]);
+                            depth.push(structval);
+                            token.push(out.join(""));
+                            types.push(type);
+                            lines.push(linev);
+                            begin.push(struct[struct.length - 1]);
+                            depth.push(structval);
+                            token.push(spareToke[0]);
+                            if (ltype === "propvar") {
+                                types.push("propvar");
+                            } else {
+                                types.push("selector");
+                            }
+                            lines.push(0);
+                        } else if (ltype === "colon" || ltype === "property" || ltype === "value" || ltype === "propvar") {
+                            do {
+                                spareToke.push(token[token.length - 1]);
+                                spareType.push(types[types.length - 1]);
+                                spareLine.push(lines[lines.length - 1]);
+                                spareDept.push(depth[depth.length - 1]);
+                                spareBegn.push(begin[begin.length - 1]);
+                                token.pop();
+                                types.pop();
+                                lines.pop();
+                                depth.pop();
+                                begin.pop();
+                            } while (
+                                types.length > 1 && types[types.length - 1] !== "semi" && types[types.length - 1] !== "start"
+                            );
+                            token.push(out.join(""));
+                            types.push(type);
+                            lines.push(linev);
+                            depth.push(structval);
+                            begin.push(struct[struct.length - 1]);
+                            do {
+                                token.push(spareToke[spareToke.length - 1]);
+                                types.push(spareType[spareType.length - 1]);
+                                lines.push(spareLine[spareLine.length - 1]);
+                                depth.push(spareDept[spareDept.length - 1]);
+                                begin.push(spareBegn[spareBegn.length - 1]);
+                                spareToke.pop();
+                                spareType.pop();
+                                spareLine.pop();
+                                spareDept.pop();
+                                spareBegn.pop();
+                            } while (spareToke.length > 0);
+                        } else {
+                            ltype = type;
+                            types.push(type);
+                            token.push(out.join(""));
+                            lines.push(linev);
+                            depth.push(structval);
+                            begin.push(struct[struct.length - 1]);
+                        }
+                    }
+                },
+                //do fancy things to property types like: sorting, consolidating, and padding
+                properties = function csspretty__tokenize_properties() {
+                    var aa    = 0,
+                        bb    = 1,
+                        cc    = 0,
+                        dd    = 0,
+                        p     = [],
+                        set   = [
+                            []
+                        ],
+                        next  = 0,
+                        stoke = [],
+                        stype = [],
+                        sline = [],
+                        sdept = [],
+                        sbegn = [];
+                    //identify properties and build out prop/val sets
+                    for (aa = token.length - 1; aa > -1; aa = aa - 1) {
+                        if (types[aa] === "start") {
+                            bb = bb - 1;
+                            if (bb === 0) {
+                                next = aa;
+                                set.pop();
+                                for (aa = set.length - 1; aa > -1; aa = aa - 1) {
+                                    set[aa].reverse();
+                                }
+                                break;
+                            }
+                        }
+                        if (types[aa] === "end") {
+                            bb = bb + 1;
+                        }
+                        if (bb === 1 && (types[aa] === "property" || (types[aa] === "propvar" && types[aa + 1] === "colon")) && options.mode === "beautify") {
+                            p.push(aa);
+                        }
+                        set[set.length - 1].push(aa);
+                        if (bb === 1 && (types[aa - 1] === "comment" || types[aa - 1] === "comment-inline" || types[aa - 1] === "semi" || types[aa - 1] === "end" || types[aa - 1] === "start") && types[aa] !== "start" && types[aa] !== "end") {
+                            set.push([]);
+                        }
+                    }
+                    //this reverse fixes the order of consecutive comments
+                    set.reverse();
+                    p.reverse();
+
+                    //consolidate margin and padding
+                    (function csspretty__tokenize_properties_propcheck() {
+                        var leng      = set.length,
+                            fourcount = function csspretty__tokenize_properties_propcheck_fourcount(name) {
+                                var test     = [
+                                        false, false, false, false
+                                    ],
+                                    val      = [
+                                        "0", "0", "0", "0"
+                                    ],
+                                    zero     = (/^(0+([a-z]+|%))/),
+                                    start    = aa,
+                                    yy       = -1,
+                                    zz       = 0,
+                                    valsplit = [],
+                                    store    = function csspretty__tokenize_properties_propcheck_fourcount_store(side) {
+                                        yy         = yy + 1;
+                                        val[side]  = token[set[aa][2]];
+                                        test[side] = true;
+                                        if (start < 0) {
+                                            start = aa;
+                                        }
+                                    };
+                                for (aa = aa; aa < leng; aa = aa + 1) {
+                                    if (token[set[aa][2]] !== undefined && token[set[aa][0]].indexOf(name) === 0) {
+                                        if (token[set[aa][0]] === name || token[set[aa][0]].indexOf(name + " ") === 0) {
+                                            yy       = yy + 1;
+                                            valsplit = token[set[aa][2]].split(" ");
+                                            if (valsplit.length === 1) {
+                                                val = [
+                                                    token[set[aa][2]],
+                                                    token[set[aa][2]],
+                                                    token[set[aa][2]],
+                                                    token[set[aa][2]]
+                                                ];
+                                            } else if (valsplit.length === 2) {
+                                                val = [
+                                                    valsplit[0], valsplit[1], valsplit[0], valsplit[1]
+                                                ];
+                                            } else if (valsplit.length === 3) {
+                                                val = [
+                                                    valsplit[0], valsplit[1], valsplit[2], valsplit[1]
+                                                ];
+                                            } else if (valsplit.length === 4) {
+                                                val = [
+                                                    valsplit[0], valsplit[1], valsplit[2], valsplit[3]
+                                                ];
+                                            } else {
+                                                return;
+                                            }
+                                            test = [true, true, true, true];
+                                        } else if (token[set[aa][0]].indexOf(name + "-bottom") === 0) {
+                                            store(2);
+                                        } else if (token[set[aa][0]].indexOf(name + "-left") === 0) {
+                                            store(3);
+                                        } else if (token[set[aa][0]].indexOf(name + "-right") === 0) {
+                                            store(1);
+                                        } else if (token[set[aa][0]].indexOf(name + "-top") === 0) {
+                                            store(0);
+                                        }
+                                    }
+                                    if (set[aa + 1] === undefined || token[set[aa + 1][0]].indexOf(name) < 0 || aa === leng - 1) {
+                                        if (test[0] === true && test[1] === true && test[2] === true && test[3] === true) {
+                                            set.splice(start + 1, yy);
+                                            leng = leng - yy;
+                                            aa   = aa - yy;
+                                            zz   = 0;
+                                            bb   = p.length;
+                                            do {
+                                                if (p[zz] === set[start][0]) {
+                                                    break;
+                                                }
+                                                zz = zz + 1;
+                                            } while (zz < bb);
+                                            if (zz < bb) {
+                                                p.splice(zz + 1, yy);
+                                            }
+                                            token[set[start][0]] = name;
+                                            if (zero.test(val[0]) === true) {
+                                                val[0] = "0";
+                                            }
+                                            if (zero.test(val[1]) === true) {
+                                                val[1] = "0";
+                                            }
+                                            if (zero.test(val[2]) === true) {
+                                                val[2] = "0";
+                                            }
+                                            if (zero.test(val[3]) === true) {
+                                                val[3] = "0";
+                                            }
+                                            if (val[1] === val[3]) {
+                                                val.pop();
+                                                if (val[0] === val[2]) {
+                                                    val.pop();
+                                                    if (val[0] === val[1]) {
+                                                        val.pop();
+                                                    }
+                                                }
+                                            }
+                                            token[set[start][2]] = val.join(" ");
+                                            if (token[set[start][2]].indexOf("!important") > 0) {
+                                                token[set[start][2]] = token[set[start][2]].replace(/\s!important/g, "") + " !i" +
+                                                        "mportant";
+                                            }
+                                            if (options.mode === "beautify" && verticalop === true) {
+                                                if (token[set[start][0]].charAt(token[set[start][0]].length - 1) === " ") {
+                                                    yy = token[set[start][0]].length - name.length;
+                                                    do {
+                                                        name = name + " ";
+                                                        yy   = yy - 1;
+                                                    } while (yy > 0);
+                                                }
+                                            }
+                                        }
+                                        break;
+                                    }
+                                }
+                            };
+                        for (aa = 0; aa < leng; aa = aa + 1) {
+                            if (types[set[aa][0]] === "property") {
+                                if (token[set[aa][0]].indexOf("margin") === 0) {
+                                    fourcount("margin");
+                                }
+                                if (token[set[aa][0]].indexOf("padding") === 0) {
+                                    fourcount("padding");
+                                }
+                            }
+                        }
+                    }());
+
+                    //pad out those property names so that the colons are vertically aligned
+                    if (verticalop === true) {
+                        bb = 0;
+                        for (aa = p.length - 1; aa > -1; aa = aa - 1) {
+                            if (token[p[aa]].length > bb && token[p[aa]] !== "filter" && token[p[aa]] !== "progid") {
+                                bb = token[p[aa]].length;
+                            }
+                        }
+                        for (aa = p.length - 1; aa > -1; aa = aa - 1) {
+                            cc = bb - token[p[aa]].length;
+                            if (cc > 0 && token[p[aa]] !== "filter" && token[p[aa]] !== "progid") {
+                                do {
+                                    token[p[aa]] = token[p[aa]] + " ";
+                                    cc           = cc - 1;
+                                } while (cc > 0);
+                            }
+                        }
+                        if (endtest === false) {
+                            return;
+                        }
+                    }
+
+                    bb = set.length;
+                    for (aa = 0; aa < bb; aa = aa + 1) {
+                        dd = set[aa].length;
+                        for (cc = 0; cc < dd; cc = cc + 1) {
+                            stoke.push(token[set[aa][cc]]);
+                            stype.push(types[set[aa][cc]]);
+                            sline.push(lines[set[aa][cc]]);
+                            sdept.push(depth[set[aa][cc]]);
+                            sbegn.push(begin[set[aa][cc]]);
+                        }
+                    }
+                    //replace a block's data with sorted analyzed data
+                    token.splice(next + 1, token.length - next - 1);
+                    types.splice(next + 1, types.length - next - 1);
+                    lines.splice(next + 1, lines.length - next - 1);
+                    depth.splice(next + 1, depth.length - next - 1);
+                    begin.splice(next + 1, begin.length - next - 1);
+                    token = token.concat(stoke);
+                    types = types.concat(stype);
+                    lines = lines.concat(sline);
+                    depth = depth.concat(sdept);
+                    begin = begin.concat(sbegn);
+                };
+            //token building loop
+            for (a = 0; a < len; a = a + 1) {
+                if (ltype !== "comment" && ltype !== "comment-inline" && ltype !== "" && options.topcoms === true) {
+                    options.topcoms = false;
+                }
+                if ((/\s/).test(b[a]) === true) {
+                    stats.space = stats.space + 1;
+                    space       = space + b[a];
+                } else if (b[a] === "/" && b[a + 1] === "*") {
+                    comment(false);
+                } else if (b[a] === "/" && b[a + 1] === "/") {
+                    comment(true);
+                } else if (b[a] === "<" && b[a + 1] === "?" && b[a + 2] === "p" && b[a + 3] === "h" && b[a + 4] === "p") {
+                    //php
+                    external("<?php", "?>");
+                } else if (b[a] === "<" && b[a + 1] === "%") {
+                    //asp
+                    external("<%", "%>");
+                } else if (b[a] === "{" && b[a + 1] === "%") {
+                    //asp
+                    external("{%", "%}");
+                } else if (b[a] === "{" && b[a + 1] === "{" && b[a + 2] === "{") {
+                    //mustache
+                    external("{{{", "}}}");
+                } else if (b[a] === "{" && b[a + 1] === "{") {
+                    //handlebars
+                    external("{{", "}}");
+                } else if (b[a] === "<" && b[a + 1] === "!" && b[a + 2] === "-" && b[a + 3] === "-" && b[a + 4] === "#") {
+                    //ssi
+                    external("<!--#", "-->");
+                } else if (b[a] === "@" && b[a + 1] === "e" && b[a + 2] === "l" && b[a + 3] === "s" && b[a + 4] === "e" && (b[a + 5] === "{" || (/\s/).test(b[a + 5]) === true)) {
+                    types.push("external_else");
+                    token.push("@else");
+                    lines.push(0);
+                    depth.push(depth[depth.length - 1]);
+                    begin.push(begin[begin.length - 1]);
+                    a = a + 4;
+                } else if (b[a] === "{" || (b[a] === "(" && token[token.length - 1] === ":" && types[types.length - 2] === "propvar")) {
+                    if (b[a] === "{" && token[token.length - 2] === ":") {
+                        types[types.length - 1] = "pseudo";
+                    }
+                    item("start");
+                    struct.push(token.length);
+                    ltype = "start";
+                    types.push("start");
+                    token.push(b[a]);
+                    begin.push(token.length);
+                    if (b[a] === "(") {
+                        structval = "map";
+                        depth.push("map");
+                        mapper.push(0);
+                    } else {
+                        structval = "block";
+                        depth.push("block");
+                    }
+                    nosort.push(false);
+                    lines.push(spacer(false));
+                    stats.braces = stats.braces + 1;
+                } else if (b[a] === "}" || (b[a] === ")" && structval === "map" && mapper[mapper.length - 1] === 0)) {
+                    endtest = true;
+                    if (b[a] === "}" && types[types.length - 1] === "item" && token[token.length - 2] === "{" && token[token.length - 3] !== undefined && token[token.length - 3].charAt(token[token.length - 3].length - 1) === "@") {
+                        token[token.length - 3] = token[token.length - 3] + "{" + token[token.length - 1] +
+                                "}";
+                        token.pop();
+                        token.pop();
+                        types.pop();
+                        types.pop();
+                        lines.pop();
+                        lines.pop();
+                        depth.pop();
+                        depth.pop();
+                        begin.pop();
+                        begin.pop();
+                    } else {
+                        if (b[a] === ")") {
+                            mapper.pop();
+                        } else if (b[a] === "}" && ltype === "value" && token[token.length - 1] !== ";") {
+                            token.push(";");
+                            types.push("semi");
+                            lines.push(0);
+                            depth.push("block");
+                            begin.push(begin[begin.length - 1]);
+                        }
+                        item("end");
+                        if (options.mode !== "diff") {
+                            properties();
+                        }
+                        ltype = "end";
+                        if (objsortop === true && nosort[nosort.length - 1] === false) {
+                            objSort();
+                        }
+                        nosort.pop();
+                        types.push("end");
+                        token.push(b[a]);
+                        lines.push(spacer(false));
+                        depth.push(structval);
+                        begin.push(struct[struct.length - 1]);
+                        stats.braces = stats.braces + 1;
+                    }
+                    struct.pop();
+                    if (token[struct[struct.length - 1]] === "{") {
+                        structval = "block";
+                    } else if (token[struct[struct.length - 1]] === "(") {
+                        structval = "map";
+                    } else {
+                        structval = "root";
+                    }
+                } else if (b[a] === ";" || (b[a] === "," && structval === "map")) {
+                    item("semi");
+                    if (types[types.length - 1] !== "semi" && types[types.length - 1] !== "start" && esctest(a) === false) {
+                        ltype = "semi";
+                        types.push("semi");
+                        token.push(b[a]);
+                        lines.push(spacer(false));
+                        depth.push(structval);
+                        begin.push(begin[begin.length - 1]);
+                    }
+                    stats.semi = stats.semi + 1;
+                    space      = "";
+                } else if (b[a] === ":" && types[types.length - 1] !== "end") {
+                    item("colon");
+                    types.push("colon");
+                    token.push(":");
+                    if ((/\s/).test(b[a - 1]) === true) {
+                        lines.push(1);
+                    } else {
+                        lines.push(0);
+                    }
+                    ltype       = "colon";
+                    stats.colon = stats.colon + 1;
+                    space       = "";
+                } else {
+                    if (structval === "map" && b[a] === "(") {
+                        mapper[mapper.length - 1] = mapper[mapper.length - 1] + 1;
+                    }
+                    buildtoken();
+                }
+            }
+            if (endtest === false && verticalop === true) {
+                properties();
+            }
+        }());
+
+        if (options.mode === "parse") {
+            return (function csspretty__parse() {
+                var a      = 0,
+                    c      = token.length,
+                    record = [],
+                    def    = {
+                        token: "string - The parsed code tokens",
+                        types: "string - Data types of the tokens: colon, comment, comment-inline, end, extern" +
+                                "al, external_else, external_end, external_start, item, propvar, pseudo, select" +
+                                "or, semi, start, value",
+                        lines: "number - Whether the token is preceeded any space and/or line breaks in the or" +
+                                "iginal code source",
+                        depth: "string - Type of current structure",
+                        begin: "number - Index where current structure begins"
+                    };
+                if (options.parseFormat === "sequential") {
+                    for (a = 0; a < c; a = a + 1) {
+                        record.push([
+                            token[a], types[a], lines[a], depth[a], begin[a]
+                        ]);
+                    }
+                    if (options.nodeasync === true) {
+                        return [
+                            {
+                                data      : record,
+                                definition: def
+                            },
+                            ""
+                        ];
+                    }
+                    return {data: record, definition: def};
+                }
+                if (options.parseFormat === "htmltable") {
+                    return (function csspretty__parse_html() {
+                        var report = [],
+                            aa     = 0,
+                            len    = 0;
+                        report.push("<table summary='CSS parse table'><thead><tr><th>index</th>");
+                        report.push("<th>token</th>");
+                        report.push("<th>types</th>");
+                        report.push("<th>lines</th>");
+                        report.push("<th>depth</th>");
+                        report.push("<th>begin</th>");
+                        report.push("</tr></thead><tbody>");
+                        len = token.length;
+                        for (aa = 0; aa < len; aa = aa + 1) {
+                            report.push("<tr><td>");
+                            report.push(aa);
+                            report.push("</td><td>");
+                            report.push(
+                                token[aa].replace(/&/g, "&amp;").replace(/>/g, "&gt;").replace(/</g, "&lt;")
+                            );
+                            report.push("</td><td>");
+                            report.push(types[aa]);
+                            report.push("</td><td>");
+                            report.push(lines[aa]);
+                            report.push("</td><td>");
+                            report.push(depth[aa]);
+                            report.push("</td><td>");
+                            report.push(begin[aa]);
+                            report.push("</td></tr>");
+                        }
+                        report.push("</tbody></table>");
+                        if (options.nodeasync === true) {
+                            return [
+                                {
+                                    data      : report.join(""),
+                                    definition: def
+                                },
+                                ""
+                            ];
+                        }
+                        return {data: report.join(""), definition: def};
+                    }());
+                }
+                if (options.nodeasync === true) {
+                    return [
+                        {
+                            data      : {
+                                token: token,
+                                types: types,
+                                lines: lines,
+                                depth: depth,
+                                begin: begin
+                            },
+                            definition: def
+                        },
+                        ""
+                    ];
+                }
+                return {
+                    data      : {
+                        token: token,
+                        types: types,
+                        lines: lines,
+                        depth: depth,
+                        begin: begin
+                    },
+                    definition: def
+                };
+            }());
+        }
+
+        //analysis
+        if (options.mode === "analysis") {
+            return (function csspretty__summary() {
+                var summ  = [],
+                    inl   = options.source.length,
+                    out   = output.length,
+                    uris  = uri.length,
+                    uric  = 0,
+                    a     = 0,
+                    b     = 0,
+                    color = [];
+                (function csspretty_summary_colorNormalize() {
+                    var aa = 0,
+                        bb = 0,
+                        cc = colors.length;
+                    colors.sort();
+                    color.push(colors[0]);
+                    for (aa = 0; aa < cc; aa = aa + 1) {
+                        if (colors[aa] !== color[bb]) {
+                            color.push(colors[aa]);
+                            bb = bb + 1;
+                        }
+                    }
+                }());
+                summ.push(
+                    "<div class='report' id='cssreport'><p><strong>Number of HTTP requests:</strong" +
+                    "> <em>"
+                );
+                summ.push(uris);
+                summ.push(
+                    "</em></p><table class='analysis' id='css-parts' summary='Component counts and " +
+                    "sizes'><caption>Component counts and sizes</caption><thead><tr><th>Type Name</" +
+                    "th><th>Quantity</th><th>Character Size</th></tr></thead><tbody><tr><th>curly b" +
+                    "races</th><td>"
+                );
+                summ.push(stats.braces);
+                summ.push("</td><td>");
+                summ.push(stats.braces);
+                summ.push("</td></tr><tr><th>colon</th><td>");
+                summ.push(stats.colon);
+                summ.push("</td><td>");
+                summ.push(stats.colon);
+                summ.push("</td></tr><tr><th>comments</th><td>");
+                summ.push(stats.comments.count);
+                summ.push("</td><td>");
+                summ.push(stats.comments.chars);
+                summ.push("</td></tr><tr><th>properties</th><td>");
+                summ.push(stats.properties.count);
+                summ.push("</td><td>");
+                summ.push(stats.properties.chars);
+                summ.push("</td></tr><tr><th>selectors</th><td>");
+                summ.push(stats.selectors.count);
+                summ.push("</td><td>");
+                summ.push(stats.selectors.chars);
+                summ.push("</td></tr><tr><th>semicolons</th><td>");
+                summ.push(stats.semi);
+                summ.push("</td><td>");
+                summ.push(stats.semi);
+                summ.push("</td></tr><tr><th>white space</th><td>");
+                summ.push(stats.space);
+                summ.push("</td><td>");
+                summ.push(stats.space);
+                summ.push("</td></tr><tr><th>values</th><td>");
+                summ.push(stats.values.count);
+                summ.push("</td><td>");
+                summ.push(stats.values.chars);
+                summ.push("</td></tr><tr><th>variables</th><td>");
+                summ.push(stats.variables.count);
+                summ.push("</td><td>");
+                summ.push(stats.variables.chars);
+                summ.push(
+                    "</td></tr></tbody></table><table class='analysis' id='css-size' summary='CSS c" +
+                    "haracter size change'><caption>CSS character size change</caption><tbody><tr><" +
+                    "th>Input</th><td>"
+                );
+                summ.push(inl);
+                summ.push("</td></tr><tr><th>Output</th><td>");
+                summ.push(out);
+                summ.push("</td></tr><tr><th>");
+                if (out > inl) {
+                    summ.push("Increase</th><td>");
+                    summ.push(out - inl);
+                    summ.push("</td></tr><tr><th>Percent Change</th><td>");
+                    a = (((out - inl) / out) * 100);
+                    summ.push(a.toFixed(2));
+                } else {
+                    summ.push("Decrease</th><td>");
+                    summ.push(inl - out);
+                    summ.push("</td></tr><tr><th>Percent Change</th><td>");
+                    a = (((inl - out) / inl) * 100);
+                    summ.push(a.toFixed(2));
+                }
+                summ.push(
+                    "%</td></tr></tbody></table><table class='analysis' id='css-uri' summary='A lis" +
+                    "t of HTTP requests'><caption>A List of HTTP Requests</caption><thead><tr><th>Q" +
+                    "uantity</th><th>URI</th></tr></thead><tbody>"
+                );
+                for (a = 0; a < uris; a = a + 1) {
+                    uric = 1;
+                    for (b = a + 1; b < uris; b = b + 1) {
+                        if (uri[a] === uri[b]) {
+                            uric = uric + 1;
+                            uri.splice(b, 1);
+                            uris = uris - 1;
+                        }
+                    }
+                    summ.push("<tr><td>");
+                    summ.push(uric);
+                    summ.push("</td><td>");
+                    summ.push(
+                        uri[a].replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+                    );
+                    summ.push("</td></tr>");
+                }
+                summ.push("</tbody></table>");
+                summ.push("</div><span class='clear'></span>");
+                if (color.length === 0) {
+                    summ.push("<h4>0 colors were identified in the provided code.</h4>");
+                } else {
+                    summ.push("<h4>These ");
+                    summ.push(color.length);
+                    if (color.length > 1) {
+                        summ.push(" different");
+                    }
+                    summ.push(" color");
+                    if (color.length > 1) {
+                        summ.push("s");
+                    }
+                    summ.push(" were identified in the provided code:</h4><p>");
+                    summ.push(color.join(", "));
+                    summ.push("</p>");
+                    if (options.accessibility === true) {
+                        (function csspretty__summary_colorConvert() {
+                            var vl        = "",
+                                bb        = color.length,
+                                aa        = 0,
+                                luminance = function csspretty__summary_colorConvert_luminance(rgb) {
+                                    var convert = function csspretty__summary_colorConvert_luminance_convert(x) {
+                                        if (x === 0) {
+                                            return 0;
+                                        }
+                                        x = (x / 255);
+                                        if ((x * 100000) <= 3928) {
+                                            return ((x * 100) / 1292) * 10000;
+                                        }
+                                        x = x * 100000;
+                                        return Math.pow(((x + 5500) / 105500), 2.4) * 10000;
+                                    };
+                                    return (
+                                        (2126 * convert(rgb[0])) + (7152 * convert(rgb[1])) + (722 * convert(rgb[2]))
+                                    ) / 100000000;
+                                },
+                                hexToDec  = function csspretty__summary_colorConvert_hexToDec(val) {
+                                    var str = val
+                                            .slice(1)
+                                            .split(""),
+                                        rgb = [],
+                                        num = [],
+                                        aaa = 0,
+                                        bbb = str.length;
+                                    for (aaa = 0; aaa < bbb; aaa = aaa + 1) {
+                                        if (str[aaa] === "a") {
+                                            num.push(10);
+                                        } else if (str[aaa] === "b") {
+                                            num.push(11);
+                                        } else if (str[aaa] === "c") {
+                                            num.push(12);
+                                        } else if (str[aaa] === "d") {
+                                            num.push(13);
+                                        } else if (str[aaa] === "e") {
+                                            num.push(14);
+                                        } else if (str[aaa] === "f") {
+                                            num.push(15);
+                                        } else {
+                                            num.push(Number(str[aaa]));
+                                        }
+                                    }
+                                    if (bbb === 3) {
+                                        rgb.push((num[0] * 16) + num[0]);
+                                        rgb.push((num[1] * 16) + num[1]);
+                                        rgb.push((num[2] * 16) + num[2]);
+                                    } else {
+                                        rgb.push((num[0] * 16) + num[1]);
+                                        rgb.push((num[2] * 16) + num[3]);
+                                        rgb.push((num[4] * 16) + num[5]);
+                                    }
+                                    return luminance(rgb);
+                                },
+                                rgbToDec  = function csspretty__summary_colorConvert_rgbToDec(val) {
+                                    var rgb  = [],
+                                        rgbs = [],
+                                        rr   = 0;
+                                    if (vl.charAt(3) === "a") {
+                                        vl   = vl
+                                            .slice(5, vl.length - 1)
+                                            .replace(/\s+/g, "");
+                                        rgbs = vl.split(",");
+                                        rgbs.pop();
+                                    } else {
+                                        vl   = vl
+                                            .slice(4, vl.length - 1)
+                                            .replace(/\s+/g, "");
+                                        rgbs = vl.split(",");
+                                    }
+                                    do {
+                                        if ((/^([0-9a-f]{2})$/).test(rgbs[rr]) === false) {
+                                            if (rgbs[rr].charAt(rgbs[rr].length - 1) === "%") {
+                                                vl = rgbs[rr].slice(0, rgbs[rr].length - 1);
+                                                if (isNaN(vl) === true) {
+                                                    return val;
+                                                }
+                                                rgb.push(Number(vl));
+                                                if (rgb[rr] < 0) {
+                                                    rgb[rr] = 0;
+                                                } else if (rgb[rr] > 100) {
+                                                    rgb[rr] = 100;
+                                                }
+                                                rgb[rr] = Math.round(2.55 * rgb[rr]);
+                                            } else {
+                                                if (isNaN(rgbs[rr]) === true) {
+                                                    return val;
+                                                }
+                                                rgb.push(Number(rgbs[rr]));
+                                                if (rgb[rr] < 0) {
+                                                    rgb[rr] = 0;
+                                                } else if (rgb[rr] > 255) {
+                                                    rgb[rr] = 255;
+                                                }
+                                                rgb[rr] = Math.round(rgb[rr]);
+                                            }
+                                        }
+                                        rr = rr + 1;
+                                    } while (rr < 3);
+                                    return luminance(rgb);
+                                };
+                            colors = [];
+                            for (aa = 0; aa < bb; aa = aa + 1) {
+                                if (color[aa] === undefined) {
+                                    break;
+                                }
+                                vl = color[aa].toLowerCase();
+                                if ((/^(#[0-9a-f]{3,6})$/).test(vl) === true) {
+                                    colors.push(hexToDec(vl.slice(1)));
+                                } else if ((/^(rgba?\()/).test(vl) === true) {
+                                    colors.push(rgbToDec(vl));
+                                } else if (colorNames[vl] !== undefined) {
+                                    colors.push(colorNames[vl]);
+                                }
+                            }
+                        }());
+                    }
+                }
+                if (options.nodeasync === true) {
+                    return [summ.join(""), ""];
+                }
+                return summ.join("");
+            }());
+        }
+
+        //beautification
+        if (options.mode !== "minify") {
+            output = (function csspretty__beautify() {
+                var a        = 0,
+                    len      = token.length,
+                    build    = [],
+                    indent   = options.inlevel,
+                    mixin    = false,
+                    //a single unit of indentation
+                    tab      = (function csspretty__beautify_tab() {
+                        var aa = 0,
+                            bb = [];
+                        for (aa = 0; aa < options.insize; aa = aa + 1) {
+                            bb.push(options.inchar);
+                        }
+                        return bb.join("");
+                    }()),
+                    //new lines plus indentation
+                    nl       = function csspretty__beautify_nl(tabs) {
+                        var aa = 0;
+                        if (build[build.length - 1] === tab) {
+                            do {
+                                build.pop();
+                            } while (build[build.length - 1] === tab);
+                        }
+                        build.push(lf);
+                        for (aa = 0; aa < tabs; aa = aa + 1) {
+                            build.push(tab);
+                        }
+                    },
+                    //breaks selector lists onto newlines
+                    selector = function csspretty__beautify_selector(item) {
+                        var aa    = 0,
+                            bb    = 0,
+                            cc    = 0,
+                            block = "",
+                            items = [],
+                            leng  = item.length;
+                        if (options.compressedcss === true && (/\)\s*when\s*\(/).test(item) === true) {
+                            item = item.replace(
+                                /\)\s*when\s*\(/,
+                                ")" + lf + (function csspretty__beautify_selector_whenTab() {
+                                    var wtab = "",
+                                        aaa  = indent + 1;
+                                    do {
+                                        wtab = wtab + tab;
+                                        aaa  = aaa - 1;
+                                    } while (aaa > 0);
+                                    return wtab;
+                                }()) + "when ("
+                            );
+                        }
+                        for (aa = 0; aa < leng; aa = aa + 1) {
+                            if (block === "") {
+                                if (item.charAt(aa) === "\"") {
+                                    block = "\"";
+                                    bb    = bb + 1;
+                                } else if (item.charAt(aa) === "'") {
+                                    block = "'";
+                                    bb    = bb + 1;
+                                } else if (item.charAt(aa) === "(") {
+                                    block = ")";
+                                    bb    = bb + 1;
+                                } else if (item.charAt(aa) === "[") {
+                                    block = "]";
+                                    bb    = bb + 1;
+                                }
+                            } else if ((item.charAt(aa) === "(" && block === ")") || (item.charAt(aa) === "[" && block === "]")) {
+                                bb = bb + 1;
+                            } else if (item.charAt(aa) === block) {
+                                bb = bb - 1;
+                                if (bb === 0) {
+                                    block = "";
+                                }
+                            }
+                            if (block === "" && item.charAt(aa) === ",") {
+                                items.push(item.substring(cc, aa + 1));
+                                cc = aa + 1;
+                            }
+                        }
+                        if (cc > 0) {
+                            items.push(item.substr(cc));
+                        }
+                        leng = items.length;
+                        if (leng === 0) {
+                            items.push(item);
+                        }
+                        if (options.selectorlist === true) {
+                            build.push(items.join(" "));
+                        } else {
+                            build.push(items[0].replace(/,(\s*)/g, ", ").replace(/(,\u0020)$/, ","));
+                            for (aa = 1; aa < leng; aa = aa + 1) {
+                                nl(indent);
+                                build.push(items[aa].replace(/,(\s*)/g, ", ").replace(/(,\u0020)$/, ","));
+                            }
+                        }
+                        if (options.compressedcss === false) {
+                            build.push(" ");
+                        }
+                    };
+                if (options.inlevel > 0) {
+                    a = options.inlevel;
+                    do {
+                        a = a - 1;
+                        build.push(tab);
+                    } while (a > 0);
+                }
+
+                //beautification loop
+                for (a = 0; a < len; a = a + 1) {
+                    if (lines[a] > 1 && options.compressedcss === false && (types[a] === "start" || types[a] === "end" || types[a] === "selector" || types[a] === "comment" || types[a] === "property" || types[a] === "propvar" || types[a].indexOf("external") > -1)) {
+                        if (options.cssinsertlines === true && types[a] === "selector" && types[a - 1] !== "comment") {
+                            lines[a] = lines[a] - 1;
+                        }
+                        if (build[build.length - 1] === tab) {
+                            do {
+                                build.pop();
+                            } while (build[build.length - 1] === tab);
+                        }
+                        if (lines[a] > 1) {
+                            if (lines[a] > 2) {
+                                do {
+                                    lines[a] = lines[a] - 1;
+                                    build.push(lf);
+                                } while (lines[a] > 2);
+                            }
+                            nl(indent);
+                        }
+                    }
+                    if (types[a] === "start") {
+                        if (types[a - 1] === "propvar" && options.compressedcss === false) {
+                            build.push(" ");
+                        }
+                        if (a > 0 && token[a - 1].charAt(token[a - 1].length - 1) === "#") {
+                            build.push(token[a]);
+                        } else {
+                            if (options.braces === true) {
+                                if (build[build.length - 1] === " ") {
+                                    build.pop();
+                                }
+                                nl(indent);
+                            } else if (types[a - 1] === "colon") {
+                                build.push(" ");
+                            }
+                            build.push(token[a]);
+                            indent = indent + 1;
+                            if (types[a + 1] !== "end" && (options.compressedcss === false || (options.compressedcss === true && types[a + 1] === "start")) && (types[a + 1] !== "selector" || options.cssinsertlines === false)) {
+                                nl(indent);
+                            }
+                        }
+                    } else if (types[a] === "end") {
+                        if (types[a + 1] === "external_else") {
+                            indent = indent - 1;
+                            nl(indent);
+                            build.push(token[a]);
+                            build.push(" ");
+                            build.push(token[a + 1]);
+                            build.push(" ");
+                            a = a + 1;
+                        } else if (mixin === true) {
+                            mixin = false;
+                            build.push(token[a]);
+                            build.push(" ");
+                        } else {
+                            indent = indent - 1;
+                            if (types[a - 1] !== "start" && options.compressedcss === false) {
+                                nl(indent);
+                            }
+                            build.push(token[a]);
+                            if (options.compressedcss === true && types[a + 1] === "end") {
+                                nl(indent - 1);
+                            } else if (options.cssinsertlines === true && types[a + 1] === "selector" && lines[a] < 2 && token[a - 1] !== "{") {
+                                build.push(lf);
+                            } else if (types[a + 1] !== "end" && types[a + 1] !== "semi" && types[a + 1] !== "comment") {
+                                nl(indent);
+                            }
+                        }
+                    } else if (types[a] === "semi") {
+                        if (token[a] !== "x;" && (options.compressedcss === false || (options.compressedcss === true && types[a + 1] !== "end"))) {
+                            build.push(token[a]);
+                        }
+                        if (types[a + 1] === "comment-inline") {
+                            build.push(" ");
+                        } else if (types[a + 1] !== "end" && types[a + 1] !== "comment" && options.compressedcss === false) {
+                            if (options.cssinsertlines === true && types[a + 1] === "selector") {
+                                build.push(lf);
+                            } else if (lines[a + 1] > 0 || (types[a + 1] !== undefined && types[a + 1].indexOf("external") < 0)) {
+                                nl(indent);
+                            }
+                        }
+                    } else if (types[a] === "selector") {
+                        if (a > 0 && types[a - 1] !== "comment" && (options.cssinsertlines === true || (options.compressedcss === true && (types[a - 1] === "start" || types[a - 1] === "semi")))) {
+                            nl(indent);
+                        }
+                        if (token[a].charAt(token[a].length - 1) === "#") {
+                            build.push(token[a]);
+                            mixin = true;
+                        } else if (token[a].indexOf(",") > -1) {
+                            selector(token[a]);
+                        } else {
+                            if (token[a].charAt(0) === ":" && token[a - 1] === "}" && build[build.length - 1] === " ") {
+                                build.pop();
+                            }
+                            build.push(token[a]);
+                            if (options.compressedcss === false) {
+                                build.push(" ");
+                            }
+                        }
+                    } else if ((types[a] === "comment" || types[a] === "comment-inline") && types[a - 1] !== "colon" && types[a - 1] !== "property") {
+                        if (types[a - 1] === "value" && types[a] === "comment-inline") {
+                            build.push(" ");
+                        }
+                        if (a > 0 && options.compressedcss === true && types[a] === "comment" && types[a - 1] !== "comment") {
+                            build.push(lf);
+                            nl(indent);
+                        } else if (a > 0 && types[a - 1] !== "start" && types[a] !== "comment-inline") {
+                            nl(indent);
+                        }
+                        build.push(token[a]);
+                        if (types[a + 1] !== "end" && types[a + 1] !== "comment") {
+                            nl(indent);
+                        }
+                    } else {
+                        if (types[a - 1] !== "semi" && options.compressedcss === false && (mixin === false || token[a - 1] === ":") && token[a - 2] !== "filter" && token[a - 2] !== "progid") {
+                            if (types[a] === "value" || (types[a].indexOf("external") > -1 && types[a - 1] === "colon")) {
+                                build.push(" ");
+                            }
+                        } else if (options.compressedcss === true && (types[a] === "value" || types[a] === "propvar")) {
+                            token[a] = token[a].replace(/(\s*,\s*)/g, ",");
+                        }
+                        if (types[a] === "external_start") {
+                            indent = indent + 1;
+                        } else if (types[a] === "external_end") {
+                            indent = indent - 1;
+                            if (build[build.length - 1] === tab) {
+                                build.pop();
+                            }
+                        } else if (types[a] === "external_else" && build[build.length - 1] === tab) {
+                            build.pop();
+                        }
+                        build.push(token[a]);
+                        if (types[a].indexOf("external") > -1 && types[a + 1] !== "semi") {
+                            if ((types[a + 1] !== undefined && types[a + 1].indexOf("external") > -1) || (lines[a + 1] === 1 && types[a + 1] !== "end") || lines[a + 1] > 1) {
+                                nl(indent);
+                            }
+                        }
+                    }
+                }
+                if (options.newline === true) {
+                    if (options.crlf === true) {
+                        build.push("\r\n");
+                    } else {
+                        build.push("\n");
+                    }
+                }
+                if (options.preserve > 0 && (lines[lines.length - 1] > 0 || endline === true)) {
+                    return build
+                        .join("")
+                        .replace(/(\s+)$/, lf);
+                }
+                return build
+                    .join("")
+                    .replace(/(\s+)$/, "");
+            }());
+        } else {
+            if (options.newline === true) {
+                if (options.crlf === true) {
+                    output.push("\r\n");
+                } else {
+                    output.push("\n");
+                }
+            }
+            output = token
+                .join("")
+                .replace(/;\}/g, "}");
+        }
+        if (options.nodeasync === true) {
+            return [output, ""];
+        }
+        return output;
+    };
+    if ((typeof define === "object" || typeof define === "function") && (typeof ace !== "object" || ace.prettydiffid === undefined)) {
+        //requirejs support
+        define(function csspretty_requirejs() {
+            return function csspretty_requirejs_wrapper(x) {
+                return csspretty(x);
+            };
+        });
+    } else if (typeof module === "object" && typeof module.parent === "object") {
+        //commonjs and nodejs support
+        module.exports = csspretty;
+    } else {
+        global.prettydiff.csspretty = csspretty;
+    }
+}());

--- a/node_modules/prettydiff/lib/csvpretty.js
+++ b/node_modules/prettydiff/lib/csvpretty.js
@@ -1,0 +1,106 @@
+/*prettydiff.com api.topcoms:true,api.insize:4,api.inchar:" ",api.vertical:true */
+/*global ace, define, global, module*/
+/***********************************************************************
+ csvpretty is written by Austin Cheney on 2 Oct 2015.
+
+ Please see the license.txt file associated with the Pretty Diff
+ application for license information.
+ **********************************************************************/
+(function () {
+    "use strict";
+    var csvpretty = function csvpretty_(options) {
+        var token = [];
+        options.csvchar = (typeof options.csvchar === "string")
+            ? options.csvchar
+            : ",";
+        options.source  = (
+            typeof options.source !== "string" || options.source === "" || (/^(\s+)$/).test(options.source) === true
+        )
+            ? "Error: no source supplied to csvpretty."
+            : options
+                .source
+                .replace(/\r\n/g, "\n")
+                .replace(/\r/g, "\n");
+        (function csvpretty__tokenize() {
+            var input      = options
+                    .source
+                    .split(""),
+                d          = options.csvchar.length,
+                e          = 0,
+                cell       = [],
+                row        = [],
+                quote      = false,
+                cellCrunch = function csvpretty__tokenize_cellCrunch() {
+                    var str = cell.join("");
+                    cell = [];
+                    if (str !== "") {
+                        row.push(str);
+                    }
+                },
+                parse      = function csvpretty__tokenize_parse(item, index, arr) {
+                    if (quote === false) {
+                        if (cell.length === 0 && item === "\"" && (arr[index + 1] !== "\"" || arr[index + 2] === "\"")) {
+                            quote = true;
+                        } else if (item === "\"" && arr[index + 1] === "\"") {
+                            cell.push("\"");
+                            arr[index + 1] = "";
+                        } else if (item === "\n") {
+                            cellCrunch();
+                            token.push(row);
+                            row = [];
+                        } else if (item === options.csvchar.charAt(0)) {
+                            if (d === 1) {
+                                cellCrunch();
+                            } else {
+                                e = 0;
+                                do {
+                                    e = e + 1;
+                                } while (e < d && arr[index + e] === options.csvchar.charAt(e));
+                                if (e === d) {
+                                    cellCrunch();
+                                    e = 1;
+                                    do {
+                                        arr[index + e] = "";
+                                        e              = e + 1;
+                                    } while (e < d);
+                                } else if (item !== "") {
+                                    cell.push(item);
+                                }
+                            }
+                        } else if (item !== "") {
+                            cell.push(item);
+                        }
+                    } else if (item !== "\"" && item !== "") {
+                        cell.push(item);
+                    } else if (item === "\"" && arr[index + 1] === "\"") {
+                        cell.push("\"");
+                        arr[index + 1] = "";
+                    } else if (item === "\"") {
+                        cellCrunch();
+                        quote = false;
+                    }
+                };
+            input.forEach(parse);
+            if (cell.length > 0) {
+                cellCrunch();
+                token.push(row);
+            }
+        }());
+        return token;
+    };
+    if ((typeof define === "object" || typeof define === "function") && (typeof ace !== "object" || ace.prettydiffid === undefined)) {
+        //requirejs support
+        define(function csvpretty_requirejs() {
+            return function csvpretty_requirejs_wrapper(x) {
+                return csvpretty(x);
+            };
+        });
+    } else if (typeof module === "object" && typeof module.parent === "object") {
+        //commonjs and nodejs support
+        module.exports = function commonjs_csvpretty(x) {
+            return csvpretty(x);
+        };
+    } else {
+        global.prettydiff.csvpretty = csvpretty;
+    }
+}());

--- a/node_modules/prettydiff/lib/diffview.js
+++ b/node_modules/prettydiff/lib/diffview.js
@@ -1,0 +1,1379 @@
+/*global ace, define, global, module*/
+/*jshint laxbreak: true*/
+/*
+
+Written by Austin Cheney on 1 Mar 2017
+
+ Please see the license.txt file associated with the Pretty Diff
+ application for license information.
+
+ * Output - an array of three indexes:
+ * 1) Diff result as a HTML table
+ * 2) Number of errors after the number of error lines used for total
+ *    total error count when added to the next index
+ * 3) Number of error lines in the HTML table
+ */
+(function () {
+    "use strict";
+    var diffview = function diffview_(options) {
+        (function diffview__options() {
+            if (typeof options.diff === "string") {
+                if (options.functions !== undefined) {
+                    options.diff = options
+                        .diff
+                        .replace(options.functions.binaryCheck, "");
+                }
+                if (options.semicolon === true) {
+                    options.diff = options
+                        .diff
+                        .replace(/;\n/g, "\n")
+                        .replace(/;$/, "");
+                }
+            }
+            if (typeof options.source === "string") {
+                if (options.functions !== undefined) {
+                    options.source = options
+                        .source
+                        .replace(options.functions.binaryCheck, "");
+                }
+                if (options.semicolon === true) {
+                    options.source = options
+                        .source
+                        .replace(/;\n/g, "\n")
+                        .replace(/;$/, "");
+                }
+            }
+            options.diffview        = (options.diffview === "inline")
+                ? "inline"
+                : "sidebyside";
+            options.diffcomments    = (
+                options.diffcomments === true || options.diffcomments === "true"
+            );
+            options.diffspaceignore = (
+                options.diffspaceignore === true || options.diffspaceignore === "true"
+            );
+            options.quote           = (options.quote === true || options.quote === "true");
+            options.semicolon       = (
+                options.semicolon === true || options.semicolon === "true"
+            );
+            options.content         = (options.content === true || options.content === "true");
+            options.diffcli         = (options.diffcli === true || options.diffcli === "true");
+            options.context         = (isNaN(options.context) === false)
+                ? Number(options.context)
+                : -1;
+            if (options.diffcli === true && options.context < 0) {
+                options.context = 2;
+            }
+        }());
+        var errorout      = 0,
+            //diffline is a count of lines that are not equal
+            diffline      = 0,
+            //tab is a construct of a standard indentation for code
+            tab           = (function diffview__tab() {
+                var a      = 0,
+                    output = [];
+                if (options.inchar === "") {
+                    return "";
+                }
+                for (a = 0; a < options.insize; a = a + 1) {
+                    output.push(options.inchar);
+                }
+                return output.join("");
+            }()),
+            //translates source code from a string to an array by splitting on line breaks
+            stringAsLines = function diffview__stringAsLines(str) {
+                var lines = (options.diffcli === true)
+                    ? str
+                    : str
+                        .replace(/&/g, "&amp;")
+                        .replace(/&#lt;/g, "$#lt;")
+                        .replace(/&#gt;/g, "$#gt;")
+                        .replace(/</g, "$#lt;")
+                        .replace(/>/g, "$#gt;");
+                return lines.split("\n");
+            },
+            //array representation of base source
+            baseTextArray = (typeof options.source === "string")
+                ? stringAsLines(options.source)
+                : options.source,
+            //array representation of new source
+            newTextArray  = (typeof options.diff === "string")
+                ? stringAsLines(options.diff)
+                : options.diff,
+            opcodes       = [],
+            codeBuild     = function diffview__opcodes() {
+                var table           = {},
+                    one             = (typeof options.source === "string")
+                        ? options.source.split("\n")
+                        : options.source,
+                    two             = (typeof options.diff === "string")
+                        ? options.diff.split("\n")
+                        : options.diff,
+                    lena            = one.length,
+                    lenb            = two.length,
+                    a               = 0,
+                    b               = 0,
+                    c               = 0,
+                    d               = 0,
+                    codes           = [],
+                    fix             = function diffview__opcodes_fix(code) {
+                        var prior = codes[codes.length - 1];
+                        if (prior !== undefined) {
+                            if (prior[0] === code[0]) {
+                                if (code[0] === "replace" || code[0] === "equal") {
+                                    prior[2] = code[2];
+                                    prior[4] = code[4];
+                                } else if (code[0] === "delete") {
+                                    prior[2] = code[2];
+                                } else if (code[0] === "insert") {
+                                    prior[4] = code[4];
+                                }
+                                return;
+                            }
+                            if (prior[0] === "insert" && prior[4] - prior[3] === 1) {
+                                if (code[2] - code[1] === 1) {
+                                    if (code[0] === "replace") {
+                                        prior[0] = "replace";
+                                        prior[1] = code[1];
+                                        prior[2] = code[2];
+                                        code[0]  = "insert";
+                                        code[1]  = -1;
+                                        code[2]  = -1;
+                                    } else if (code[0] === "delete") {
+                                        code[0] = "replace";
+                                        code[3] = prior[3];
+                                        code[4] = prior[4];
+                                        codes.pop();
+                                        prior = codes[codes.length - 1];
+                                        if (prior[0] === "replace") {
+                                            prior[2] = code[2];
+                                            prior[4] = code[4];
+                                            return;
+                                        }
+                                    }
+                                } else if (code[0] === "delete") {
+                                    prior[0] = "replace";
+                                    prior[1] = code[1];
+                                    prior[2] = code[1] + 1;
+                                    code[1]  = code[1] + 1;
+                                } else if (code[0] === "replace") {
+                                    prior[0] = "replace";
+                                    prior[1] = code[1];
+                                    prior[2] = code[1] + 1;
+                                    c = prior[2];
+                                    d = prior[4];
+                                    return;
+                                }
+                            } else if (prior[0] === "insert" && code[0] === "delete" && code[2] - code[1] === 1) {
+                                prior[4] = prior[4] - 1;
+                                code[0]  = "replace";
+                                code[3]  = prior[4];
+                                code[4]  = prior[4] + 1;
+                            } else if (prior[0] === "delete" && prior[2] - prior[1] === 1) {
+                                if (code[4] - code[3] === 1) {
+                                    if (code[0] === "replace") {
+                                        prior[0] = "replace";
+                                        prior[3] = code[3];
+                                        prior[4] = code[4];
+                                        code[0]  = "delete";
+                                        code[3]  = -1;
+                                        code[4]  = -1;
+                                    } else if (code[0] === "insert") {
+                                        code[0] = "replace";
+                                        code[1] = prior[1];
+                                        code[2] = prior[2];
+                                        codes.pop();
+                                        prior = codes[codes.length - 1];
+                                        if (prior[0] === "replace") {
+                                            prior[2] = code[2];
+                                            prior[4] = code[4];
+                                            return;
+                                        }
+                                    }
+                                } else if (code[0] === "insert") {
+                                    prior[0] = "replace";
+                                    prior[3] = code[3];
+                                    prior[4] = code[3] + 1;
+                                    code[3]  = code[3] + 1;
+                                } else if (code[0] === "replace") {
+                                    prior[0] = "replace";
+                                    prior[3] = code[3];
+                                    prior[4] = code[4] + 1;
+                                    c = prior[2];
+                                    d = prior[4];
+                                    return;
+                                }
+                            } else if (prior[0] === "delete" && code[0] === "insert" && code[4] - code[3] === 1) {
+                                prior[2] = prior[2] - 1;
+                                code[0]  = "replace";
+                                code[1]  = prior[2];
+                                code[2]  = prior[2] + 1;
+                            } else if (prior[0] === "replace") {
+                                if (code[0] === "delete") {
+                                    if (one[code[2] - 1] === two[prior[4] - 1]) {
+                                        if (prior[2] - prior[1] > 1) {
+                                            prior[4] = prior[4] - 1;
+                                        }
+                                        c = c - 1;
+                                        d = d - 1;
+                                        return;
+                                    }
+                                    if (one[code[2]] === two[prior[4] - 1]) {
+                                        if (prior[2] - prior[1] > 1) {
+                                            prior[2]             = prior[2] - 1;
+                                            prior[4]             = prior[4] - 11;
+                                            table[one[c - 1]][0] = table[one[c - 1]][0] - 1;
+                                        }
+                                    }
+                                } else if (code[0] === "insert") {
+                                    if (one[prior[2] - 1] === two[code[4] - 1]) {
+                                        if (prior[2] - prior[1] > 1) {
+                                            prior[2] = prior[2] - 1;
+                                        }
+                                        c = c - 1;
+                                        d = d - 1;
+                                        return;
+                                    }
+                                    if (one[code[2] - 1] === two[prior[4]]) {
+                                        if (prior[4] - prior[3] > 1) {
+                                            prior[2]             = prior[2] - 1;
+                                            prior[4]             = prior[4] - 1;
+                                            table[two[d - 1]][1] = table[two[d - 1]][1] - 1;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        codes.push(code);
+                    },
+                    equality        = function diffview__opcodes_equality() {
+                        do {
+                            table[one[c]][0] = table[one[c]][0] - 1;
+                            table[one[c]][1] = table[one[c]][1] - 1;
+                            c                = c + 1;
+                            d                = d + 1;
+                        } while (c < lena && d < lenb && one[c] === two[d]);
+                        fix(["equal", a, c, b, d]);
+                        b = d - 1;
+                        a = c - 1;
+                    },
+                    deletion        = function diffview__opcodes_deletion() {
+                        do {
+                            table[one[c]][0] = table[one[c]][0] - 1;
+                            c                = c + 1;
+                        } while (c < lena && table[one[c]][1] < 1);
+                        fix(["delete", a, c, -1, -1]);
+                        a = c - 1;
+                        b = d - 1;
+                    },
+                    deletionStatic  = function diffview__opcodes_deletionStatic() {
+                        table[one[a]][0] = table[one[a]][0] - 1;
+                        fix([
+                            "delete", a, a + 1,
+                            -1,
+                            -1
+                        ]);
+                        a = c;
+                        b = d - 1;
+                    },
+                    insertion       = function diffview__opcodes_insertion() {
+                        do {
+                            table[two[d]][1] = table[two[d]][1] - 1;
+                            d                = d + 1;
+                        } while (d < lenb && table[two[d]][0] < 1);
+                        fix(["insert", -1, -1, b, d]);
+                        a = c - 1;
+                        b = d - 1;
+                    },
+                    insertionStatic = function diffview__opcodes_insertionStatic() {
+                        table[two[b]][1] = table[two[b]][1] - 1;
+                        fix([
+                            "insert", -1, -1, b, b + 1
+                        ]);
+                        a = c - 1;
+                        b = d;
+                    },
+                    replacement     = function diffview__opcodes_replacement() {
+                        do {
+                            table[one[c]][0] = table[one[c]][0] - 1;
+                            table[two[d]][1] = table[two[d]][1] - 1;
+                            c                = c + 1;
+                            d                = d + 1;
+                        } while (c < lena && d < lenb && table[one[c]][1] > 0 && table[two[d]][0] > 0);
+                        fix(["replace", a, c, b, d]);
+                        a = c - 1;
+                        b = d - 1;
+                    },
+                    replaceUniques  = function diffview__opcodes_replaceUniques() {
+                        do {
+                            table[one[c]][0] = table[one[c]][0] - 1;
+                            c                = c + 1;
+                            d                = d + 1;
+                        } while (c < lena && d < lenb && table[one[c]][1] < 1 && table[two[d]][0] < 1);
+                        fix(["replace", a, c, b, d]);
+                        a = c - 1;
+                        b = d - 1;
+                    };
+
+                // * First Pass, account for lines from first file
+                // * build the table from the second file
+                do {
+                    if (options.diffspaceignore === true) {
+                        two[b] = two[b].replace(/\s+/g, "");
+                    }
+                    if (table[two[b]] === undefined) {
+                        table[two[b]] = [0, 1];
+                    } else {
+                        table[two[b]][1] = table[two[b]][1] + 1;
+                    }
+                    b = b + 1;
+                } while (b < lenb);
+
+                // * Second Pass, account for lines from second file
+                // * build the table from the first file
+                lena = one.length;
+                a    = 0;
+                do {
+                    if (options.diffspaceignore === true) {
+                        one[a] = one[a].replace(/\s+/g, "");
+                    }
+                    if (table[one[a]] === undefined) {
+                        table[one[a]] = [1, 0];
+                    } else {
+                        table[one[a]][0] = table[one[a]][0] + 1;
+                    }
+                    a = a + 1;
+                } while (a < lena);
+                a = 0;
+                b = 0;
+                // find all equality... differences are what's left over solve only for the
+                // second set test removing reverse test removing undefined checks for table
+                // refs
+
+                do {
+                    c = a;
+                    d = b;
+                    if (one[a] === two[b]) {
+                        equality();
+                    } else if (table[one[a]][1] < 1 && table[two[b]][0] < 1) {
+                        replaceUniques();
+                    } else if (table[one[a]][1] < 1 && one[a + 1] !== two[b + 2]) {
+                        deletion();
+                    } else if (table[two[b]][0] < 1 && one[a + 2] !== two[b + 1]) {
+                        insertion();
+                    } else if (table[one[a]][0] - table[one[a]][1] === 1 && one[a + 1] !== two[b + 2]) {
+                        deletionStatic();
+                    } else if (table[two[b]][1] - table[two[b]][0] === 1 && one[a + 2] !== two[b + 1]) {
+                        insertionStatic();
+                    } else if (one[a + 1] === two[b]) {
+                        deletion();
+                    } else if (one[a] === two[b + 1]) {
+                        insertion();
+                    } else {
+                        replacement();
+                    }
+                    a = a + 1;
+                    b = b + 1;
+                } while (a < lena && b < lenb);
+                if (lena - a === lenb - b) {
+                    if (one[a] === two[b]) {
+                        fix(["equal", a, lena, b, lenb]);
+                    } else {
+                        fix(["replace", a, lena, b, lenb]);
+                    }
+                } else if (a < lena) {
+                    fix(["delete", a, lena, -1, -1]);
+                } else if (b < lenb) {
+                    fix(["insert", -1, -1, b, lenb]);
+                }
+                return codes;
+            };
+
+        if (Array.isArray(options.source) === false && typeof options.source !== "string") {
+            return "Error: source value is not a string or array!";
+        }
+        if (Array.isArray(options.diff) === false && typeof options.diff !== "string") {
+            return "Error: diff value is not a string or array!";
+        }
+
+        opcodes = codeBuild();
+        //diffview application contains three primary parts
+        // 1.  opcodes - performs the 'largest common subsequence'    calculation to
+        // determine which lines are different.  I    did not write this logic.  I have
+        // rewritten it for    performance, but original logic is still intact.
+        // 2.  charcomp - performs the 'largest common subsequence' upon    characters
+        // of two compared lines.
+        // 3.  The construction of the output into the 'node' array errorout is a count
+        // of differences after the opcodes generate the other two core pieces of logic
+        // are quaranteened into an anonymous function.
+        return (function diffview__report() {
+            var a              = 0,
+                i              = 0,
+                node           = ["<div class='diff'>"],
+                data           = (options.diffcli === true)
+                    ? []
+                    : [
+                        [], [], [], []
+                    ],
+                baseStart      = 0,
+                baseEnd        = 0,
+                newStart       = 0,
+                newEnd         = 0,
+                rowcnt         = 0,
+                rowItem        = -1,
+                rcount         = 0,
+                foldcount      = 0,
+                foldstart      = -1,
+                jump           = 0,
+                finaldoc       = "",
+                tabFix         = (tab === "")
+                    ? ""
+                    : new RegExp("^((" + tab.replace(/\\/g, "\\") + ")+)"),
+                noTab          = function diffview__report_noTab(str) {
+                    var b      = 0,
+                        strLen = str.length,
+                        output = [];
+                    for (b = 0; b < strLen; b = b + 1) {
+                        output.push(str[b].replace(tabFix, ""));
+                    }
+                    return output;
+                },
+                htmlfix        = function diffview__report_htmlfix(item) {
+                    return item.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+                },
+                baseTab        = (tab === "")
+                    ? []
+                    : noTab(baseTextArray),
+                newTab         = (tab === "")
+                    ? []
+                    : noTab(newTextArray),
+                opcodesLength  = opcodes.length,
+                change         = "",
+                btest          = false,
+                ntest          = false,
+                repeat         = false,
+                ctest          = true,
+                code           = [],
+                charcompOutput = [],
+                // this is the character comparison logic that performs the 'largest common
+                // subsequence' between two lines of code
+                charcomp       = function diffview__report_charcomp(lineA, lineB) {
+                    var b             = 0,
+                        dataA         = [],
+                        dataB         = [],
+                        cleanedA      = (options.diffcli === true)
+                            ? lineA
+                            : lineA
+                                .replace(/&#160;/g, " ")
+                                .replace(/&nbsp;/g, " ")
+                                .replace(/&lt;/g, "<")
+                                .replace(/&gt;/g, ">")
+                                .replace(/\$#lt;/g, "<")
+                                .replace(/\$#gt;/g, ">")
+                                .replace(/&amp;/g, "&"),
+                        cleanedB      = (options.diffcli === true)
+                            ? lineB
+                            : lineB
+                                .replace(/&#160;/g, " ")
+                                .replace(/&nbsp;/g, " ")
+                                .replace(/&lt;/g, "<")
+                                .replace(/&gt;/g, ">")
+                                .replace(/\$#lt;/g, "<")
+                                .replace(/\$#gt;/g, ">")
+                                .replace(/&amp;/g, "&"),
+                        dataMinLength = 0,
+                        currentdiff   = [],
+                        regStart      = (/_pdiffdiff\u005f/g),
+                        regEnd        = (/_epdiffdiff\u005f/g),
+                        strStart      = "_pdiffdiff\u005f",
+                        strEnd        = "_epdiffdiff\u005f",
+                        tabdiff       = (function diffview__report_charcomp_tabdiff() {
+                            var tabMatchA  = "",
+                                tabMatchB  = "",
+                                splitA     = "",
+                                splitB     = "",
+                                analysis   = [],
+                                matchListA = cleanedA.match(tabFix),
+                                matchListB = cleanedB.match(tabFix);
+                            if (matchListA === null || matchListB === null || (matchListA[0] === "" && matchListA.length === 1) || (matchListB[0] === "" && matchListB.length === 1)) {
+                                return ["", "", cleanedA, cleanedB];
+                            }
+                            tabMatchA = matchListA[0];
+                            tabMatchB = matchListB[0];
+                            splitA    = cleanedA.split(tabMatchA)[1];
+                            splitB    = cleanedB.split(tabMatchB)[1];
+                            if (tabMatchA.length > tabMatchB.length) {
+                                analysis  = tabMatchA.split(tabMatchB);
+                                tabMatchA = tabMatchB + strStart + analysis[1] + strEnd;
+                                tabMatchB = tabMatchB + strStart + strEnd;
+                            } else {
+                                analysis  = tabMatchB.split(tabMatchA);
+                                tabMatchB = tabMatchA + strStart + analysis[1] + strEnd;
+                                tabMatchA = tabMatchA + strStart + strEnd;
+                            }
+                            return [tabMatchA, tabMatchB, splitA, splitB];
+                        }()),
+                        whiteout      = function diffview__report_charcomp_whiteout(whitediff) {
+                            var spacetest = (/<((em)|(pd))>\u0020+<\/((em)|(pd))>/),
+                                crtest    = (/<((em)|(pd))>\r+<\/((em)|(pd))>/);
+                            if (spacetest.test(whitediff) === true) {
+                                return whitediff;
+                            }
+                            if (crtest.test(whitediff) === true) {
+                                return whitediff.replace(/\s+/, "(carriage return)");
+                            }
+                            return whitediff.replace(/\s+/, "(white space differences)");
+                        },
+                        //compare is the fuzzy string comparison algorithm
+                        compare       = function diffview__report_charcomp_compare(start) {
+                            var x          = 0,
+                                y          = 0,
+                                max        = Math.max(dataA.length, dataB.length),
+                                store      = [],
+                                sorta      = function diffview__report_charcomp_compare_sorta(a, b) {
+                                    if (a[1] - a[0] < b[1] - b[0]) {
+                                        return 1;
+                                    }
+                                    return -1;
+                                },
+                                sortb      = function diffview__report_charcomp_compare_sortb(a, b) {
+                                    if (a[0] + a[1] > b[0] + b[1]) {
+                                        return 1;
+                                    }
+                                    return -1;
+                                },
+                                whitetest  = (/^(\s+)$/),
+                                whitespace = false,
+                                wordtest   = false;
+                            //first gather a list of all matching indexes into an array
+                            for (x = start; x < dataMinLength; x = x + 1) {
+                                for (y = start; y < max; y = y + 1) {
+                                    if (dataA[x] === dataB[y] || dataB[x] === dataA[y]) {
+                                        store.push([x, y]);
+                                        if (dataA[y] === dataB[x] && dataA[y + 1] === dataB[x + 1] && whitetest.test(dataB[x - 1]) === true) {
+                                            wordtest = true;
+                                            store    = [
+                                                [x, y]
+                                            ];
+                                        }
+                                        if (dataA[x] === dataB[y] && dataA[x + 1] === dataB[y + 1] && whitetest.test(dataB[y - 1]) === true) {
+                                            wordtest = true;
+                                            store    = [
+                                                [x, y]
+                                            ];
+                                        }
+                                        break;
+                                    }
+                                }
+                                if (wordtest === true) {
+                                    break;
+                                }
+                            }
+                            //if there are no character matches then quit out
+                            if (store.length === 0) {
+                                return [dataMinLength, max, 0, whitespace];
+                            }
+                            // take the list of matches and sort it first sort by size of change with
+                            // shortest up front second sort by sum of change start and end the second sort
+                            // results in the smallest change from the earliest point
+                            store.sort(sorta);
+                            if (dataMinLength - start < 5000) {
+                                store.sort(sortb);
+                            }
+                            //x should always be the shorter index (change start)
+                            if (store[0][0] < store[0][1]) {
+                                x = store[0][0];
+                                y = store[0][1];
+                            } else {
+                                y = store[0][0];
+                                x = store[0][1];
+                            }
+                            //package the output
+                            if (dataA[y] === dataB[x]) {
+                                if (dataA[y - 1] === dataB[x - 1] && x !== start) {
+                                    x = x - 1;
+                                    y = y - 1;
+                                }
+                                if (options.diffspaceignore === true && ((whitetest.test(dataA[y - 1]) === true && y - start > 0) || (whitetest.test(dataB[x - 1]) === true && x - start > 0))) {
+                                    whitespace = true;
+                                }
+                                return [x, y, 0, whitespace];
+                            }
+                            if (dataA[x] === dataB[y]) {
+                                if (dataA[x - 1] === dataB[y - 1] && x !== start) {
+                                    x = x - 1;
+                                    y = y - 1;
+                                }
+                                if (options.diffspaceignore === true && ((whitetest.test(dataA[x - 1]) === true && x - start > 0) || (whitetest.test(dataB[y - 1]) === true && y - start > 0))) {
+                                    whitespace = true;
+                                }
+                                return [x, y, 1, whitespace];
+                            }
+                        };
+                    //if same after accounting for character entities then exit
+                    if (cleanedA === cleanedB) {
+                        return [lineA, lineB];
+                    }
+                    //prevent extra error counting that occurred before entering this function
+                    errorout = errorout - 1;
+                    //diff for tabs
+                    if (tabFix !== "" && cleanedA.length !== cleanedB.length && cleanedA.replace(tabFix, "") === cleanedB.replace(tabFix, "") && options.diffspaceignore === false) {
+                        errorout = errorout + 1;
+                        if (options.diffcli === true) {
+                            tabdiff[0] = tabdiff[0] + tabdiff[2];
+                            tabdiff[0] = tabdiff[0]
+                                .replace(regStart, "<pd>")
+                                .replace(regEnd, "</pd>");
+                            tabdiff[1] = tabdiff[1] + tabdiff[3];
+                            tabdiff[1] = tabdiff[1]
+                                .replace(regStart, "<pd>")
+                                .replace(regEnd, "</pd>");
+                            return [
+                                tabdiff[0], tabdiff[1]
+                            ];
+                        }
+                        tabdiff[0] = tabdiff[0] + tabdiff[2];
+                        tabdiff[0] = tabdiff[0]
+                            .replace(/&/g, "&amp;")
+                            .replace(/</g, "&lt;")
+                            .replace(/>/g, "&gt;")
+                            .replace(regStart, "<em>")
+                            .replace(regEnd, "</em>");
+                        tabdiff[1] = tabdiff[1] + tabdiff[3];
+                        tabdiff[1] = tabdiff[1]
+                            .replace(/&/g, "&amp;")
+                            .replace(/</g, "&lt;")
+                            .replace(/>/g, "&gt;")
+                            .replace(regStart, "<em>")
+                            .replace(regEnd, "</em>");
+                        return [
+                            tabdiff[0], tabdiff[1]
+                        ];
+                    }
+                    //turn the pruned input into arrays
+                    dataA         = cleanedA.split("");
+                    dataB         = cleanedB.split("");
+                    //the length of the shortest array
+                    dataMinLength = Math.min(dataA.length, dataB.length);
+                    for (b = 0; b < dataMinLength; b = b + 1) {
+                        //if undefined break the loop
+                        if (dataA[b] === undefined || dataB[b] === undefined) {
+                            break;
+                        }
+                        //iterate until the arrays are not the same
+                        if (dataA[b] !== dataB[b]) {
+                            // fuzzy string comparison returns an array with these indexes 0 - shorter
+                            // ending index of difference 1 - longer ending index of difference 2 - 0 if
+                            // index 2 is for dataA or 1 for dataB 3 - whether the difference is only
+                            // whitespace
+                            currentdiff = compare(b);
+                            //supply the difference start indicator
+                            if (currentdiff[3] === false) {
+                                //count each difference
+                                errorout = errorout + 1;
+                                if (b > 0) {
+                                    dataA[b - 1] = dataA[b - 1] + strStart;
+                                    dataB[b - 1] = dataB[b - 1] + strStart;
+                                } else {
+                                    dataA[b] = strStart + dataA[b];
+                                    dataB[b] = strStart + dataB[b];
+                                }
+                                //complex decision tree on how to supply difference end indicator
+                                if (currentdiff[2] === 1) {
+                                    if (currentdiff[0] === 0) {
+                                        dataA[0] = dataA[0].replace(regStart, strStart + strEnd);
+                                    } else if (currentdiff[0] === dataMinLength) {
+                                        if (dataB.length === dataMinLength) {
+                                            dataA[dataA.length - 1] = dataA[dataA.length - 1] + strEnd;
+                                        } else {
+                                            dataA[currentdiff[0] - 1] = dataA[currentdiff[0] - 1] + strEnd;
+                                        }
+                                    } else {
+                                        if (dataA[currentdiff[0]].indexOf(strStart) > -1) {
+                                            dataA[currentdiff[0]] = dataA[currentdiff[0]] + strEnd;
+                                        } else if (currentdiff[1] - currentdiff[0] === currentdiff[0]) {
+                                            dataA[b] = strEnd + dataA[b];
+                                        } else {
+                                            dataA[currentdiff[0]] = strEnd + dataA[currentdiff[0]];
+                                        }
+                                    }
+                                    if (currentdiff[1] > dataB.length - 1 || currentdiff[0] === dataMinLength) {
+                                        dataB[dataB.length - 1] = dataB[dataB.length - 1] + strEnd;
+                                    } else if (currentdiff[1] - currentdiff[0] === currentdiff[0]) {
+                                        dataB[b + (currentdiff[1] - currentdiff[0])] = strEnd + dataB[b + (currentdiff[1] - currentdiff[0])];
+                                    } else {
+                                        dataB[currentdiff[1]] = strEnd + dataB[currentdiff[1]];
+                                    }
+                                } else {
+                                    if (currentdiff[0] === 0) {
+                                        dataB[0] = dataB[0].replace(regStart, strStart + strEnd);
+                                    } else if (currentdiff[0] === dataMinLength) {
+                                        if (dataA.length === dataMinLength) {
+                                            dataB[dataB.length - 1] = dataB[dataB.length - 1] + strEnd;
+                                        } else {
+                                            dataB[currentdiff[0] - 1] = dataB[currentdiff[0] - 1] + strEnd;
+                                        }
+                                    } else {
+                                        if (dataB[currentdiff[0]].indexOf(strStart) > -1) {
+                                            dataB[currentdiff[0]] = dataB[currentdiff[0]] + strEnd;
+                                        } else if (currentdiff[0] - currentdiff[1] === currentdiff[1]) {
+                                            dataB[b] = strEnd + dataB[b];
+                                        } else {
+                                            dataB[currentdiff[0]] = strEnd + dataB[currentdiff[0]];
+                                        }
+                                    }
+                                    if (currentdiff[1] > dataA.length - 1 || currentdiff[0] === dataMinLength) {
+                                        dataA[dataA.length - 1] = dataA[dataA.length - 1] + strEnd;
+                                    } else if (currentdiff[0] - currentdiff[1] === currentdiff[1]) {
+                                        dataA[b + (currentdiff[0] - currentdiff[1])] = strEnd + dataA[b + (currentdiff[0] - currentdiff[1])];
+                                    } else {
+                                        dataA[currentdiff[1]] = strEnd + dataA[currentdiff[1]];
+                                    }
+                                }
+                            }
+                            // we must rebase the array with the shorter difference so that the end of the
+                            // current difference is on the same index.  This provides a common baseline by
+                            // which to find the next unmatching index
+                            if (currentdiff[1] > currentdiff[0] && currentdiff[1] - currentdiff[0] < 1000) {
+                                if (currentdiff[2] === 1) {
+                                    do {
+                                        dataA.unshift("");
+                                        currentdiff[0] = currentdiff[0] + 1;
+                                    } while (currentdiff[1] > currentdiff[0]);
+                                } else {
+                                    do {
+                                        dataB.unshift("");
+                                        currentdiff[0] = currentdiff[0] + 1;
+                                    } while (currentdiff[1] > currentdiff[0]);
+                                }
+                            }
+                            // since the previous logic will grow the shorter array we have to redefine the
+                            // shortest length
+                            dataMinLength = Math.min(dataA.length, dataB.length);
+                            //assign the incrementer to the end of the longer difference
+                            b             = currentdiff[1];
+                        }
+                    }
+                    // if one array is longer than the other and not identified as different then
+                    // identify this difference in length
+                    if (dataA.length > dataB.length && dataB[dataB.length - 1] !== undefined && dataB[dataB.length - 1].indexOf(strEnd) < 1) {
+                        dataB.push(strStart + strEnd);
+                        dataA[dataB.length - 1] = strStart + dataA[dataB.length - 1];
+                        dataA[dataA.length - 1] = dataA[dataA.length - 1] + strEnd;
+                        errorout                = errorout + 1;
+                    }
+                    if (dataB.length > dataA.length && dataA[dataA.length - 1] !== undefined && dataA[dataA.length - 1].indexOf(strEnd) < 1) {
+                        dataA.push(strStart + strEnd);
+                        dataB[dataA.length - 1] = strStart + dataB[dataA.length - 1];
+                        dataB[dataB.length - 1] = dataB[dataB.length - 1] + strEnd;
+                        errorout                = errorout + 1;
+                    }
+                    // options.diffcli output doesn't need XML protected characters to be escaped
+                    // because its output is the command line
+                    if (options.diffcli === true) {
+                        return [
+                            dataA
+                                .join("")
+                                .replace(regStart, "<pd>")
+                                .replace(regEnd, "</pd>")
+                                .replace(/<pd>\s+<\/pd>/g, whiteout),
+                            dataB
+                                .join("")
+                                .replace(regStart, "<pd>")
+                                .replace(regEnd, "</pd>")
+                                .replace(/<pd>\s+<\/pd>/g, whiteout)
+                        ];
+                    }
+                    return [
+                        dataA
+                            .join("")
+                            .replace(/&/g, "&amp;")
+                            .replace(/</g, "&lt;")
+                            .replace(/>/g, "&gt;")
+                            .replace(regStart, "<em>")
+                            .replace(regEnd, "</em>")
+                            .replace(/<em>\s+<\/em>/g, whiteout),
+                        dataB
+                            .join("")
+                            .replace(/&/g, "&amp;")
+                            .replace(/</g, "&lt;")
+                            .replace(/>/g, "&gt;")
+                            .replace(regStart, "<em>")
+                            .replace(regEnd, "</em>")
+                            .replace(/<em>\s+<\/em>/g, whiteout)
+                    ];
+                };
+            if (options.diffcli === false) {
+                if (options.diffview === "inline") {
+                    node.push("<h3 class='texttitle'>");
+                    node.push(options.sourcelabel);
+                    node.push(" vs. ");
+                    node.push(options.difflabel);
+                    node.push("</h3><ol class='count'>");
+                } else {
+                    data[0].push("<div class='diff-left'><h3 class='texttitle'>");
+                    data[0].push(options.sourcelabel);
+                    data[0].push("</h3><ol class='count'>");
+                    data[2].push("<div class='diff-right'><h3 class='texttitle'>");
+                    data[2].push(options.difflabel);
+                    data[2].push("</h3><ol class='count' style='cursor:w-resize'>");
+                }
+            } else {
+                foldstart = 0;
+            }
+            for (a = 0; a < opcodesLength; a = a + 1) {
+                code      = opcodes[a];
+                change    = code[0];
+                baseStart = code[1];
+                baseEnd   = code[2];
+                newStart  = code[3];
+                newEnd    = code[4];
+                rowcnt    = Math.max(baseEnd - baseStart, newEnd - newStart);
+                ctest     = true;
+
+                if (foldstart > -1 && options.diffcli === false) {
+                    data[0][foldstart] = data[0][foldstart].replace("xxx", foldcount);
+                }
+                if (options.diffcli === true) {
+                    if (foldstart > 49 && change === "equal") {
+                        break;
+                    }
+                    if (options.diffspaceignore === true && change === "replace" && baseTextArray[baseStart] !== undefined && newTextArray[newStart] !== undefined && baseTextArray[baseStart].replace(/\s+/g, "") === newTextArray[newStart].replace(/\s+/g, "")) {
+                        change = "equal";
+                    } else if (change !== "equal") {
+                        if (a > 0 && opcodes[a - 1][0] === "equal") {
+                            foldcount = options.context;
+                            if ((ntest === true || change === "insert") && (options.diffspaceignore === false || (/^(\s+)$/g).test(newTextArray[newStart]) === false)) {
+                                foldstart = foldstart + 1;
+                                if (options.api === "dom") {
+                                    data.push("</li><li><h3>Line: ");
+                                    data.push(opcodes[a - 1][2] + 1);
+                                    data.push("</h3>");
+                                } else {
+                                    data.push("");
+                                    data.push("\u001b[36mLine: " + (opcodes[a - 1][2] + 1) + "\u001b[39m");
+                                }
+                                if (foldcount > 0) {
+                                    do {
+                                        if (newStart - foldcount > -1) {
+                                            if (options.api === "dom") {
+                                                data.push("<p>");
+                                                data.push(htmlfix(newTextArray[newStart - foldcount]));
+                                                data.push("</p>");
+                                            } else {
+                                                data.push(newTextArray[newStart - foldcount]);
+                                            }
+                                        }
+                                        foldcount = foldcount - 1;
+                                    } while (foldcount > 0);
+                                }
+                            } else {
+                                foldstart = foldstart + 1;
+                                if (options.api === "dom") {
+                                    data.push("</li><li><h3>Line: ");
+                                    data.push(baseStart + 1);
+                                    data.push("</h3>");
+                                } else {
+                                    data.push("");
+                                    data.push("\u001b[36mLine: " + (baseStart + 1) + "\u001b[39m");
+                                }
+                                if (foldcount > 0) {
+                                    do {
+                                        if (baseStart - foldcount > -1) {
+                                            if (options.api === "dom") {
+                                                data.push("<p>");
+                                                data.push(htmlfix(newTextArray[newStart - foldcount]));
+                                                data.push("</p>");
+                                            } else {
+                                                data.push(baseTextArray[baseStart - foldcount]);
+                                            }
+                                        }
+                                        foldcount = foldcount - 1;
+                                    } while (foldcount > 0);
+                                }
+                            }
+                        } else if (a < 1) {
+                            if (options.api === "dom") {
+                                data.push("</li><li><h3>Line: 1</h3>");
+                            } else {
+                                data.push("");
+                                data.push("\u001b[36mLine: 1\u001b[39m");
+                            }
+                            foldstart = foldstart + 1;
+                        }
+                        foldcount = 0;
+                        if ((ntest === true || change === "insert") && (options.diffspaceignore === false || (/^(\s+)$/g).test(newTextArray[newStart]) === false)) {
+                            do {
+                                if (options.api === "dom") {
+                                    data.push("<ins>");
+                                    data.push(htmlfix(newTextArray[newStart + foldcount]));
+                                    data.push("</ins>");
+                                } else {
+                                    data.push("\u001b[32m" + newTextArray[newStart + foldcount] + "\u001b[39m");
+                                }
+                                foldcount = foldcount + 1;
+                            } while (foldcount < 7 && foldcount + newStart < newEnd);
+                        } else if (change === "delete" && (options.diffspaceignore === false || (/^(\s+)$/g).test(baseTextArray[baseStart]) === false)) {
+                            do {
+                                if (options.api === "dom") {
+                                    data.push("<del>");
+                                    data.push(htmlfix(baseTextArray[baseStart + foldcount]))
+                                    data.push("</del>");
+                                } else {
+                                    data.push("\u001b[31m" + baseTextArray[baseStart + foldcount] + "\u001b[39m");
+                                }
+                                foldcount = foldcount + 1;
+                            } while (foldcount < 7 && foldcount + baseStart < baseEnd);
+                        } else if (change === "replace" && (options.diffspaceignore === false || baseTextArray[baseStart].replace(/\s+/g, "") !== newTextArray[newStart].replace(/\s+/g, ""))) {
+                            do {
+                                charcompOutput = charcomp(
+                                    baseTextArray[baseStart + foldcount],
+                                    newTextArray[newStart + foldcount]
+                                );
+                                if (options.api === "dom") {
+                                    data.push("<del>");
+                                    data.push(htmlfix(charcompOutput[0]).replace(/&lt;pd&gt;/g, "<em>").replace(/&lt;\/pd&gt;/g, "</em>"));
+                                    data.push("</del><ins>");
+                                    data.push(htmlfix(charcompOutput[1]).replace(/&lt;pd&gt;/g, "<em>").replace(/&lt;\/pd&gt;/g, "</em>"));
+                                    data.push("</ins>");
+                                } else {
+                                    data.push("\u001b[31m" + charcompOutput[0].replace(/<pd>/g, "\u001b[1m").replace(/<\/pd>/g, "\u001b[22m") + "\u001b[39m");
+                                    data.push("\u001b[32m" + charcompOutput[1].replace(/<pd>/g, "\u001b[1m").replace(/<\/pd>/g, "\u001b[22m") + "\u001b[39m");
+                                }
+                                foldcount = foldcount + 1;
+                            } while (foldcount < 7 && foldcount + baseStart < baseEnd);
+                        }
+                        if (((change === "insert" && foldcount + newStart === newEnd) || (change !== "insert" && foldcount + baseStart === baseEnd)) && baseTextArray[baseStart + foldcount] !== undefined && options.context > 0 && a < opcodesLength - 1 && opcodes[a + 1][0] === "equal") {
+                            foldcount = 0;
+                            baseStart = opcodes[a + 1][1];
+                            baseEnd   = opcodes[a + 1][2] - baseStart;
+                            do {
+                                if (options.api === "dom") {
+                                    data.push("<p>");
+                                    data.push(htmlfix(baseTextArray[baseStart + foldcount]));
+                                    data.push("</p>");
+                                } else {
+                                    data.push(baseTextArray[baseStart + foldcount]);
+                                }
+                                foldcount = foldcount + 1;
+                            } while (foldcount < options.context && foldcount < baseEnd);
+                        }
+                        if (btest === true) {
+                            baseStart = baseStart + 1;
+                            btest     = false;
+                        } else if (ntest === true) {
+                            newStart = newStart + 1;
+                            ntest    = false;
+                        } else {
+                            baseStart = baseStart + 1;
+                            newStart  = newStart + 1;
+                        }
+                    }
+                } else {
+                    for (i = 0; i < rowcnt; i = i + 1) {
+                        //apply options.context collapsing for the output, if needed
+                        if (options.context > -1 && opcodes.length > 1 && ((a > 0 && i === options.context) || (a === 0 && i === 0)) && change === "equal") {
+                            ctest = false;
+                            jump  = rowcnt - ((a === 0
+                                ? 1
+                                : 2) * options.context);
+                            if (jump > 1) {
+                                baseStart = baseStart + jump;
+                                newStart  = newStart + jump;
+                                i         = i + (jump - 1);
+                                if (options.diffcli === true) {
+                                    data[5].push([baseStart, newStart]);
+                                } else {
+                                    data[0].push("<li>...</li>");
+                                    if (options.diffview !== "inline") {
+                                        data[1].push("<li class=\"skip\">&#10;</li>");
+                                    }
+                                    data[2].push("<li>...</li>");
+                                    data[3].push("<li class=\"skip\">&#10;</li>");
+                                }
+                                if (a + 1 === opcodes.length) {
+                                    break;
+                                }
+                            }
+                        } else if (change !== "equal") {
+                            diffline = diffline + 1;
+                        }
+                        foldcount = foldcount + 1;
+                        // this is a check against false positives incurred by increasing or reducing of
+                        // nesting.  At this time it only checks one level deep.
+                        if (tab !== "") {
+                            if (btest === false && baseTextArray[baseEnd] !== newTextArray[newEnd] && typeof baseTextArray[baseStart + 1] === "string" && typeof newTextArray[newStart] === "string" && baseTab[baseStart + 1] === newTab[newStart] && baseTab[baseStart] !== newTab[newStart] && (typeof newTextArray[newStart - 1] !== "string" || baseTab[baseStart] !== newTab[newStart - 1])) {
+                                btest = true;
+                            } else if (ntest === false && baseTextArray[baseEnd] !== newTextArray[newEnd] && typeof newTextArray[newStart + 1] === "string" && typeof baseTextArray[baseStart] === "string" && newTab[newStart + 1] === baseTab[baseStart] && newTab[newStart] !== baseTab[baseStart] && (typeof baseTextArray[baseStart - 1] !== "string" || newTab[newStart] !== baseTab[baseStart - 1])) {
+                                ntest = true;
+                            }
+                        }
+                        if (options.diffview === "inline") {
+                            if (options.diffspaceignore === true && change === "replace" && baseTextArray[baseStart].replace(/\s+/g, "") === newTextArray[newStart].replace(/\s+/g, "")) {
+                                change   = "equal";
+                                errorout = errorout - 1;
+                            }
+                            if (options.context < 0 && rowItem < a) {
+                                rowItem = a;
+                                if (foldstart > -1) {
+                                    if (data[0][foldstart + 1] === foldcount - 1) {
+                                        data[0][foldstart] = "<li class=\"" + data[0][foldstart].slice(
+                                            data[0][foldstart].indexOf(
+                                                "line xxx\">- "
+                                            ) + 12
+                                        );
+                                    } else {
+                                        data[0][foldstart] = data[0][foldstart].replace(
+                                            "xxx",
+                                            (foldcount - 1 + rcount)
+                                        );
+                                    }
+                                }
+                                if (change !== "replace") {
+                                    if (baseEnd - baseStart > 1 || newEnd - newStart > 1) {
+                                        data[0].push("<li class=\"fold\" title=\"folds from line " + (
+                                            foldcount + rcount
+                                        ) + " to line xxx\">- ");
+                                        foldstart = data[0].length - 1;
+                                    } else {
+                                        data[0].push("<li>");
+                                    }
+                                    if (ntest === true || change === "insert") {
+                                        data[0].push("&#10;");
+                                    } else {
+                                        data[0].push(baseStart + 1);
+                                    }
+                                    data[0].push("</li>");
+                                } else {
+                                    rcount = rcount + 1;
+                                }
+                            } else if (change !== "replace") {
+                                data[0].push("<li>");
+                                if (ntest === true || change === "insert") {
+                                    data[0].push("&#10;");
+                                } else {
+                                    data[0].push(baseStart + 1);
+                                }
+                                data[0].push("</li>");
+                            } else if (change === "replace") {
+                                rcount = rcount + 1;
+                            }
+                            if (ntest === true || change === "insert") {
+                                data[2].push("<li>");
+                                data[2].push(newStart + 1);
+                                data[2].push("&#10;</li>");
+                                if (options.diffspaceignore === true && newTextArray[newStart].replace(/\s+/g, "") === "") {
+                                    data[3].push("<li class=\"equal\">");
+                                    diffline = diffline - 1;
+                                } else {
+                                    data[3].push("<li class=\"insert\">");
+                                }
+                                data[3].push(newTextArray[newStart]);
+                                data[3].push("&#10;</li>");
+                            } else if (btest === true || change === "delete") {
+                                data[2].push("<li class=\"empty\">&#10;</li>");
+                                if (options.diffspaceignore === true && baseTextArray[baseStart].replace(/\s+/g, "") === "") {
+                                    data[3].push("<li class=\"equal\">");
+                                    diffline = diffline - 1;
+                                } else {
+                                    data[3].push("<li class=\"delete\">");
+                                }
+                                data[3].push(baseTextArray[baseStart]);
+                                data[3].push("&#10;</li>");
+                            } else if (change === "replace") {
+                                if (baseTextArray[baseStart] !== newTextArray[newStart]) {
+                                    if (baseTextArray[baseStart] === "") {
+                                        charcompOutput = [
+                                            "", newTextArray[newStart]
+                                        ];
+                                    } else if (newTextArray[newStart] === "") {
+                                        charcompOutput = [baseTextArray[baseStart], ""];
+                                    } else if (baseStart < baseEnd && newStart < newEnd) {
+                                        charcompOutput = charcomp(baseTextArray[baseStart], newTextArray[newStart]);
+                                    }
+                                }
+                                if (baseStart < baseEnd) {
+                                    data[0].push("<li>" + (
+                                        baseStart + 1
+                                    ) + "</li>");
+                                    data[2].push("<li class=\"empty\">&#10;</li>");
+                                    if (options.diffspaceignore === true && baseTextArray[baseStart].replace(/\s+/g, "") === "") {
+                                        data[3].push("<li class=\"equal\">");
+                                        diffline = diffline - 1;
+                                    } else {
+                                        data[3].push("<li class=\"delete\">");
+                                    }
+                                    if (newStart < newEnd) {
+                                        data[3].push(charcompOutput[0]);
+                                    } else {
+                                        data[3].push(baseTextArray[baseStart]);
+                                    }
+                                    data[3].push("&#10;</li>");
+                                }
+                                if (newStart < newEnd) {
+                                    data[0].push("<li class=\"empty\">&#10;</li>");
+                                    data[2].push("<li>");
+                                    data[2].push(newStart + 1);
+                                    data[2].push("</li>");
+                                    if (options.diffspaceignore === true && newTextArray[newStart].replace(/\s+/g, "") === "") {
+                                        data[3].push("<li class=\"equal\">");
+                                        diffline = diffline - 1;
+                                    } else {
+                                        data[3].push("<li class=\"insert\">");
+                                    }
+                                    if (baseStart < baseEnd) {
+                                        data[3].push(charcompOutput[1]);
+                                    } else {
+                                        data[3].push(newTextArray[newStart]);
+                                    }
+                                    data[3].push("&#10;</li>");
+                                }
+                            } else if (baseStart < baseEnd || newStart < newEnd) {
+                                data[2].push("<li>");
+                                data[2].push(newStart + 1);
+                                data[2].push("</li>");
+                                data[3].push("<li class=\"");
+                                data[3].push(change);
+                                data[3].push("\">");
+                                data[3].push(baseTextArray[baseStart]);
+                                data[3].push("&#10;</li>");
+                            }
+                            if (btest === true) {
+                                baseStart = baseStart + 1;
+                                btest     = false;
+                            } else if (ntest === true) {
+                                newStart = newStart + 1;
+                                ntest    = false;
+                            } else {
+                                baseStart = baseStart + 1;
+                                newStart  = newStart + 1;
+                            }
+                        } else {
+                            if (btest === false && ntest === false && typeof baseTextArray[baseStart] === "string" && typeof newTextArray[newStart] === "string") {
+                                if (change === "replace" && baseStart < baseEnd && newStart < newEnd && baseTextArray[baseStart] !== newTextArray[newStart]) {
+                                    charcompOutput = charcomp(baseTextArray[baseStart], newTextArray[newStart]);
+                                } else {
+                                    charcompOutput = [
+                                        baseTextArray[baseStart], newTextArray[newStart]
+                                    ];
+                                }
+                                if (baseStart === Number(data[0][data[0].length - 1].substring(
+                                    data[0][data[0].length - 1].indexOf(">") + 1,
+                                    data[0][data[0].length - 1].lastIndexOf("<")
+                                )) - 1 || newStart === Number(data[2][data[2].length - 1].substring(
+                                    data[2][data[2].length - 1].indexOf(">") + 1,
+                                    data[2][data[2].length - 1].lastIndexOf("<")
+                                )) - 1) {
+                                    repeat = true;
+                                }
+                                if (repeat === false) {
+                                    if (baseStart < baseEnd) {
+                                        if (options.context < 0 && rowItem < a && (opcodes[a][2] - opcodes[a][1] > 1 || opcodes[a][4] - opcodes[a][3] > 1)) {
+                                            rowItem = a;
+                                            data[0].push(
+                                                "<li class=\"fold\" title=\"folds from line " + foldcount +
+                                                " to line xxx\">- " + (
+                                                    baseStart + 1
+                                                ) + "</li>"
+                                            );
+                                            foldstart = data[0].length - 1;
+                                        } else {
+                                            data[0].push("<li>" + (
+                                                baseStart + 1
+                                            ) + "</li>");
+                                        }
+                                        data[1].push("<li class=\"");
+                                        if (newStart >= newEnd) {
+                                            if (options.diffspaceignore === true && baseTextArray[baseStart].replace(/\s+/g, "") === "") {
+                                                data[1].push("equal");
+                                                diffline = diffline - 1;
+                                            } else {
+                                                data[1].push("delete");
+                                            }
+                                        } else if (baseTextArray[baseStart] === "" && newTextArray[newStart] !== "" && (options.diffspaceignore === false || (baseTextArray[baseStart].replace(/\s+/g, "") !== "" && newTextArray[newStart].replace(/\s+/g, "") !== ""))) {
+                                            data[1].push("empty");
+                                        } else {
+                                            data[1].push(change);
+                                        }
+                                        data[1].push("\">");
+                                        data[1].push(charcompOutput[0]);
+                                        data[1].push("&#10;</li>");
+                                    } else if (ctest === true) {
+                                        if (options.context < 0 && rowItem < a && (opcodes[a][2] - opcodes[a][1] > 1 || opcodes[a][4] - opcodes[a][3])) {
+                                            rowItem = a;
+                                            if (foldstart > -1) {
+                                                data[0][foldstart] = data[0][foldstart].replace("xxx", (foldcount - 1));
+                                            }
+                                            data[0].push(
+                                                "<li class=\"fold\" title=\"folds from line " + foldcount + " to line xxx\">- &" +
+                                                "#10;</li>"
+                                            );
+                                            foldstart = data[0].length - 1;
+                                        } else {
+                                            data[0].push("<li class=\"empty\">&#10;</li>");
+                                        }
+                                        data[1].push("<li class=\"empty\"></li>");
+                                    }
+                                    if (newStart < newEnd) {
+                                        data[2].push("<li>" + (
+                                            newStart + 1
+                                        ) + "</li>");
+                                        data[3].push("<li class=\"");
+                                        if (baseStart >= baseEnd) {
+                                            if (options.diffspaceignore === true && newTextArray[newStart].replace(/\s+/g, "") === "") {
+                                                data[3].push("equal");
+                                                diffline = diffline - 1;
+                                            } else {
+                                                data[3].push("insert");
+                                            }
+                                        } else if (newTextArray[newStart] === "" && baseTextArray[baseStart] !== "" && (options.diffspaceignore === false || (baseTextArray[baseStart].replace(/\s+/g, "") !== "" && newTextArray[newStart].replace(/\s+/g, "") !== ""))) {
+                                            data[3].push("empty");
+                                        } else {
+                                            data[3].push(change);
+                                        }
+                                        data[3].push("\">");
+                                        data[3].push(charcompOutput[1]);
+                                        data[3].push("&#10;</li>");
+                                    } else if (ctest === true) {
+                                        data[2].push("<li class=\"empty\">&#10;</li>");
+                                        data[3].push("<li class=\"empty\"></li>");
+                                    }
+                                } else {
+                                    repeat = false;
+                                }
+                                if (baseStart < baseEnd) {
+                                    baseStart = baseStart + 1;
+                                }
+                                if (newStart < newEnd) {
+                                    newStart = newStart + 1;
+                                }
+                            } else if (btest === true || (typeof baseTextArray[baseStart] === "string" && typeof newTextArray[newStart] !== "string")) {
+                                if (baseStart !== Number(data[0][data[0].length - 1].substring(
+                                    data[0][data[0].length - 1].indexOf(">") + 1,
+                                    data[0][data[0].length - 1].lastIndexOf("<")
+                                )) - 1) {
+                                    if (options.context < 0 && rowItem < a && opcodes[a][2] - opcodes[a][1] > 1) {
+                                        rowItem = a;
+                                        data[0].push(
+                                            "<li class=\"fold\" title=\"folds from line " + foldcount +
+                                            " to line xxx\">- " + (
+                                                baseStart + 1
+                                            ) + "</li>"
+                                        );
+                                        foldstart = data[0].length - 1;
+                                    } else {
+                                        data[0].push("<li>" + (
+                                            baseStart + 1
+                                        ) + "</li>");
+                                    }
+                                    data[1].push("<li class=\"delete\">");
+                                    data[1].push(baseTextArray[baseStart]);
+                                    data[1].push("&#10;</li>");
+                                    data[2].push("<li class=\"empty\">&#10;</li>");
+                                    data[3].push("<li class=\"empty\"></li>");
+                                }
+                                btest     = false;
+                                baseStart = baseStart + 1;
+                            } else if (ntest === true || (typeof baseTextArray[baseStart] !== "string" && typeof newTextArray[newStart] === "string")) {
+                                if (newStart !== Number(data[2][data[2].length - 1].substring(
+                                    data[2][data[2].length - 1].indexOf(">") + 1,
+                                    data[2][data[2].length - 1].lastIndexOf("<")
+                                )) - 1) {
+                                    if (options.context < 0 && rowItem < a && opcodes[a][4] - opcodes[a][3] > 1) {
+                                        rowItem = a;
+                                        data[0].push(
+                                            "<li class=\"fold\" title=\"folds from line " + foldcount + " to line xxx\">-</" +
+                                            "li>"
+                                        );
+                                        foldstart = data[0].length - 1;
+                                    } else {
+                                        data[0].push("<li class=\"empty\">&#10;</li>");
+                                    }
+                                    data[1].push("<li class=\"empty\"></li>");
+                                    data[2].push("<li>" + (
+                                        newStart + 1
+                                    ) + "</li>");
+                                    data[3].push("<li class=\"insert\">");
+                                    data[3].push(newTextArray[newStart]);
+                                    data[3].push("&#10;</li>");
+                                }
+                                ntest    = false;
+                                newStart = newStart + 1;
+                            }
+                        }
+                    }
+                }
+            }
+            if (options.diffcli === true) {
+                if (a < opcodesLength && foldstart > 49) {
+                    diffline = -1;
+                }
+                if (options.api === "dom") {
+                    data.push("</li></ol>");
+                    return [data.join("").replace("</li>", "<ol class=\"diffcli\">"), foldstart, diffline];
+                }
+                return [data, foldstart, diffline];
+            }
+            if (foldstart > -1) {
+                data[0][foldstart] = data[0][foldstart].replace("xxx", foldcount + rcount);
+            }
+            node.push(data[0].join(""));
+            node.push("</ol><ol class=");
+            if (options.diffview === "inline") {
+                node.push("\"count\">");
+            } else {
+                node.push("\"data\" data-prettydiff-ignore=\"true\">");
+                node.push(data[1].join(""));
+                node.push("</ol></div>");
+            }
+            node.push(data[2].join(""));
+            node.push("</ol><ol class=\"data\" data-prettydiff-ignore=\"true\">");
+            node.push(data[3].join(""));
+            if (options.diffview === "inline") {
+                node.push("</ol>");
+            } else {
+                node.push("</ol></div>");
+            }
+            node.push(
+                "<p class=\"author\">Diff view written by <a href=\"http://prettydiff.com/\">Pr" +
+                "etty Diff</a>.</p></div>"
+            );
+            baseTab  = (errorout === 1)
+                ? ""
+                : "s";
+            newTab   = (diffline === 1)
+                ? ""
+                : "s";
+            finaldoc = "<p><strong>Number of differences:</strong> <em>" + (
+                errorout + diffline
+            ) + "</em> difference" + baseTab + " from <em>" + diffline + "</em> line" +
+                    newTab + " of code.</p>" + node.join("");
+            return [
+                finaldoc
+                    .replace(
+                        /li\u0020class="equal"><\/li/g,
+                        "li class=\"equal\">&#10;</li"
+                    )
+                    .replace(/\$#gt;/g, "&gt;")
+                    .replace(/\$#lt;/g, "&lt;")
+                    .replace(/%#lt;/g, "$#lt;")
+                    .replace(/%#gt;/g, "$#gt;"),
+                errorout,
+                diffline
+            ];
+        }());
+    };
+    if ((typeof define === "object" || typeof define === "function") && (typeof ace !== "object" || ace.prettydiffid === undefined)) {
+        //requirejs support
+        define(function diffview_requirejs() {
+            return function diffview_requirejs_wrapper(x) {
+                return diffview(x);
+            };
+        });
+    } else if (typeof module === "object" && typeof module.parent === "object") {
+        //commonjs and nodejs support
+        module.exports = diffview;
+    } else {
+        global.prettydiff.diffview = diffview;
+    }
+}());

--- a/node_modules/prettydiff/lib/finalFile.js
+++ b/node_modules/prettydiff/lib/finalFile.js
@@ -1,0 +1,1402 @@
+/*global ace, define, global, module*/
+(function finalFile_init() {
+    "use strict";
+    var finalFile = {
+        css   : {
+            color  : {
+                canvas: "#prettydiff.canvas{background:#986 url(\"data:image/png;base64,iVBORw0KGgoAAAA" +
+                        "NSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAACXBIWXMAAC4jAAAuIwF4pT92AAAKT2lDQ1BQaG90b3Nob" +
+                        "3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AUkSYqIQkQSoghodkVUcE" +
+                        "RRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXXPues852zzwfACAyWSDNRN" +
+                        "YAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgABeNMLCADATZvAMByH/w/qQpl" +
+                        "cAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAtAGAnf+bTAICd+Jl7AQBblCEVA" +
+                        "aCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3AMDOEAuyAAgMADBRiIUpAAR7AGD" +
+                        "IIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dXLh4ozkkXKxQ2YQJhmkAuwnmZGTKBN" +
+                        "A/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qI" +
+                        "l7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14" +
+                        "L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcU" +
+                        "l0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZ" +
+                        "kmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzABhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQii" +
+                        "GzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/phCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIB" +
+                        "BKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5h1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogv" +
+                        "QZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+Q8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu" +
+                        "4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhMWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1h" +
+                        "ILCPWEo8TLxB7iEPENyQSiUMyJ7mQAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkn" +
+                        "eTD5DPkG+Qh8lsKnWJAcaT4U+IoUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR" +
+                        "1mjnNgxZJS6WtopXTGmgXaPdpr+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl3G" +
+                        "K+YTKYZ04sZx1QwNzHrmOeZD5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9rkZ" +
+                        "VM1PjqQnUlqtVqp1Q61MbU2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWsNq" +
+                        "4Z1gTXEJrHN2Xx2KruY/R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG6Y" +
+                        "0TLkxZVxrqpaXllirSKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr1r" +
+                        "i6qa6UbobtEd79up+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL8f" +
+                        "b8VFDXcNAQ6VhlWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDtMx" +
+                        "83MzaLN1pk1mz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1ru" +
+                        "tu6cRp7lOk06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqsdW" +
+                        "h1+c7RyFDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+Lps" +
+                        "bxt3IveRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5PQ" +
+                        "0+BZ7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/3r" +
+                        "/0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5pD" +
+                        "oVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5qPNo" +
+                        "3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIsOpZAT" +
+                        "IhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5hCepkLx" +
+                        "MDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQrAVZLQq2Q" +
+                        "qboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9rGo5sjxxeds" +
+                        "K4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1dT1gvWd+1YfqGn" +
+                        "Rs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aXDm4N2dq0Dd9WtO3" +
+                        "19kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7vPY07NXbW7z3/T7Jv" +
+                        "ttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3SPVRSj9Yr60cOxx++/p3" +
+                        "vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKaRptTmvtbYlu6T8w+0dbq3" +
+                        "nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO32oPb++6EHTh0kX/i+c7vDv" +
+                        "OXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21e2b36RueN87d9L158Rb/1tWeO" +
+                        "T3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfVP1v+3Njv3H9qwHeg89HcR/cGhYP" +
+                        "P/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i/suuFxYvfvjV69fO0ZjRoZfyl5O/b" +
+                        "Xyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8IH8o/2j5sfVT0Kf7kxmTk/8EA5jz/GM" +
+                        "zLdsAAEFdaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9I" +
+                        "lc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pgo8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1" +
+                        "ldGEvIiB4OnhtcHRrPSJBZG9iZSBYTVAgQ29yZSA1LjYtYzAxNCA3OS4xNTY3OTcsIDIwMTQvMDgvM" +
+                        "jAtMDk6NTM6MDIgICAgICAgICI+CiAgIDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5" +
+                        "vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+CiAgICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmO" +
+                        "mFib3V0PSIiCiAgICAgICAgICAgIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4" +
+                        "wLyIKICAgICAgICAgICAgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tb" +
+                        "S8iCiAgICAgICAgICAgIHhtbG5zOnN0RXZ0PSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R" +
+                        "5cGUvUmVzb3VyY2VFdmVudCMiCiAgICAgICAgICAgIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvY" +
+                        "mUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIgogICAgICAgICAgICB4bWxuczpkYz0iaHR" +
+                        "0cDovL3B1cmwub3JnL2RjL2VsZW1lbnRzLzEuMS8iCiAgICAgICAgICAgIHhtbG5zOnBob3Rvc2hvc" +
+                        "D0iaHR0cDovL25zLmFkb2JlLmNvbS9waG90b3Nob3AvMS4wLyIKICAgICAgICAgICAgeG1sbnM6dGl" +
+                        "mZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iCiAgICAgICAgICAgIHhtbG5zOmV4aWY9I" +
+                        "mh0dHA6Ly9ucy5hZG9iZS5jb20vZXhpZi8xLjAvIj4KICAgICAgICAgPHhtcDpDcmVhdG9yVG9vbD5" +
+                        "BZG9iZSBQaG90b3Nob3AgQ0MgMjAxNCAoTWFjaW50b3NoKTwveG1wOkNyZWF0b3JUb29sPgogICAgI" +
+                        "CAgICA8eG1wOkNyZWF0ZURhdGU+MjAxNi0wMS0xMlQxMjoyNDozOC0wNjowMDwveG1wOkNyZWF0ZUR" +
+                        "hdGU+CiAgICAgICAgIDx4bXA6TWV0YWRhdGFEYXRlPjIwMTYtMDEtMTNUMTM6MTg6MDctMDY6MDA8L" +
+                        "3htcDpNZXRhZGF0YURhdGU+CiAgICAgICAgIDx4bXA6TW9kaWZ5RGF0ZT4yMDE2LTAxLTEzVDEzOjE" +
+                        "4OjA3LTA2OjAwPC94bXA6TW9kaWZ5RGF0ZT4KICAgICAgICAgPHhtcE1NOkluc3RhbmNlSUQ+eG1wL" +
+                        "mlpZDoxZGYzYjhkMy03NzgyLTQ0MGUtYjA5OS1iYjM5NjA0MDVhOWQ8L3htcE1NOkluc3RhbmNlSUQ" +
+                        "+CiAgICAgICAgIDx4bXBNTTpEb2N1bWVudElEPmFkb2JlOmRvY2lkOnBob3Rvc2hvcDoxYzM3NjE4M" +
+                        "S1mOWU4LTExNzgtOWE5Yy1kODI1ZGZiMGE0NzA8L3htcE1NOkRvY3VtZW50SUQ+CiAgICAgICAgIDx" +
+                        "4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ+eG1wLmRpZDo2YjI0ZTI3YS1jZjA3LTQ5ZDEtOWIwZC02O" +
+                        "DEzMTFkNzQwMzE8L3htcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD4KICAgICAgICAgPHhtcE1NOkhpc3R" +
+                        "vcnk+CiAgICAgICAgICAgIDxyZGY6U2VxPgogICAgICAgICAgICAgICA8cmRmOmxpIHJkZjpwYXJzZ" +
+                        "VR5cGU9IlJlc291cmNlIj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0OmFjdGlvbj5jcmVhdGVkPC9" +
+                        "zdEV2dDphY3Rpb24+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDppbnN0YW5jZUlEPnhtcC5paWQ6N" +
+                        "mIyNGUyN2EtY2YwNy00OWQxLTliMGQtNjgxMzExZDc0MDMxPC9zdEV2dDppbnN0YW5jZUlEPgogICA" +
+                        "gICAgICAgICAgICAgICA8c3RFdnQ6d2hlbj4yMDE2LTAxLTEyVDEyOjI0OjM4LTA2OjAwPC9zdEV2d" +
+                        "Dp3aGVuPgogICAgICAgICAgICAgICAgICA8c3RFdnQ6c29mdHdhcmVBZ2VudD5BZG9iZSBQaG90b3N" +
+                        "ob3AgQ0MgMjAxNCAoTWFjaW50b3NoKTwvc3RFdnQ6c29mdHdhcmVBZ2VudD4KICAgICAgICAgICAgI" +
+                        "CAgPC9yZGY6bGk+CiAgICAgICAgICAgICAgIDxyZGY6bGkgcmRmOnBhcnNlVHlwZT0iUmVzb3VyY2U" +
+                        "iPgogICAgICAgICAgICAgICAgICA8c3RFdnQ6YWN0aW9uPnNhdmVkPC9zdEV2dDphY3Rpb24+CiAgI" +
+                        "CAgICAgICAgICAgICAgIDxzdEV2dDppbnN0YW5jZUlEPnhtcC5paWQ6ZDUzYzc4NDMtYTVmMi00ODQ" +
+                        "3LThjNDMtNmUyYzBhNDY4YmViPC9zdEV2dDppbnN0YW5jZUlEPgogICAgICAgICAgICAgICAgICA8c" +
+                        "3RFdnQ6d2hlbj4yMDE2LTAxLTEyVDEyOjI0OjM4LTA2OjAwPC9zdEV2dDp3aGVuPgogICAgICAgICA" +
+                        "gICAgICAgICA8c3RFdnQ6c29mdHdhcmVBZ2VudD5BZG9iZSBQaG90b3Nob3AgQ0MgMjAxNCAoTWFja" +
+                        "W50b3NoKTwvc3RFdnQ6c29mdHdhcmVBZ2VudD4KICAgICAgICAgICAgICAgICAgPHN0RXZ0OmNoYW5" +
+                        "nZWQ+Lzwvc3RFdnQ6Y2hhbmdlZD4KICAgICAgICAgICAgICAgPC9yZGY6bGk+CiAgICAgICAgICAgI" +
+                        "CAgIDxyZGY6bGkgcmRmOnBhcnNlVHlwZT0iUmVzb3VyY2UiPgogICAgICAgICAgICAgICAgICA8c3R" +
+                        "FdnQ6YWN0aW9uPmRlcml2ZWQ8L3N0RXZ0OmFjdGlvbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0O" +
+                        "nBhcmFtZXRlcnM+Y29udmVydGVkIGZyb20gaW1hZ2UvcG5nIHRvIGFwcGxpY2F0aW9uL3ZuZC5hZG9" +
+                        "iZS5waG90b3Nob3A8L3N0RXZ0OnBhcmFtZXRlcnM+CiAgICAgICAgICAgICAgIDwvcmRmOmxpPgogI" +
+                        "CAgICAgICAgICAgICA8cmRmOmxpIHJkZjpwYXJzZVR5cGU9IlJlc291cmNlIj4KICAgICAgICAgICA" +
+                        "gICAgICAgPHN0RXZ0OmFjdGlvbj5zYXZlZDwvc3RFdnQ6YWN0aW9uPgogICAgICAgICAgICAgICAgI" +
+                        "CA8c3RFdnQ6aW5zdGFuY2VJRD54bXAuaWlkOjgzYTc5MGFkLWMwZWQtNGIzYS05ZDJhLWE5YzQ2MWR" +
+                        "mMzVhMTwvc3RFdnQ6aW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAgPHN0RXZ0OndoZW4+MjAxN" +
+                        "i0wMS0xM1QxMzoxMzoyMy0wNjowMDwvc3RFdnQ6d2hlbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ" +
+                        "0OnNvZnR3YXJlQWdlbnQ+QWRvYmUgUGhvdG9zaG9wIENDIDIwMTQgKE1hY2ludG9zaCk8L3N0RXZ0O" +
+                        "nNvZnR3YXJlQWdlbnQ+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDpjaGFuZ2VkPi88L3N0RXZ0OmN" +
+                        "oYW5nZWQ+CiAgICAgICAgICAgICAgIDwvcmRmOmxpPgogICAgICAgICAgICAgICA8cmRmOmxpIHJkZ" +
+                        "jpwYXJzZVR5cGU9IlJlc291cmNlIj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0OmFjdGlvbj5kZXJ" +
+                        "pdmVkPC9zdEV2dDphY3Rpb24+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDpwYXJhbWV0ZXJzPmNvb" +
+                        "nZlcnRlZCBmcm9tIGFwcGxpY2F0aW9uL3ZuZC5hZG9iZS5waG90b3Nob3AgdG8gaW1hZ2UvcG5nPC9" +
+                        "zdEV2dDpwYXJhbWV0ZXJzPgogICAgICAgICAgICAgICA8L3JkZjpsaT4KICAgICAgICAgICAgICAgP" +
+                        "HJkZjpsaSByZGY6cGFyc2VUeXBlPSJSZXNvdXJjZSI+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDp" +
+                        "hY3Rpb24+c2F2ZWQ8L3N0RXZ0OmFjdGlvbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0Omluc3Rhb" +
+                        "mNlSUQ+eG1wLmlpZDoxZGYzYjhkMy03NzgyLTQ0MGUtYjA5OS1iYjM5NjA0MDVhOWQ8L3N0RXZ0Oml" +
+                        "uc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDp3aGVuPjIwMTYtMDEtMTNUMTM6MTg6M" +
+                        "DctMDY6MDA8L3N0RXZ0OndoZW4+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDpzb2Z0d2FyZUFnZW5" +
+                        "0PkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE0IChNYWNpbnRvc2gpPC9zdEV2dDpzb2Z0d2FyZUFnZW50P" +
+                        "gogICAgICAgICAgICAgICAgICA8c3RFdnQ6Y2hhbmdlZD4vPC9zdEV2dDpjaGFuZ2VkPgogICAgICA" +
+                        "gICAgICAgICA8L3JkZjpsaT4KICAgICAgICAgICAgPC9yZGY6U2VxPgogICAgICAgICA8L3htcE1NO" +
+                        "khpc3Rvcnk+CiAgICAgICAgIDx4bXBNTTpEZXJpdmVkRnJvbSByZGY6cGFyc2VUeXBlPSJSZXNvdXJ" +
+                        "jZSI+CiAgICAgICAgICAgIDxzdFJlZjppbnN0YW5jZUlEPnhtcC5paWQ6ODNhNzkwYWQtYzBlZC00Y" +
+                        "jNhLTlkMmEtYTljNDYxZGYzNWExPC9zdFJlZjppbnN0YW5jZUlEPgogICAgICAgICAgICA8c3RSZWY" +
+                        "6ZG9jdW1lbnRJRD54bXAuZGlkOjgzYTc5MGFkLWMwZWQtNGIzYS05ZDJhLWE5YzQ2MWRmMzVhMTwvc" +
+                        "3RSZWY6ZG9jdW1lbnRJRD4KICAgICAgICAgICAgPHN0UmVmOm9yaWdpbmFsRG9jdW1lbnRJRD54bXA" +
+                        "uZGlkOjZiMjRlMjdhLWNmMDctNDlkMS05YjBkLTY4MTMxMWQ3NDAzMTwvc3RSZWY6b3JpZ2luYWxEb" +
+                        "2N1bWVudElEPgogICAgICAgICA8L3htcE1NOkRlcml2ZWRGcm9tPgogICAgICAgICA8ZGM6Zm9ybWF" +
+                        "0PmltYWdlL3BuZzwvZGM6Zm9ybWF0PgogICAgICAgICA8cGhvdG9zaG9wOkNvbG9yTW9kZT4zPC9wa" +
+                        "G90b3Nob3A6Q29sb3JNb2RlPgogICAgICAgICA8cGhvdG9zaG9wOklDQ1Byb2ZpbGU+c1JHQiBJRUM" +
+                        "2MTk2Ni0yLjE8L3Bob3Rvc2hvcDpJQ0NQcm9maWxlPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvb" +
+                        "j4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICAgICA8dGlmZjpYUmVzb2x1dGlvbj4zMDAwMDAwLzE" +
+                        "wMDAwPC90aWZmOlhSZXNvbHV0aW9uPgogICAgICAgICA8dGlmZjpZUmVzb2x1dGlvbj4zMDAwMDAwL" +
+                        "zEwMDAwPC90aWZmOllSZXNvbHV0aW9uPgogICAgICAgICA8dGlmZjpSZXNvbHV0aW9uVW5pdD4yPC9" +
+                        "0aWZmOlJlc29sdXRpb25Vbml0PgogICAgICAgICA8ZXhpZjpDb2xvclNwYWNlPjE8L2V4aWY6Q29sb" +
+                        "3JTcGFjZT4KICAgICAgICAgPGV4aWY6UGl4ZWxYRGltZW5zaW9uPjQ8L2V4aWY6UGl4ZWxYRGltZW5" +
+                        "zaW9uPgogICAgICAgICA8ZXhpZjpQaXhlbFlEaW1lbnNpb24+NDwvZXhpZjpQaXhlbFlEaW1lbnNpb" +
+                        "24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgogICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "AogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgC" +
+                        "iAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAo" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgIAo8P3hwYWN" +
+                        "rZXQgZW5kPSJ3Ij8+bleIyQAAACBjSFJNAAB6JQAAgIMAAPn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX" +
+                        "8VGAAAANElEQVR42mJ89+4uAwMDAwPD6lkTGd69u/vu3d2ZHXnv3t1lgLPevbvLrCTIEJqWD1EJGAD" +
+                        "aTRll80WcLAAAAABJRU5ErkJggg==\");color:#420}#prettydiff.canvas *:focus{outline" +
+                        ":0.1em dashed #f00}#prettydiff.canvas a{color:#039}#prettydiff.canvas .content" +
+                        "area,#prettydiff.canvas legend,#prettydiff.canvas fieldset select,#prettydiff." +
+                        "canvas .diff td,#prettydiff.canvas .report td,#prettydiff.canvas .data li,#pre" +
+                        "ttydiff.canvas .diff-right,#prettydiff.canvas fieldset input{background:#eeeee" +
+                        "8;border-color:#420}#prettydiff.canvas select,#prettydiff.canvas input,#pretty" +
+                        "diff.canvas .diff,#prettydiff.canvas .beautify,#prettydiff.canvas .report,#pre" +
+                        "ttydiff.canvas .beautify h3,#prettydiff.canvas .diff h3,#prettydiff.canvas .be" +
+                        "autify h4,#prettydiff.canvas .diff h4,#prettydiff.canvas #report,#prettydiff.c" +
+                        "anvas #report .author,#prettydiff.canvas fieldset{background:#ddddd8;border-co" +
+                        "lor:#420}#prettydiff.canvas fieldset fieldset{background:#eeeee8}#prettydiff.c" +
+                        "anvas fieldset fieldset input,#prettydiff.canvas fieldset fieldset select{back" +
+                        "ground:#ddddd8}#prettydiff.canvas h2,#prettydiff.canvas h2 button,#prettydiff." +
+                        "canvas h3,#prettydiff.canvas legend{color:#900}#prettydiff.canvas .contentarea" +
+                        "{box-shadow:0 1em 1em #b8a899}#prettydiff.canvas .segment{background:#fff}#pre" +
+                        "ttydiff.canvas h2 button,#prettydiff.canvas .segment,#prettydiff.canvas ol.seg" +
+                        "ment li{border-color:#420}#prettydiff.canvas th{background:#e8ddcc}#prettydiff" +
+                        ".canvas li h4{color:#06f}#prettydiff.canvas code{background:#eee;border-color:" +
+                        "#eee;color:#00f}#prettydiff.canvas ol.segment h4 strong{color:#c00}#prettydiff" +
+                        ".canvas button{background-color:#ddddd8;border-color:#420;box-shadow:0 0.25em " +
+                        "0.5em #b8a899;color:#900}#prettydiff.canvas button:hover{background-color:#ccb" +
+                        ";border-color:#630;box-shadow:0 0.25em 0.5em #b8a899;color:#630}#prettydiff.ca" +
+                        "nvas th{background:#ccccc8}#prettydiff.canvas thead th,#prettydiff.canvas th.h" +
+                        "eading{background:#ccb}#prettydiff.canvas .diff h3{background:#ddd;border-colo" +
+                        "r:#999}#prettydiff.canvas td,#prettydiff.canvas th,#prettydiff.canvas .segment" +
+                        ",#prettydiff.canvas .count li,#prettydiff.canvas .data li,#prettydiff.canvas ." +
+                        "diff-right{border-color:#ccccc8}#prettydiff.canvas .count{background:#eed;bord" +
+                        "er-color:#999}#prettydiff.canvas .count li.fold{color:#900}#prettydiff.canvas " +
+                        "h2 button{background:#f8f8f8;box-shadow:0.1em 0.1em 0.25em #ddd}#prettydiff.ca" +
+                        "nvas li h4{color:#00f}#prettydiff.canvas code{background:#eee;border-color:#ee" +
+                        "e;color:#009}#prettydiff.canvas ol.segment h4 strong{color:#c00}#prettydiff.ca" +
+                        "nvas .data .delete{background:#ffd8d8}#prettydiff.canvas .data .delete em{back" +
+                        "ground:#fff8f8;border-color:#c44;color:#900}#prettydiff.canvas .data .insert{b" +
+                        "ackground:#d8ffd8}#prettydiff.canvas .data .insert em{background:#f8fff8;borde" +
+                        "r-color:#090;color:#363}#prettydiff.canvas .data .replace{background:#fec}#pre" +
+                        "ttydiff.canvas .data .replace em{background:#ffe;border-color:#a86;color:#852}" +
+                        "#prettydiff.canvas .data .empty{background:#ddd}#prettydiff.canvas .data em.s0" +
+                        "{color:#000}#prettydiff.canvas .data em.s1{color:#f66}#prettydiff.canvas .data" +
+                        " em.s2{color:#12f}#prettydiff.canvas .data em.s3{color:#090}#prettydiff.canvas" +
+                        " .data em.s4{color:#d6d}#prettydiff.canvas .data em.s5{color:#7cc}#prettydiff." +
+                        "canvas .data em.s6{color:#c85}#prettydiff.canvas .data em.s7{color:#737}#prett" +
+                        "ydiff.canvas .data em.s8{color:#6d0}#prettydiff.canvas .data em.s9{color:#dd0}" +
+                        "#prettydiff.canvas .data em.s10{color:#893}#prettydiff.canvas .data em.s11{col" +
+                        "or:#b97}#prettydiff.canvas .data em.s12{color:#bbb}#prettydiff.canvas .data em" +
+                        ".s13{color:#cc3}#prettydiff.canvas .data em.s14{color:#333}#prettydiff.canvas " +
+                        ".data em.s15{color:#9d9}#prettydiff.canvas .data em.s16{color:#880}#prettydiff" +
+                        ".canvas .data .l0{background:#eeeee8}#prettydiff.canvas .data .l1{background:#" +
+                        "fed}#prettydiff.canvas .data .l2{background:#def}#prettydiff.canvas .data .l3{" +
+                        "background:#efe}#prettydiff.canvas .data .l4{background:#fef}#prettydiff.canva" +
+                        "s .data .l5{background:#eef}#prettydiff.canvas .data .l6{background:#fff8cc}#p" +
+                        "rettydiff.canvas .data .l7{background:#ede}#prettydiff.canvas .data .l8{backgr" +
+                        "ound:#efc}#prettydiff.canvas .data .l9{background:#ffd}#prettydiff.canvas .dat" +
+                        "a .l10{background:#edc}#prettydiff.canvas .data .l11{background:#fdb}#prettydi" +
+                        "ff.canvas .data .l12{background:#f8f8f8}#prettydiff.canvas .data .l13{backgrou" +
+                        "nd:#ffb}#prettydiff.canvas .data .l14{background:#eec}#prettydiff.canvas .data" +
+                        " .l15{background:#cfc}#prettydiff.canvas .data .l16{background:#eea}#prettydif" +
+                        "f.canvas .data .c0{background:inherit}#prettydiff.canvas #report p em{color:#0" +
+                        "60}#prettydiff.canvas #report p strong{color:#009}",
+                shadow: "#prettydiff.shadow{background:#333 url(\"data:image/png;base64,iVBORw0KGgoAAAA" +
+                        "NSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAACXBIWXMAAC4jAAAuIwF4pT92AAAKT2lDQ1BQaG90b3Nob" +
+                        "3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AUkSYqIQkQSoghodkVUcE" +
+                        "RRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXXPues852zzwfACAyWSDNRN" +
+                        "YAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgABeNMLCADATZvAMByH/w/qQpl" +
+                        "cAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAtAGAnf+bTAICd+Jl7AQBblCEVA" +
+                        "aCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3AMDOEAuyAAgMADBRiIUpAAR7AGD" +
+                        "IIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dXLh4ozkkXKxQ2YQJhmkAuwnmZGTKBN" +
+                        "A/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qI" +
+                        "l7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14" +
+                        "L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcU" +
+                        "l0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZ" +
+                        "kmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzABhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQii" +
+                        "GzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/phCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIB" +
+                        "BKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5h1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogv" +
+                        "QZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+Q8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu" +
+                        "4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhMWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1h" +
+                        "ILCPWEo8TLxB7iEPENyQSiUMyJ7mQAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkn" +
+                        "eTD5DPkG+Qh8lsKnWJAcaT4U+IoUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR" +
+                        "1mjnNgxZJS6WtopXTGmgXaPdpr+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl3G" +
+                        "K+YTKYZ04sZx1QwNzHrmOeZD5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9rkZ" +
+                        "VM1PjqQnUlqtVqp1Q61MbU2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWsNq" +
+                        "4Z1gTXEJrHN2Xx2KruY/R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG6Y" +
+                        "0TLkxZVxrqpaXllirSKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr1r" +
+                        "i6qa6UbobtEd79up+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL8f" +
+                        "b8VFDXcNAQ6VhlWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDtMx" +
+                        "83MzaLN1pk1mz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1ru" +
+                        "tu6cRp7lOk06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqsdW" +
+                        "h1+c7RyFDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+Lps" +
+                        "bxt3IveRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5PQ" +
+                        "0+BZ7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/3r" +
+                        "/0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5pD" +
+                        "oVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5qPNo" +
+                        "3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIsOpZAT" +
+                        "IhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5hCepkLx" +
+                        "MDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQrAVZLQq2Q" +
+                        "qboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9rGo5sjxxeds" +
+                        "K4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1dT1gvWd+1YfqGn" +
+                        "Rs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aXDm4N2dq0Dd9WtO3" +
+                        "19kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7vPY07NXbW7z3/T7Jv" +
+                        "ttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3SPVRSj9Yr60cOxx++/p3" +
+                        "vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKaRptTmvtbYlu6T8w+0dbq3" +
+                        "nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO32oPb++6EHTh0kX/i+c7vDv" +
+                        "OXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21e2b36RueN87d9L158Rb/1tWeO" +
+                        "T3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfVP1v+3Njv3H9qwHeg89HcR/cGhYP" +
+                        "P/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i/suuFxYvfvjV69fO0ZjRoZfyl5O/b" +
+                        "Xyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8IH8o/2j5sfVT0Kf7kxmTk/8EA5jz/GM" +
+                        "zLdsAAEQFaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9I" +
+                        "lc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pgo8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1" +
+                        "ldGEvIiB4OnhtcHRrPSJBZG9iZSBYTVAgQ29yZSA1LjYtYzAxNCA3OS4xNTY3OTcsIDIwMTQvMDgvM" +
+                        "jAtMDk6NTM6MDIgICAgICAgICI+CiAgIDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5" +
+                        "vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+CiAgICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmO" +
+                        "mFib3V0PSIiCiAgICAgICAgICAgIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4" +
+                        "wLyIKICAgICAgICAgICAgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tb" +
+                        "S8iCiAgICAgICAgICAgIHhtbG5zOnN0RXZ0PSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R" +
+                        "5cGUvUmVzb3VyY2VFdmVudCMiCiAgICAgICAgICAgIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvY" +
+                        "mUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIgogICAgICAgICAgICB4bWxuczpkYz0iaHR" +
+                        "0cDovL3B1cmwub3JnL2RjL2VsZW1lbnRzLzEuMS8iCiAgICAgICAgICAgIHhtbG5zOnBob3Rvc2hvc" +
+                        "D0iaHR0cDovL25zLmFkb2JlLmNvbS9waG90b3Nob3AvMS4wLyIKICAgICAgICAgICAgeG1sbnM6dGl" +
+                        "mZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iCiAgICAgICAgICAgIHhtbG5zOmV4aWY9I" +
+                        "mh0dHA6Ly9ucy5hZG9iZS5jb20vZXhpZi8xLjAvIj4KICAgICAgICAgPHhtcDpDcmVhdG9yVG9vbD5" +
+                        "BZG9iZSBQaG90b3Nob3AgQ0MgMjAxNCAoTWFjaW50b3NoKTwveG1wOkNyZWF0b3JUb29sPgogICAgI" +
+                        "CAgICA8eG1wOkNyZWF0ZURhdGU+MjAxNi0wMS0xMlQxMjoyNDozOC0wNjowMDwveG1wOkNyZWF0ZUR" +
+                        "hdGU+CiAgICAgICAgIDx4bXA6TWV0YWRhdGFEYXRlPjIwMTYtMDEtMTNUMTU6MTE6MzMtMDY6MDA8L" +
+                        "3htcDpNZXRhZGF0YURhdGU+CiAgICAgICAgIDx4bXA6TW9kaWZ5RGF0ZT4yMDE2LTAxLTEzVDE1OjE" +
+                        "xOjMzLTA2OjAwPC94bXA6TW9kaWZ5RGF0ZT4KICAgICAgICAgPHhtcE1NOkluc3RhbmNlSUQ+eG1wL" +
+                        "mlpZDo4MDAwYTE3Zi1jZTY1LTQ5NTUtYjFmMS05YjVkODIwNDIyNjU8L3htcE1NOkluc3RhbmNlSUQ" +
+                        "+CiAgICAgICAgIDx4bXBNTTpEb2N1bWVudElEPmFkb2JlOmRvY2lkOnBob3Rvc2hvcDoxZmZhNDk1Y" +
+                        "y1mYTU2LTExNzgtOWE5Yy1kODI1ZGZiMGE0NzA8L3htcE1NOkRvY3VtZW50SUQ+CiAgICAgICAgIDx" +
+                        "4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ+eG1wLmRpZDo2YjI0ZTI3YS1jZjA3LTQ5ZDEtOWIwZC02O" +
+                        "DEzMTFkNzQwMzE8L3htcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD4KICAgICAgICAgPHhtcE1NOkhpc3R" +
+                        "vcnk+CiAgICAgICAgICAgIDxyZGY6U2VxPgogICAgICAgICAgICAgICA8cmRmOmxpIHJkZjpwYXJzZ" +
+                        "VR5cGU9IlJlc291cmNlIj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0OmFjdGlvbj5jcmVhdGVkPC9" +
+                        "zdEV2dDphY3Rpb24+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDppbnN0YW5jZUlEPnhtcC5paWQ6N" +
+                        "mIyNGUyN2EtY2YwNy00OWQxLTliMGQtNjgxMzExZDc0MDMxPC9zdEV2dDppbnN0YW5jZUlEPgogICA" +
+                        "gICAgICAgICAgICAgICA8c3RFdnQ6d2hlbj4yMDE2LTAxLTEyVDEyOjI0OjM4LTA2OjAwPC9zdEV2d" +
+                        "Dp3aGVuPgogICAgICAgICAgICAgICAgICA8c3RFdnQ6c29mdHdhcmVBZ2VudD5BZG9iZSBQaG90b3N" +
+                        "ob3AgQ0MgMjAxNCAoTWFjaW50b3NoKTwvc3RFdnQ6c29mdHdhcmVBZ2VudD4KICAgICAgICAgICAgI" +
+                        "CAgPC9yZGY6bGk+CiAgICAgICAgICAgICAgIDxyZGY6bGkgcmRmOnBhcnNlVHlwZT0iUmVzb3VyY2U" +
+                        "iPgogICAgICAgICAgICAgICAgICA8c3RFdnQ6YWN0aW9uPnNhdmVkPC9zdEV2dDphY3Rpb24+CiAgI" +
+                        "CAgICAgICAgICAgICAgIDxzdEV2dDppbnN0YW5jZUlEPnhtcC5paWQ6ZDUzYzc4NDMtYTVmMi00ODQ" +
+                        "3LThjNDMtNmUyYzBhNDY4YmViPC9zdEV2dDppbnN0YW5jZUlEPgogICAgICAgICAgICAgICAgICA8c" +
+                        "3RFdnQ6d2hlbj4yMDE2LTAxLTEyVDEyOjI0OjM4LTA2OjAwPC9zdEV2dDp3aGVuPgogICAgICAgICA" +
+                        "gICAgICAgICA8c3RFdnQ6c29mdHdhcmVBZ2VudD5BZG9iZSBQaG90b3Nob3AgQ0MgMjAxNCAoTWFja" +
+                        "W50b3NoKTwvc3RFdnQ6c29mdHdhcmVBZ2VudD4KICAgICAgICAgICAgICAgICAgPHN0RXZ0OmNoYW5" +
+                        "nZWQ+Lzwvc3RFdnQ6Y2hhbmdlZD4KICAgICAgICAgICAgICAgPC9yZGY6bGk+CiAgICAgICAgICAgI" +
+                        "CAgIDxyZGY6bGkgcmRmOnBhcnNlVHlwZT0iUmVzb3VyY2UiPgogICAgICAgICAgICAgICAgICA8c3R" +
+                        "FdnQ6YWN0aW9uPmRlcml2ZWQ8L3N0RXZ0OmFjdGlvbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0O" +
+                        "nBhcmFtZXRlcnM+Y29udmVydGVkIGZyb20gaW1hZ2UvcG5nIHRvIGFwcGxpY2F0aW9uL3ZuZC5hZG9" +
+                        "iZS5waG90b3Nob3A8L3N0RXZ0OnBhcmFtZXRlcnM+CiAgICAgICAgICAgICAgIDwvcmRmOmxpPgogI" +
+                        "CAgICAgICAgICAgICA8cmRmOmxpIHJkZjpwYXJzZVR5cGU9IlJlc291cmNlIj4KICAgICAgICAgICA" +
+                        "gICAgICAgPHN0RXZ0OmFjdGlvbj5zYXZlZDwvc3RFdnQ6YWN0aW9uPgogICAgICAgICAgICAgICAgI" +
+                        "CA8c3RFdnQ6aW5zdGFuY2VJRD54bXAuaWlkOjgzYTc5MGFkLWMwZWQtNGIzYS05ZDJhLWE5YzQ2MWR" +
+                        "mMzVhMTwvc3RFdnQ6aW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAgPHN0RXZ0OndoZW4+MjAxN" +
+                        "i0wMS0xM1QxMzoxMzoyMy0wNjowMDwvc3RFdnQ6d2hlbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ" +
+                        "0OnNvZnR3YXJlQWdlbnQ+QWRvYmUgUGhvdG9zaG9wIENDIDIwMTQgKE1hY2ludG9zaCk8L3N0RXZ0O" +
+                        "nNvZnR3YXJlQWdlbnQ+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDpjaGFuZ2VkPi88L3N0RXZ0OmN" +
+                        "oYW5nZWQ+CiAgICAgICAgICAgICAgIDwvcmRmOmxpPgogICAgICAgICAgICAgICA8cmRmOmxpIHJkZ" +
+                        "jpwYXJzZVR5cGU9IlJlc291cmNlIj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0OmFjdGlvbj5zYXZ" +
+                        "lZDwvc3RFdnQ6YWN0aW9uPgogICAgICAgICAgICAgICAgICA8c3RFdnQ6aW5zdGFuY2VJRD54bXAua" +
+                        "WlkOjA0ZGYyNDk5LWE1NTktNDE4MC1iNjA1LWI2MTk3MWMxNWEwMzwvc3RFdnQ6aW5zdGFuY2VJRD4" +
+                        "KICAgICAgICAgICAgICAgICAgPHN0RXZ0OndoZW4+MjAxNi0wMS0xM1QxNToxMTozMy0wNjowMDwvc" +
+                        "3RFdnQ6d2hlbj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0OnNvZnR3YXJlQWdlbnQ+QWRvYmUgUGh" +
+                        "vdG9zaG9wIENDIDIwMTQgKE1hY2ludG9zaCk8L3N0RXZ0OnNvZnR3YXJlQWdlbnQ+CiAgICAgICAgI" +
+                        "CAgICAgICAgIDxzdEV2dDpjaGFuZ2VkPi88L3N0RXZ0OmNoYW5nZWQ+CiAgICAgICAgICAgICAgIDw" +
+                        "vcmRmOmxpPgogICAgICAgICAgICAgICA8cmRmOmxpIHJkZjpwYXJzZVR5cGU9IlJlc291cmNlIj4KI" +
+                        "CAgICAgICAgICAgICAgICAgPHN0RXZ0OmFjdGlvbj5jb252ZXJ0ZWQ8L3N0RXZ0OmFjdGlvbj4KICA" +
+                        "gICAgICAgICAgICAgICAgPHN0RXZ0OnBhcmFtZXRlcnM+ZnJvbSBhcHBsaWNhdGlvbi92bmQuYWRvY" +
+                        "mUucGhvdG9zaG9wIHRvIGltYWdlL3BuZzwvc3RFdnQ6cGFyYW1ldGVycz4KICAgICAgICAgICAgICA" +
+                        "gPC9yZGY6bGk+CiAgICAgICAgICAgICAgIDxyZGY6bGkgcmRmOnBhcnNlVHlwZT0iUmVzb3VyY2UiP" +
+                        "gogICAgICAgICAgICAgICAgICA8c3RFdnQ6YWN0aW9uPmRlcml2ZWQ8L3N0RXZ0OmFjdGlvbj4KICA" +
+                        "gICAgICAgICAgICAgICAgPHN0RXZ0OnBhcmFtZXRlcnM+Y29udmVydGVkIGZyb20gYXBwbGljYXRpb" +
+                        "24vdm5kLmFkb2JlLnBob3Rvc2hvcCB0byBpbWFnZS9wbmc8L3N0RXZ0OnBhcmFtZXRlcnM+CiAgICA" +
+                        "gICAgICAgICAgIDwvcmRmOmxpPgogICAgICAgICAgICAgICA8cmRmOmxpIHJkZjpwYXJzZVR5cGU9I" +
+                        "lJlc291cmNlIj4KICAgICAgICAgICAgICAgICAgPHN0RXZ0OmFjdGlvbj5zYXZlZDwvc3RFdnQ6YWN" +
+                        "0aW9uPgogICAgICAgICAgICAgICAgICA8c3RFdnQ6aW5zdGFuY2VJRD54bXAuaWlkOjgwMDBhMTdmL" +
+                        "WNlNjUtNDk1NS1iMWYxLTliNWQ4MjA0MjI2NTwvc3RFdnQ6aW5zdGFuY2VJRD4KICAgICAgICAgICA" +
+                        "gICAgICAgPHN0RXZ0OndoZW4+MjAxNi0wMS0xM1QxNToxMTozMy0wNjowMDwvc3RFdnQ6d2hlbj4KI" +
+                        "CAgICAgICAgICAgICAgICAgPHN0RXZ0OnNvZnR3YXJlQWdlbnQ+QWRvYmUgUGhvdG9zaG9wIENDIDI" +
+                        "wMTQgKE1hY2ludG9zaCk8L3N0RXZ0OnNvZnR3YXJlQWdlbnQ+CiAgICAgICAgICAgICAgICAgIDxzd" +
+                        "EV2dDpjaGFuZ2VkPi88L3N0RXZ0OmNoYW5nZWQ+CiAgICAgICAgICAgICAgIDwvcmRmOmxpPgogICA" +
+                        "gICAgICAgICA8L3JkZjpTZXE+CiAgICAgICAgIDwveG1wTU06SGlzdG9yeT4KICAgICAgICAgPHhtc" +
+                        "E1NOkRlcml2ZWRGcm9tIHJkZjpwYXJzZVR5cGU9IlJlc291cmNlIj4KICAgICAgICAgICAgPHN0UmV" +
+                        "mOmluc3RhbmNlSUQ+eG1wLmlpZDowNGRmMjQ5OS1hNTU5LTQxODAtYjYwNS1iNjE5NzFjMTVhMDM8L" +
+                        "3N0UmVmOmluc3RhbmNlSUQ+CiAgICAgICAgICAgIDxzdFJlZjpkb2N1bWVudElEPnhtcC5kaWQ6ODN" +
+                        "hNzkwYWQtYzBlZC00YjNhLTlkMmEtYTljNDYxZGYzNWExPC9zdFJlZjpkb2N1bWVudElEPgogICAgI" +
+                        "CAgICAgICA8c3RSZWY6b3JpZ2luYWxEb2N1bWVudElEPnhtcC5kaWQ6NmIyNGUyN2EtY2YwNy00OWQ" +
+                        "xLTliMGQtNjgxMzExZDc0MDMxPC9zdFJlZjpvcmlnaW5hbERvY3VtZW50SUQ+CiAgICAgICAgIDwve" +
+                        "G1wTU06RGVyaXZlZEZyb20+CiAgICAgICAgIDxkYzpmb3JtYXQ+aW1hZ2UvcG5nPC9kYzpmb3JtYXQ" +
+                        "+CiAgICAgICAgIDxwaG90b3Nob3A6Q29sb3JNb2RlPjM8L3Bob3Rvc2hvcDpDb2xvck1vZGU+CiAgI" +
+                        "CAgICAgIDxwaG90b3Nob3A6SUNDUHJvZmlsZT5zUkdCIElFQzYxOTY2LTIuMTwvcGhvdG9zaG9wOkl" +
+                        "DQ1Byb2ZpbGU+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50YXRpb24+C" +
+                        "iAgICAgICAgIDx0aWZmOlhSZXNvbHV0aW9uPjMwMDAwMDAvMTAwMDA8L3RpZmY6WFJlc29sdXRpb24" +
+                        "+CiAgICAgICAgIDx0aWZmOllSZXNvbHV0aW9uPjMwMDAwMDAvMTAwMDA8L3RpZmY6WVJlc29sdXRpb" +
+                        "24+CiAgICAgICAgIDx0aWZmOlJlc29sdXRpb25Vbml0PjI8L3RpZmY6UmVzb2x1dGlvblVuaXQ+CiA" +
+                        "gICAgICAgIDxleGlmOkNvbG9yU3BhY2U+MTwvZXhpZjpDb2xvclNwYWNlPgogICAgICAgICA8ZXhpZ" +
+                        "jpQaXhlbFhEaW1lbnNpb24+NDwvZXhpZjpQaXhlbFhEaW1lbnNpb24+CiAgICAgICAgIDxleGlmOlB" +
+                        "peGVsWURpbWVuc2lvbj40PC9leGlmOlBpeGVsWURpbWVuc2lvbj4KICAgICAgPC9yZGY6RGVzY3Jpc" +
+                        "HRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CiAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "AogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgC" +
+                        "iAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAo" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "AogICAgICAgICAgICAgICAgICAgICAgICAgICAgCjw/eHBhY2tldCBlbmQ9InciPz5hSvvCAAAAIGN" +
+                        "IUk0AAHolAACAgwAA+f8AAIDpAAB1MAAA6mAAADqYAAAXb5JfxUYAAAAlSURBVHjaPMYxAQAwDAMgV" +
+                        "kv1VFFRuy9cvN0F7m66JNNhOvwBAPyqCtNeO5K2AAAAAElFTkSuQmCC\");color:#fff}#prettyd" +
+                        "iff.shadow *:focus{outline:0.1em dashed #ff0}#prettydiff.shadow a:visited{colo" +
+                        "r:#f93}#prettydiff.shadow a{color:#cf3}#prettydiff.shadow .contentarea,#pretty" +
+                        "diff.shadow legend,#prettydiff.shadow fieldset select,#prettydiff.shadow .diff" +
+                        " td,#prettydiff.shadow .report td,#prettydiff.shadow .data li,#prettydiff.shad" +
+                        "ow .diff-right,#prettydiff.shadow fieldset input{background:#333;border-color:" +
+                        "#666}#prettydiff.shadow select,#prettydiff.shadow input,#prettydiff.shadow .di" +
+                        "ff,#prettydiff.shadow .beautify,#prettydiff.shadow .report,#prettydiff.shadow " +
+                        ".beautify h3,#prettydiff.shadow .diff h3,#prettydiff.shadow .beautify h4,#pret" +
+                        "tydiff.shadow .diff h4,#prettydiff.shadow #report,#prettydiff.shadow #report ." +
+                        "author,#prettydiff.shadow fieldset{background:#222;border-color:#666}#prettydi" +
+                        "ff.shadow fieldset fieldset{background:#333}#prettydiff.shadow fieldset fields" +
+                        "et input,#prettydiff.shadow fieldset fieldset select{background:#222}#prettydi" +
+                        "ff.shadow h2,#prettydiff.shadow h2 button,#prettydiff.shadow h3,#prettydiff.sh" +
+                        "adow input,#prettydiff.shadow option,#prettydiff.shadow select,#prettydiff.sha" +
+                        "dow legend{color:#ccc}#prettydiff.shadow .contentarea{box-shadow:0 1em 1em #00" +
+                        "0}#prettydiff.shadow .segment{background:#222}#prettydiff.shadow h2 button,#pr" +
+                        "ettydiff.shadow td,#prettydiff.shadow th,#prettydiff.shadow .segment,#prettydi" +
+                        "ff.shadow ol.segment li{border-color:#666}#prettydiff.shadow .count li.fold{co" +
+                        "lor:#cf3}#prettydiff.shadow th{background:#000}#prettydiff.shadow h2 button{ba" +
+                        "ckground:#585858;box-shadow:0.1em 0.1em 0.25em #000}#prettydiff.shadow li h4{c" +
+                        "olor:#ff0}#prettydiff.shadow code{background:#585858;border-color:#585858;colo" +
+                        "r:#ccf}#prettydiff.shadow ol.segment h4 strong{color:#f30}#prettydiff.shadow b" +
+                        "utton{background-color:#333;border-color:#666;box-shadow:0 0.25em 0.5em #000;c" +
+                        "olor:#ccc}#prettydiff.shadow button:hover{background-color:#777;border-color:#" +
+                        "aaa;box-shadow:0 0.25em 0.5em #222;color:#fff}#prettydiff.shadow th{background" +
+                        ":#444}#prettydiff.shadow thead th,#prettydiff.shadow th.heading{background:#44" +
+                        "4}#prettydiff.shadow .diff h3{background:#000;border-color:#666}#prettydiff.sh" +
+                        "adow .segment,#prettydiff.shadow .data li,#prettydiff.shadow .diff-right{borde" +
+                        "r-color:#444}#prettydiff.shadow .count li{border-color:#333}#prettydiff.shadow" +
+                        " .count{background:#555;border-color:#333}#prettydiff.shadow li h4{color:#ff0}" +
+                        "#prettydiff.shadow code{background:#000;border-color:#000;color:#ddd}#prettydi" +
+                        "ff.shadow ol.segment h4 strong{color:#c00}#prettydiff.shadow .data .delete{bac" +
+                        "kground:#300}#prettydiff.shadow .data .delete em{background:#200;border-color:" +
+                        "#c63;color:#c66}#prettydiff.shadow .data .insert{background:#030}#prettydiff.s" +
+                        "hadow .data .insert em{background:#010;border-color:#090;color:#6c0}#prettydif" +
+                        "f.shadow .data .replace{background:#345}#prettydiff.shadow .data .replace em{b" +
+                        "ackground:#023;border-color:#09c;color:#7cf}#prettydiff.shadow .data .empty{ba" +
+                        "ckground:#111}#prettydiff.shadow .diff .author{border-color:#666}#prettydiff.s" +
+                        "hadow .data em.s0{color:#fff}#prettydiff.shadow .data em.s1{color:#d60}#pretty" +
+                        "diff.shadow .data em.s2{color:#aaf}#prettydiff.shadow .data em.s3{color:#0c0}#" +
+                        "prettydiff.shadow .data em.s4{color:#f6f}#prettydiff.shadow .data em.s5{color:" +
+                        "#0cc}#prettydiff.shadow .data em.s6{color:#dc3}#prettydiff.shadow .data em.s7{" +
+                        "color:#a7a}#prettydiff.shadow .data em.s8{color:#7a7}#prettydiff.shadow .data " +
+                        "em.s9{color:#ff6}#prettydiff.shadow .data em.s10{color:#33f}#prettydiff.shadow" +
+                        " .data em.s11{color:#933}#prettydiff.shadow .data em.s12{color:#990}#prettydif" +
+                        "f.shadow .data em.s13{color:#987}#prettydiff.shadow .data em.s14{color:#fc3}#p" +
+                        "rettydiff.shadow .data em.s15{color:#897}#prettydiff.shadow .data em.s16{color" +
+                        ":#f30}#prettydiff.shadow .data .l0{background:#333}#prettydiff.shadow .data .l" +
+                        "1{background:#633}#prettydiff.shadow .data .l2{background:#335}#prettydiff.sha" +
+                        "dow .data .l3{background:#353}#prettydiff.shadow .data .l4{background:#636}#pr" +
+                        "ettydiff.shadow .data .l5{background:#366}#prettydiff.shadow .data .l6{backgro" +
+                        "und:#640}#prettydiff.shadow .data .l7{background:#303}#prettydiff.shadow .data" +
+                        " .l8{background:#030}#prettydiff.shadow .data .l9{background:#660}#prettydiff." +
+                        "shadow .data .l10{background:#003}#prettydiff.shadow .data .l11{background:#30" +
+                        "0}#prettydiff.shadow .data .l12{background:#553}#prettydiff.shadow .data .l13{" +
+                        "background:#432}#prettydiff.shadow .data .l14{background:#640}#prettydiff.shad" +
+                        "ow .data .l15{background:#562}#prettydiff.shadow .data .l16{background:#600}#p" +
+                        "rettydiff.shadow .data .c0{background:inherit}",
+                white : "#prettydiff.white{background:#f8f8f8 url(\"data:image/png;base64,iVBORw0KGgoAA" +
+                        "AANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAACXBIWXMAAC4jAAAuIwF4pT92AAAKT2lDQ1BQaG90b3N" +
+                        "ob3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AUkSYqIQkQSoghodkVU" +
+                        "cERRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXXPues852zzwfACAyWSDN" +
+                        "RNYAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgABeNMLCADATZvAMByH/w/qQ" +
+                        "plcAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAtAGAnf+bTAICd+Jl7AQBblCE" +
+                        "VAaCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3AMDOEAuyAAgMADBRiIUpAAR7A" +
+                        "GDIIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dXLh4ozkkXKxQ2YQJhmkAuwnmZGTK" +
+                        "BNA/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+5c+rcEAAAOF0ftH+LC+zGoA7BoBt/" +
+                        "qIl7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf" +
+                        "14L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd0yLESWK5WCoU41EScY5EmozzMqUiiUKSK" +
+                        "cUl0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQC" +
+                        "AZkmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzABhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQ" +
+                        "iiGzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/phCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcF" +
+                        "IBBKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5h1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGo" +
+                        "gvQZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+Q8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqw" +
+                        "Du4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhMWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh" +
+                        "1hILCPWEo8TLxB7iEPENyQSiUMyJ7mQAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIX" +
+                        "kneTD5DPkG+Qh8lsKnWJAcaT4U+IoUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoE" +
+                        "zR1mjnNgxZJS6WtopXTGmgXaPdpr+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl" +
+                        "3GK+YTKYZ04sZx1QwNzHrmOeZD5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9r" +
+                        "kZVM1PjqQnUlqtVqp1Q61MbU2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWs" +
+                        "Nq4Z1gTXEJrHN2Xx2KruY/R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG" +
+                        "6Y0TLkxZVxrqpaXllirSKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr" +
+                        "1ri6qa6UbobtEd79up+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL" +
+                        "8fb8VFDXcNAQ6VhlWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDt" +
+                        "Mx83MzaLN1pk1mz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1" +
+                        "rutu6cRp7lOk06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqs" +
+                        "dWh1+c7RyFDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+L" +
+                        "psbxt3IveRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5" +
+                        "PQ0+BZ7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/" +
+                        "3r/0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5" +
+                        "pDoVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5qP" +
+                        "No3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIsOpZ" +
+                        "ATIhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5hCepk" +
+                        "LxMDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQrAVZLQq" +
+                        "2QqboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9rGo5sjxxe" +
+                        "dsK4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1dT1gvWd+1Yfq" +
+                        "GnRs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aXDm4N2dq0Dd9Wt" +
+                        "O319kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7vPY07NXbW7z3/T7" +
+                        "JvttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3SPVRSj9Yr60cOxx++/" +
+                        "p3vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKaRptTmvtbYlu6T8w+0db" +
+                        "q3nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO32oPb++6EHTh0kX/i+c7v" +
+                        "DvOXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21e2b36RueN87d9L158Rb/1tW" +
+                        "eOT3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfVP1v+3Njv3H9qwHeg89HcR/cGh" +
+                        "YPP/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i/suuFxYvfvjV69fO0ZjRoZfyl5O" +
+                        "/bXyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8IH8o/2j5sfVT0Kf7kxmTk/8EA5jz/" +
+                        "GMzLdsAADo2aVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ" +
+                        "9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pgo8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zO" +
+                        "m1ldGEvIiB4OnhtcHRrPSJBZG9iZSBYTVAgQ29yZSA1LjYtYzAxNCA3OS4xNTY3OTcsIDIwMTQvMDg" +
+                        "vMjAtMDk6NTM6MDIgICAgICAgICI+CiAgIDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53M" +
+                        "y5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+CiAgICAgIDxyZGY6RGVzY3JpcHRpb24gcmR" +
+                        "mOmFib3V0PSIiCiAgICAgICAgICAgIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvM" +
+                        "S4wLyIKICAgICAgICAgICAgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9" +
+                        "tbS8iCiAgICAgICAgICAgIHhtbG5zOnN0RXZ0PSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc" +
+                        "1R5cGUvUmVzb3VyY2VFdmVudCMiCiAgICAgICAgICAgIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmc" +
+                        "vZGMvZWxlbWVudHMvMS4xLyIKICAgICAgICAgICAgeG1sbnM6cGhvdG9zaG9wPSJodHRwOi8vbnMuY" +
+                        "WRvYmUuY29tL3Bob3Rvc2hvcC8xLjAvIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnM" +
+                        "uYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgICAgICAgICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb" +
+                        "2JlLmNvbS9leGlmLzEuMC8iPgogICAgICAgICA8eG1wOkNyZWF0b3JUb29sPkFkb2JlIFBob3Rvc2h" +
+                        "vcCBDQyAyMDE0IChNYWNpbnRvc2gpPC94bXA6Q3JlYXRvclRvb2w+CiAgICAgICAgIDx4bXA6Q3JlY" +
+                        "XRlRGF0ZT4yMDE2LTAxLTEyVDEyOjI0OjM4LTA2OjAwPC94bXA6Q3JlYXRlRGF0ZT4KICAgICAgICA" +
+                        "gPHhtcDpNZXRhZGF0YURhdGU+MjAxNi0wMS0xMlQxMjoyNDozOC0wNjowMDwveG1wOk1ldGFkYXRhR" +
+                        "GF0ZT4KICAgICAgICAgPHhtcDpNb2RpZnlEYXRlPjIwMTYtMDEtMTJUMTI6MjQ6MzgtMDY6MDA8L3h" +
+                        "tcDpNb2RpZnlEYXRlPgogICAgICAgICA8eG1wTU06SW5zdGFuY2VJRD54bXAuaWlkOmQ1M2M3ODQzL" +
+                        "WE1ZjItNDg0Ny04YzQzLTZlMmMwYTQ2OGJlYjwveG1wTU06SW5zdGFuY2VJRD4KICAgICAgICAgPHh" +
+                        "tcE1NOkRvY3VtZW50SUQ+YWRvYmU6ZG9jaWQ6cGhvdG9zaG9wOjFjMzc2MTgxLWY5ZTgtMTE3OC05Y" +
+                        "TljLWQ4MjVkZmIwYTQ3MDwveG1wTU06RG9jdW1lbnRJRD4KICAgICAgICAgPHhtcE1NOk9yaWdpbmF" +
+                        "sRG9jdW1lbnRJRD54bXAuZGlkOjZiMjRlMjdhLWNmMDctNDlkMS05YjBkLTY4MTMxMWQ3NDAzMTwve" +
+                        "G1wTU06T3JpZ2luYWxEb2N1bWVudElEPgogICAgICAgICA8eG1wTU06SGlzdG9yeT4KICAgICAgICA" +
+                        "gICAgPHJkZjpTZXE+CiAgICAgICAgICAgICAgIDxyZGY6bGkgcmRmOnBhcnNlVHlwZT0iUmVzb3VyY" +
+                        "2UiPgogICAgICAgICAgICAgICAgICA8c3RFdnQ6YWN0aW9uPmNyZWF0ZWQ8L3N0RXZ0OmFjdGlvbj4" +
+                        "KICAgICAgICAgICAgICAgICAgPHN0RXZ0Omluc3RhbmNlSUQ+eG1wLmlpZDo2YjI0ZTI3YS1jZjA3L" +
+                        "TQ5ZDEtOWIwZC02ODEzMTFkNzQwMzE8L3N0RXZ0Omluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICA" +
+                        "gIDxzdEV2dDp3aGVuPjIwMTYtMDEtMTJUMTI6MjQ6MzgtMDY6MDA8L3N0RXZ0OndoZW4+CiAgICAgI" +
+                        "CAgICAgICAgICAgIDxzdEV2dDpzb2Z0d2FyZUFnZW50PkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE0ICh" +
+                        "NYWNpbnRvc2gpPC9zdEV2dDpzb2Z0d2FyZUFnZW50PgogICAgICAgICAgICAgICA8L3JkZjpsaT4KI" +
+                        "CAgICAgICAgICAgICAgPHJkZjpsaSByZGY6cGFyc2VUeXBlPSJSZXNvdXJjZSI+CiAgICAgICAgICA" +
+                        "gICAgICAgIDxzdEV2dDphY3Rpb24+c2F2ZWQ8L3N0RXZ0OmFjdGlvbj4KICAgICAgICAgICAgICAgI" +
+                        "CAgPHN0RXZ0Omluc3RhbmNlSUQ+eG1wLmlpZDpkNTNjNzg0My1hNWYyLTQ4NDctOGM0My02ZTJjMGE" +
+                        "0NjhiZWI8L3N0RXZ0Omluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgIDxzdEV2dDp3aGVuPjIwM" +
+                        "TYtMDEtMTJUMTI6MjQ6MzgtMDY6MDA8L3N0RXZ0OndoZW4+CiAgICAgICAgICAgICAgICAgIDxzdEV" +
+                        "2dDpzb2Z0d2FyZUFnZW50PkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE0IChNYWNpbnRvc2gpPC9zdEV2d" +
+                        "Dpzb2Z0d2FyZUFnZW50PgogICAgICAgICAgICAgICAgICA8c3RFdnQ6Y2hhbmdlZD4vPC9zdEV2dDp" +
+                        "jaGFuZ2VkPgogICAgICAgICAgICAgICA8L3JkZjpsaT4KICAgICAgICAgICAgPC9yZGY6U2VxPgogI" +
+                        "CAgICAgICA8L3htcE1NOkhpc3Rvcnk+CiAgICAgICAgIDxkYzpmb3JtYXQ+aW1hZ2UvcG5nPC9kYzp" +
+                        "mb3JtYXQ+CiAgICAgICAgIDxwaG90b3Nob3A6Q29sb3JNb2RlPjM8L3Bob3Rvc2hvcDpDb2xvck1vZ" +
+                        "GU+CiAgICAgICAgIDxwaG90b3Nob3A6SUNDUHJvZmlsZT5zUkdCIElFQzYxOTY2LTIuMTwvcGhvdG9" +
+                        "zaG9wOklDQ1Byb2ZpbGU+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50Y" +
+                        "XRpb24+CiAgICAgICAgIDx0aWZmOlhSZXNvbHV0aW9uPjMwMDAwMDAvMTAwMDA8L3RpZmY6WFJlc29" +
+                        "sdXRpb24+CiAgICAgICAgIDx0aWZmOllSZXNvbHV0aW9uPjMwMDAwMDAvMTAwMDA8L3RpZmY6WVJlc" +
+                        "29sdXRpb24+CiAgICAgICAgIDx0aWZmOlJlc29sdXRpb25Vbml0PjI8L3RpZmY6UmVzb2x1dGlvblV" +
+                        "uaXQ+CiAgICAgICAgIDxleGlmOkNvbG9yU3BhY2U+MTwvZXhpZjpDb2xvclNwYWNlPgogICAgICAgI" +
+                        "CA8ZXhpZjpQaXhlbFhEaW1lbnNpb24+NDwvZXhpZjpQaXhlbFhEaW1lbnNpb24+CiAgICAgICAgIDx" +
+                        "leGlmOlBpeGVsWURpbWVuc2lvbj40PC9leGlmOlBpeGVsWURpbWVuc2lvbj4KICAgICAgPC9yZGY6R" +
+                        "GVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CiAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "AogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgC" +
+                        "iAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAo" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA" +
+                        "gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI" +
+                        "CAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgCjw/eHBhY2tldCBlbmQ9InciPz5cKga" +
+                        "XAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1MAAA6mAAADqYAAAXb5JfxUYAAAAkSURBVHjaPMahA" +
+                        "QAwDMCg7P+/KnsPcq4oHqpqdwNmBt3QDX8AeAUmcrZLnM4AAAAASUVORK5CYII=\")}#prettydiff" +
+                        ".white *:focus{outline:0.1em dashed #06f}#prettydiff.white .contentarea,#prett" +
+                        "ydiff.white legend,#prettydiff.white fieldset select,#prettydiff.white .diff t" +
+                        "d,#prettydiff.white .report td,#prettydiff.white .data li,#prettydiff.white .d" +
+                        "iff-right,#prettydiff.white fieldset input{background:#fff;border-color:#999}#" +
+                        "prettydiff.white select,#prettydiff.white input,#prettydiff.white .diff,#prett" +
+                        "ydiff.white .beautify,#prettydiff.white .report,#prettydiff.white .beautify h3" +
+                        ",#prettydiff.white .diff h3,#prettydiff.white .beautify h4,#prettydiff.white ." +
+                        "diff h4,#prettydiff.white #pdsamples li div,#prettydiff.white #report,#prettyd" +
+                        "iff.white .author,#prettydiff.white #report .author,#prettydiff.white fieldset" +
+                        "{background:#eee;border-color:#999}#prettydiff.white .diff h3{background:#ddd;" +
+                        "border-color:#999}#prettydiff.white fieldset fieldset{background:#ddd}#prettyd" +
+                        "iff.white .contentarea{box-shadow:0 1em 1em #999}#prettydiff.white button{back" +
+                        "ground-color:#eee;border-color:#999;box-shadow:0 0.25em 0.5em #ccc;color:#666}" +
+                        "#prettydiff.white button:hover{background-color:#def;border-color:#03c;box-sha" +
+                        "dow:0 0.25em 0.5em #ccf;color:#03c}#prettydiff.white h2,#prettydiff.white h2 b" +
+                        "utton,#prettydiff.white h3{color:#b00}#prettydiff.white th{background:#eee;col" +
+                        "or:#333}#prettydiff.white thead th{background:#eef}#prettydiff.white .report s" +
+                        "trong{color:#009}#prettydiff.white .report em{color:#080}#prettydiff.white h2 " +
+                        "button,#prettydiff.white td,#prettydiff.white th,#prettydiff.white .segment,#p" +
+                        "rettydiff.white .count li,#prettydiff.white .diff-right #prettydiff.white ol.s" +
+                        "egment li{border-color:#ccc}#prettydiff.white .data li{border-color:#ccc}#pret" +
+                        "tydiff.white .count li.fold{color:#900}#prettydiff.white .count{background:#ee" +
+                        "d;border-color:#999}#prettydiff.white h2 button{background:#f8f8f8;box-shadow:" +
+                        "0.1em 0.1em 0.25em #ddd}#prettydiff.white li h4{color:#00f}#prettydiff.white c" +
+                        "ode{background:#eee;border-color:#eee;color:#009}#prettydiff.white ol.segment " +
+                        "h4 strong{color:#c00}#prettydiff.white .data .delete{background:#ffd8d8}#prett" +
+                        "ydiff.white .data .delete em{background:#fff8f8;border-color:#c44;color:#900}#" +
+                        "prettydiff.white .data .insert{background:#d8ffd8}#prettydiff.white .data .ins" +
+                        "ert em{background:#f8fff8;border-color:#090;color:#363}#prettydiff.white .data" +
+                        " .replace{background:#fec}#prettydiff.white .data .replace em{background:#ffe;" +
+                        "border-color:#a86;color:#852}#prettydiff.white .data .empty{background:#ddd}#p" +
+                        "rettydiff.white .data em.s0{color:#000}#prettydiff.white .data em.s1{color:#f6" +
+                        "6}#prettydiff.white .data em.s2{color:#12f}#prettydiff.white .data em.s3{color" +
+                        ":#090}#prettydiff.white .data em.s4{color:#d6d}#prettydiff.white .data em.s5{c" +
+                        "olor:#7cc}#prettydiff.white .data em.s6{color:#c85}#prettydiff.white .data em." +
+                        "s7{color:#737}#prettydiff.white .data em.s8{color:#6d0}#prettydiff.white .data" +
+                        " em.s9{color:#dd0}#prettydiff.white .data em.s10{color:#893}#prettydiff.white " +
+                        ".data em.s11{color:#b97}#prettydiff.white .data em.s12{color:#bbb}#prettydiff." +
+                        "white .data em.s13{color:#cc3}#prettydiff.white .data em.s14{color:#333}#prett" +
+                        "ydiff.white .data em.s15{color:#9d9}#prettydiff.white .data em.s16{color:#880}" +
+                        "#prettydiff.white .data .l0{background:#fff}#prettydiff.white .data .l1{backgr" +
+                        "ound:#fed}#prettydiff.white .data .l2{background:#def}#prettydiff.white .data " +
+                        ".l3{background:#efe}#prettydiff.white .data .l4{background:#fef}#prettydiff.wh" +
+                        "ite .data .l5{background:#eef}#prettydiff.white .data .l6{background:#fff8cc}#" +
+                        "prettydiff.white .data .l7{background:#ede}#prettydiff.white .data .l8{backgro" +
+                        "und:#efc}#prettydiff.white .data .l9{background:#ffd}#prettydiff.white .data ." +
+                        "l10{background:#edc}#prettydiff.white .data .l11{background:#fdb}#prettydiff.w" +
+                        "hite .data .l12{background:#f8f8f8}#prettydiff.white .data .l13{background:#ff" +
+                        "b}#prettydiff.white .data .l14{background:#eec}#prettydiff.white .data .l15{ba" +
+                        "ckground:#cfc}#prettydiff.white .data .l16{background:#eea}#prettydiff.white ." +
+                        "data .c0{background:inherit}#prettydiff.white #report p em{color:#080}#prettyd" +
+                        "iff.white #report p strong{color:#009}"
+            },
+            global : "#prettydiff{text-align:center;font-size:10px;overflow-y:scroll}#prettydiff .co" +
+                    "ntentarea{border-style:solid;border-width:0.1em;font-family:\"Century Gothic\"" +
+                    ",\"Trebuchet MS\";margin:0 auto;max-width:93em;padding:1em;text-align:left}#pr" +
+                    "ettydiff dd,#prettydiff dt,#prettydiff p,#prettydiff li,#prettydiff td,#pretty" +
+                    "diff blockquote,#prettydiff th{clear:both;font-family:\"Palatino Linotype\",\"" +
+                    "Book Antiqua\",Palatino,serif;font-size:1.6em;line-height:1.6em;text-align:lef" +
+                    "t}#prettydiff blockquote{font-style:italic}#prettydiff dt{font-size:1.4em;font" +
+                    "-weight:bold;line-height:inherit}#prettydiff li li,#prettydiff li p{font-size:" +
+                    "1em}#prettydiff th,#prettydiff td{border-style:solid;border-width:0.1em;paddin" +
+                    "g:0.1em 0.2em}#prettydiff td span{display:block}#prettydiff code,#prettydiff t" +
+                    "extarea{font-family:\"Courier New\",Courier,\"Lucida Console\",monospace}#pret" +
+                    "tydiff code,#prettydiff textarea{display:block;font-size:0.8em;width:100%}#pre" +
+                    "ttydiff code span{display:block;white-space:pre}#prettydiff code{border-style:" +
+                    "solid;border-width:0.2em;line-height:1em}#prettydiff textarea{line-height:1.4e" +
+                    "m}#prettydiff label{display:inline;font-size:1.4em}#prettydiff legend{border-r" +
+                    "adius:1em;border-style:solid;border-width:0.1em;font-size:1.4em;font-weight:bo" +
+                    "ld;margin-left:-0.25em;padding:0 0.5em}#prettydiff fieldset fieldset legend{fo" +
+                    "nt-size:1.2em}#prettydiff table{border-collapse:collapse}#prettydiff div.repor" +
+                    "t{border-style:none}#prettydiff h2,#prettydiff h3,#prettydiff h4{clear:both}#p" +
+                    "rettydiff table{margin:0 0 1em}#prettydiff .analysis .bad,#prettydiff .analysi" +
+                    "s .good{font-weight:bold}#prettydiff h1{font-size:3em;font-weight:normal;margi" +
+                    "n-top:0}#prettydiff h1 span{font-size:0.5em}#prettydiff h1 svg{border-style:so" +
+                    "lid;border-width:0.05em;float:left;height:1.5em;margin-right:0.5em;width:1.5em" +
+                    "}#prettydiff h2{border-style:none;background:transparent;font-size:1em;box-sha" +
+                    "dow:none;margin:0}#prettydiff h2 button{background:transparent;border-style:so" +
+                    "lid;cursor:pointer;display:block;font-size:2.5em;font-weight:normal;text-align" +
+                    ":left;width:100%;border-width:0.05em;font-weight:normal;margin:1em 0 0;padding" +
+                    ":0.1em}#prettydiff h2 span{display:block;float:right;font-size:0.5em}#prettydi" +
+                    "ff h3{font-size:2em;margin:0;background:transparent;box-shadow:none;border-sty" +
+                    "le:none}#prettydiff h4{font-size:1.6em;font-family:\"Century Gothic\",\"Trebuc" +
+                    "het MS\";margin:0}#prettydiff li h4{font-size:1em}#prettydiff button,#prettydi" +
+                    "ff fieldset,#prettydiff div input,#prettydiff textarea{border-style:solid;bord" +
+                    "er-width:0.1em}#prettydiff section{border-style:none}#prettydiff h2 button,#pr" +
+                    "ettydiff select,#prettydiff option{font-family:inherit}#prettydiff select{bord" +
+                    "er-style:inset;border-width:0.1em;width:13.5em}#prettydiff #dcolorScheme{float" +
+                    ":right;margin:-3em 0 0}#prettydiff #dcolorScheme label,#prettydiff #dcolorSche" +
+                    "me label{display:inline-block;font-size:1em}#prettydiff .clear{clear:both;disp" +
+                    "lay:block}#prettydiff caption,#prettydiff .content-hide{height:1em;left:-1000e" +
+                    "m;overflow:hidden;position:absolute;top:-1000em;width:1em}",
+            reports: "#prettydiff #report.contentarea{font-family:\"Lucida Sans Unicode\",\"Helvetic" +
+                    "a\",\"Arial\",sans-serif;max-width:none;overflow:scroll}#prettydiff .diff .rep" +
+                    "lace em,#prettydiff .diff .delete em,#prettydiff .diff .insert em{border-style" +
+                    ":solid;border-width:0.1em}#prettydiff #report dd,#prettydiff #report dt,#prett" +
+                    "ydiff #report p,#prettydiff #report li,#prettydiff #report td,#prettydiff #rep" +
+                    "ort blockquote,#prettydiff #report th{font-family:\"Lucida Sans Unicode\",\"He" +
+                    "lvetica\",\"Arial\",sans-serif;font-size:1.2em}#prettydiff div#webtool{backgro" +
+                    "und:transparent;font-size:inherit;margin:0;padding:0}#prettydiff #jserror span" +
+                    "{display:block}#prettydiff #a11y{background:transparent;padding:0}#prettydiff " +
+                    "#a11y div{margin:0.5em 0;border-style:solid;border-width:0.1em}#prettydiff #a1" +
+                    "1y h4{margin:0.25em 0}#prettydiff #a11y ol{border-style:solid;border-width:0.1" +
+                    "em}#prettydiff #cssreport.doc table{clear:none;float:left;margin-left:1em}#pre" +
+                    "ttydiff #css-size{left:24em}#prettydiff #css-uri{left:40em}#prettydiff #css-ur" +
+                    "i td{text-align:left}#prettydiff .report .analysis th{text-align:left}#prettyd" +
+                    "iff .report .analysis .parseData td{font-family:\"Courier New\",Courier,\"Luci" +
+                    "da Console\",monospace;text-align:left;white-space:pre}#prettydiff .report .an" +
+                    "alysis td{text-align:right}#prettydiff .analysis{float:left;margin:0 1em 1em 0" +
+                    "}#prettydiff .analysis td,#prettydiff .analysis th{padding:0.5em}#prettydiff #" +
+                    "statreport div{border-style:none}#prettydiff .diff,#prettydiff .beautify{borde" +
+                    "r-style:solid;border-width:0.1em;display:inline-block;margin:0 1em 1em 0;posit" +
+                    "ion:relative}#prettydiff .diff,#prettydiff .diff li #prettydiff .diff h3,#pret" +
+                    "tydiff .diff h4,#prettydiff .beautify,#prettydiff .beautify li,#prettydiff .be" +
+                    "autify h3,#prettydiff .beautify h4{font-family:\"Courier New\",Courier,\"Lucid" +
+                    "a Console\",monospace}#prettydiff .diff li,#prettydiff .beautify li,#prettydif" +
+                    "f .diff h3,#prettydiff .diff h4,#prettydiff .beautify h3,#prettydiff .beautify" +
+                    " h4{border-style:none none solid none;border-width:0 0 0.1em 0;box-shadow:none" +
+                    ";display:block;font-size:1.2em;margin:0 0 0 -.1em;padding:0.2em 2em;text-align" +
+                    ":left}#prettydiff .diff .skip{border-style:none none solid;border-width:0 0 0." +
+                    "1em}#prettydiff .diff .diff-left{border-style:none;display:table-cell}#prettyd" +
+                    "iff .diff .diff-right{border-style:none none none solid;border-width:0 0 0 0.1" +
+                    "em;display:table-cell;margin-left:-.1em;min-width:16.5em;right:0;top:0}#pretty" +
+                    "diff .diff .data li,#prettydiff .beautify .data li{min-width:16.5em;padding:0." +
+                    "5em}#prettydiff .diff li,#prettydiff .diff p,#prettydiff .diff h3,#prettydiff " +
+                    ".beautify li,#prettydiff .beautify p,#prettydiff .beautify h3{font-size:1.2em}" +
+                    "#prettydiff .diff li em,#prettydiff .beautify li em{font-style:normal;font-wei" +
+                    "ght:bold;margin:-0.5em -0.09em}#prettydiff .diff p.author{border-style:solid;b" +
+                    "order-width:0.2em 0.1em 0.1em;margin:0;overflow:hidden;padding:0.4em;text-alig" +
+                    "n:right}#prettydiff .difflabel{display:block;height:0}#prettydiff .count{borde" +
+                    "r-style:solid;border-width:0 0.1em 0 0;font-weight:normal;padding:0;text-align" +
+                    ":right}#prettydiff .count li{padding:0.5em 1em;text-align:right}#prettydiff .c" +
+                    "ount li.fold{cursor:pointer;font-weight:bold;padding-left:0.5em}#prettydiff .d" +
+                    "ata{text-align:left;white-space:pre}#prettydiff .beautify .data em{display:inl" +
+                    "ine-block;font-style:normal;font-weight:bold}#prettydiff .beautify li,#prettyd" +
+                    "iff .diff li{border-style:none none solid;border-width:0 0 0.1em;display:block" +
+                    ";height:1em;line-height:1.2;list-style-type:none;margin:0;white-space:pre}#pre" +
+                    "ttydiff .beautify ol,#prettydiff .diff ol{display:table-cell;margin:0;padding:" +
+                    "0}#prettydiff .beautify em.l0,#prettydiff .beautify em.l1,#prettydiff .beautif" +
+                    "y em.l2,#prettydiff .beautify em.l3,#prettydiff .beautify em.l4,#prettydiff .b" +
+                    "eautify em.l5,#prettydiff .beautify em.l6,#prettydiff .beautify em.l7,#prettyd" +
+                    "iff .beautify em.l8,#prettydiff .beautify em.l9,#prettydiff .beautify em.l10,#" +
+                    "prettydiff .beautify em.l11,#prettydiff .beautify em.l12,#prettydiff .beautify" +
+                    " em.l13,#prettydiff .beautify em.l14,#prettydiff .beautify em.l15,#prettydiff " +
+                    ".beautify em.l16{height:2.2em;margin:0 0 -1em;position:relative;top:-0.5em}#pr" +
+                    "ettydiff .beautify em.l0{margin-left:-0.5em;padding-left:0.5em}#prettydiff #re" +
+                    "port .beautify,#prettydiff #report .beautify li,#prettydiff #report .diff,#pre" +
+                    "ttydiff #report .diff li{font-family:\"Courier New\",Courier,\"Lucida Console" +
+                    "\",monospace}#prettydiff #report .beautify{border-style:solid}#prettydiff #rep" +
+                    "ort .diff h3,#prettydiff #report .beautify h3{margin:0}"
+        },
+        html  : {
+            body  : "/*]]>*\/</style></head><body id=\"prettydiff\" class=\"",
+            color : "white",
+            end   : "//]]>\r\n</script></body></html>",
+            head  : "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><!DOCTYPE html PUBLIC \"-//W3C//DTD" +
+                    " XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\"><html xmlns=" +
+                    "\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\"><head><title>Pretty Diff - Th" +
+                    "e difference tool</title><meta name=\"robots\" content=\"index, follow\"/> <me" +
+                    "ta name=\"DC.title\" content=\"Pretty Diff - The difference tool\"/> <link rel" +
+                    "=\"canonical\" href=\"http://prettydiff.com/\" type=\"application/xhtml+xml\"/" +
+                    "><meta http-equiv=\"Content-Type\" content=\"application/xhtml+xml;charset=UTF" +
+                    "-8\"/><meta http-equiv=\"Content-Style-Type\" content=\"text/css\"/><style typ" +
+                    "e=\"text/css\">/*<![CDATA[*\/",
+            intro : "\"><div class=\"contentarea\" id=\"report\"><section role=\"heading\"><h1><svg" +
+                    " height=\"2000.000000pt\" id=\"pdlogo\" preserveAspectRatio=\"xMidYMid meet\" " +
+                    "version=\"1.0\" viewBox=\"0 0 2000.000000 2000.000000\" width=\"2000.000000pt" +
+                    "\" xmlns=\"http://www.w3.org/2000/svg\"><g fill=\"#999\" stroke=\"none\" trans" +
+                    "form=\"translate(0.000000,2000.000000) scale(0.100000,-0.100000)\"> <path d=\"" +
+                    "M14871 18523 c-16 -64 -611 -2317 -946 -3588 -175 -660 -319 -1202 -320 -1204 -2" +
+                    " -2 -50 39 -107 91 -961 876 -2202 1358 -3498 1358 -1255 0 -2456 -451 -3409 -12" +
+                    "79 -161 -140 -424 -408 -560 -571 -507 -607 -870 -1320 -1062 -2090 -58 -232 -38" +
+                    "6 -1479 -2309 -8759 -148 -563 -270 -1028 -270 -1033 0 -4 614 -8 1365 -8 l1364 " +
+                    "0 10 38 c16 63 611 2316 946 3587 175 660 319 1202 320 1204 2 2 50 -39 107 -91 " +
+                    "543 -495 1169 -862 1863 -1093 1707 -568 3581 -211 4965 946 252 210 554 524 767" +
+                    " 796 111 143 312 445 408 613 229 406 408 854 525 1320 57 225 380 1451 2310 875" +
+                    "9 148 563 270 1028 270 1033 0 4 -614 8 -1365 8 l-1364 0 -10 -37z m-4498 -5957 " +
+                    "c477 -77 889 -256 1245 -542 523 -419 850 -998 954 -1689 18 -121 18 -549 0 -670" +
+                    " -80 -529 -279 -972 -612 -1359 -412 -480 -967 -779 -1625 -878 -121 -18 -549 -1" +
+                    "8 -670 0 -494 74 -918 255 -1283 548 -523 419 -850 998 -954 1689 -18 121 -18 54" +
+                    "9 0 670 104 691 431 1270 954 1689 365 293 828 490 1283 545 50 6 104 13 120 15 " +
+                    "72 10 495 -3 588 -18z\"/></g></svg><a href=\"prettydiff.com.xhtml\">Pretty Dif" +
+                    "f</a></h1><p id=\"dcolorScheme\"><label class=\"label\" for=\"colorScheme\">Co" +
+                    "lor Scheme</label><select id=\"colorScheme\"><option>Canvas</option><option>Sh" +
+                    "adow</option><option selected=\"selected\">White</option></select></p><p>Find " +
+                    "<a href=\"https://github.com/prettydiff/prettydiff\">Pretty Diff on GitHub</a>" +
+                    ".</p></section><section role=\"main\">",
+            script: "</section></div><script type=\"application/javascript\">//<![CDATA[\r\n"
+        },
+        script: {
+            beautify: "var pd={};pd.colorchange=function(){\"use strict\";var options=this.getElement" +
+                    "sByTagName(\"option\");document.getElementsByTagName(\"body\")[0].setAttribute" +
+                    "(\"class\",options[this.selectedIndex].innerHTML.toLowerCase());};pd.colorsche" +
+                    "me=document.getElementById(\"colorScheme\");pd.colorscheme.onchange=pd.colorch" +
+                    "ange;pd.beaufold=function dom__beaufold(){\"use strict\";var self=this,title=s" +
+                    "elf.getAttribute(\"title\").split(\"line \"),min=Number(title[1].substr(0,titl" +
+                    "e[1].indexOf(\" \"))),max=Number(title[2]),a=0,b=\"\",list=[self.parentNode.ge" +
+                    "tElementsByTagName(\"li\"),self.parentNode.nextSibling.getElementsByTagName(\"" +
+                    "li\")];if(self.innerHTML.charAt(0)===\"-\"){for(a=min;a<max;a=a+1){list[0][a]." +
+                    "style.display=\"none\";list[1][a].style.display=\"none\";}self.innerHTML=\"+\"" +
+                    "+self.innerHTML.substr(1);}else{for(a=min;a<max;a=a+1){list[0][a].style.displa" +
+                    "y=\"block\";list[1][a].style.display=\"block\";if(list[0][a].getAttribute(\"cl" +
+                    "ass\")===\"fold\"&&list[0][a].innerHTML.charAt(0)===\"+\"){b=list[0][a].getAtt" +
+                    "ribute(\"title\");b=b.substring(b.indexOf(\"to line \")+1);a=Number(b)-1;}}sel" +
+                    "f.innerHTML=\"-\"+self.innerHTML.substr(1);}};(function(){\"use strict\";var l" +
+                    "ists=document.getElementsByTagName(\"ol\"),listslen=lists.length,list=[],listl" +
+                    "en=0,a=0,b=0;for(a=0;a<listslen;a+=1){if(lists[a].getAttribute(\"class\")===\"" +
+                    "count\"&&lists[a].parentNode.getAttribute(\"class\")===\"beautify\"){list=list" +
+                    "s[a].getElementsByTagName(\"li\");listlen=list.length;for(b=0;b<listlen;b=b+1)" +
+                    "{if(list[b].getAttribute(\"class\")===\"fold\"){list[b].onmousedown=pd.beaufol" +
+                    "d;}}}}}());",
+            diff    : "var pd={};pd.colorchange=function(){\"use strict\";var options=this.getElement" +
+                    "sByTagName(\"option\");document.getElementsByTagName(\"body\")[0].setAttribute" +
+                    "(\"class\",options[this.selectedIndex].innerHTML.toLowerCase())};pd.difffold=f" +
+                    "unction dom__difffold(){\"use strict\";var a=0,b=0,self=this,title=self.getAtt" +
+                    "ribute(\"title\").split(\"line \"),min=Number(title[1].substr(0,title[1].index" +
+                    "Of(\" \"))),max=Number(title[2]),inner=self.innerHTML,lists=[],parent=self.par" +
+                    "entNode.parentNode,listnodes=(parent.getAttribute(\"class\")===\"diff\")?paren" +
+                    "t.getElementsByTagName(\"ol\"):parent.parentNode.getElementsByTagName(\"ol\")," +
+                    "listLen=listnodes.length;for(a=0;a<listLen;a=a+1){lists.push(listnodes[a].getE" +
+                    "lementsByTagName(\"li\"))}max=(max>=lists[0].length)?lists[0].length:max;if(in" +
+                    "ner.charAt(0)===\"-\"){self.innerHTML=\"+\"+inner.substr(1);for(a=min;a<max;a=" +
+                    "a+1){for(b=0;b<listLen;b=b+1){lists[b][a].style.display=\"none\"}}}else{self.i" +
+                    "nnerHTML=\"-\"+inner.substr(1);for(a=min;a<max;a=a+1){for(b=0;b<listLen;b=b+1)" +
+                    "{lists[b][a].style.display=\"block\"}}}};pd.colSliderGrab=function(e){\"use st" +
+                    "rict\";var event=e||window.event,touch=(e!==null&&e.type===\"touchstart\"),nod" +
+                    "e=this,diffRight=node.parentNode,diff=diffRight.parentNode,subOffset=0,lists=d" +
+                    "iff.getElementsByTagName(\"ol\"),counter=lists[0].clientWidth,data=lists[1].cl" +
+                    "ientWidth,width=lists[2].parentNode.clientWidth,total=lists[2].parentNode.pare" +
+                    "ntNode.clientWidth,offset=lists[2].parentNode.offsetLeft-lists[2].parentNode.p" +
+                    "arentNode.offsetLeft,min=((total-counter-data-2)-width),max=(total-width-count" +
+                    "er),status=\"ew\",minAdjust=min+15,maxAdjust=max-15,withinRange=false,diffLeft" +
+                    "=diffRight.previousSibling,drop=function dom__event_colSliderGrab_drop(f){f=f|" +
+                    "|window.event;f.preventDefault();node.style.cursor=status+\"-resize\";if(touch" +
+                    "===true){document.ontouchmove=null;document.ontouchend=null}else{document.onmo" +
+                    "usemove=null;document.onmouseup=null}},boxmove=function dom__event_colSliderGr" +
+                    "ab_boxmove(f){f=f||window.event;f.preventDefault();if(touch===true){subOffset=" +
+                    "offset-f.touches[0].clientX}else{subOffset=offset-f.clientX}if(subOffset>minAd" +
+                    "just&&subOffset<maxAdjust){withinRange=true}if(withinRange===true&&subOffset>m" +
+                    "axAdjust){diffRight.style.width=((total-counter-2)/10)+\"em\";status=\"e\"}els" +
+                    "e if(withinRange===true&&subOffset<minAdjust){diffRight.style.width=((total-co" +
+                    "unter-data-2)/10)+\"em\";status=\"w\"}else if(subOffset<max&&subOffset>min){di" +
+                    "ffRight.style.width=((width+subOffset)/10)+\"em\";status=\"ew\"}if(touch===tru" +
+                    "e){document.ontouchend=drop}else{document.onmouseup=drop}};event.preventDefaul" +
+                    "t();if(typeof pd.data===\"object\"&&pd.data.node.report.code.box!==null){offse" +
+                    "t=offset+pd.data.node.report.code.box.offsetLeft;offset=offset-pd.data.node.re" +
+                    "port.code.body.scrollLeft}else{subOffset=(document.body.parentNode.scrollLeft>" +
+                    "document.body.scrollLeft)?document.body.parentNode.scrollLeft:document.body.sc" +
+                    "rollLeft;offset=offset-subOffset}offset=offset+node.clientWidth;node.style.cur" +
+                    "sor=\"ew-resize\";diff.style.width=(total/10)+\"em\";diff.style.display=\"inli" +
+                    "ne-block\";if(diffLeft.nodeType!==1){do{diffLeft=diffLeft.previousSibling}whil" +
+                    "e(diffLeft.nodeType!==1)}diffLeft.style.display=\"block\";diffRight.style.widt" +
+                    "h=(diffRight.clientWidth/10)+\"em\";diffRight.style.position=\"absolute\";if(t" +
+                    "ouch===true){document.ontouchmove=boxmove;document.ontouchstart=false}else{doc" +
+                    "ument.onmousemove=boxmove;document.onmousedown=null}return false};(function(){" +
+                    "\"use strict\";var lists=document.getElementById(\"prettydiff\").getElementsBy" +
+                    "TagName(\"ol\"),cells=lists[0].getElementsByTagName(\"li\"),len=cells.length,a" +
+                    "=0;for(a=0;a<len;a=a+1){if(cells[a].getAttribute(\"class\")===\"fold\"){cells[" +
+                    "a].onclick=pd.difffold}}if(lists.length>3){lists[2].onmousedown=pd.colSliderGr" +
+                    "ab;lists[2].ontouchstart=pd.colSliderGrab}pd.colorscheme=document.getElementBy" +
+                    "Id(\"colorScheme\");pd.colorscheme.onchange=pd.colorchange}());",
+            minimal : "var pd={};pd.colorchange=function(){\"use strict\";var options=this.getElement" +
+                    "sByTagName(\"option\");document.getElementsByTagName(\"body\")[0].setAttribute" +
+                    "(\"class\",options[this.selectedIndex].innerHTML.toLowerCase())};document.getE" +
+                    "lementById(\"colorScheme\").onchange=pd.colorchange;"
+        }
+    };
+    finalFile.order = [
+        finalFile.html.head, //0
+        finalFile.css.color.canvas, //1
+        finalFile.css.color.shadow, //2
+        finalFile.css.color.white, //3
+        finalFile.css.reports, //4
+        finalFile.css.global, //5
+        finalFile.html.body, //6
+        finalFile.html.color, //7
+        finalFile.html.intro, //8
+        "", //9 - for meta analysis, like stats and accessibility
+        "", //10 - for generated report
+        finalFile.html.script, //11
+        finalFile.script.minimal, //12
+        finalFile.html.end //13
+    ];
+    global.prettydiff.finalFile = finalFile;
+    if ((typeof define === "object" || typeof define === "function") && (typeof ace !== "object" || ace.prettydiffid === undefined)) {
+        //requirejs support
+        define(function finalFile_requirejs() {
+            return global.prettydiff.finalFile;
+        });
+    } else if (typeof module === "object" && typeof module.parent === "object") {
+        //commonjs and nodejs support
+        module.exports = global.prettydiff.finalFile;
+    }
+}());

--- a/node_modules/prettydiff/lib/global.js
+++ b/node_modules/prettydiff/lib/global.js
@@ -1,0 +1,9 @@
+/* Always include this library before any other. This library exists only to
+ * provide a common namespace in the browser to what node provides to simulate a
+ * browser's global scope
+ */
+var global = {
+    prettydiff: {
+        pd: {}
+    }
+};

--- a/node_modules/prettydiff/lib/jspretty.js
+++ b/node_modules/prettydiff/lib/jspretty.js
@@ -1,0 +1,6696 @@
+/*prettydiff.com topcoms:true,insize:4,inchar:" ",vertical:true */
+/*jshint laxbreak: true*/
+/*global __dirname, ace, define, global, module, process, require*/
+/*
+ Special thanks to Harry Whitfield for assistance in providing test
+ cases.
+
+ jspretty is written by Austin Cheney on 2 Nov 2012
+
+ Please see the license.txt file associated with the Pretty Diff
+ application for license information.
+ -----------------------------------------------------------------------
+ */
+(function jspretty_init() {
+    "use strict";
+    var jspretty = function jspretty_(options) {
+        var sourcemap    = [
+                0, ""
+            ],
+            json         = (options.lang === "json"),
+            globalerror  = "",
+            // all data that is created from the tokization process is stored in the
+            // following four arrays: token, types, level, and lines.  All of this data
+            // passes from the tokenization process to be analyzed by the algorithm
+            token        = [], //stores parsed tokens
+            types        = [], //parallel array that describes the tokens
+            level        = [], //parallel array that list indentation per token
+            lines        = [], //used to preserve empty lines
+            depth        = [], //describes the token's current container
+            begin        = [], //index where current container starts
+            globals      = [], //which variables are declared globals
+            // meta used to find scope and variables for jsscope these values are assigned in parallel to the other arrays
+            //* irrelevant tokens are represented with an empty string
+            // * first '(' following 'function' is token index number of function's closing
+            // curly brace
+            //* variables are represented with the value 'v'
+            //* the closing brace of a function is an array of variables
+            meta         = [],
+            // lists a number at the opening paren of a function that points to the token
+            // index of the function's closing curly brace.  At the closing curly brace
+            // index this array stores an array indicating the names of variables declared
+            // in the current function for coloring by function depth in jsscope.  This
+            // array is ignored if jsscope is false
+            varlist      = [],
+            // groups variables from a variable list into a child array as well as
+            // properties of objects.  This array for adding extra space so that the "="
+            // following declared variables of a variable list is vertically aligned and
+            // likewise of the ":" with object properties
+            markupvar = [],
+            // notes a token index of a JSX markup tag assigned to JavaScript variable. This
+            // is necessary for indentation apart from syntactical factors.
+            error        = [],
+            news         = 0,
+            scolon       = 0,
+            // counts uncessary use of 'new' keyword variables j, k, l, m, n, o, p, q, and w
+            // are used as various counters for the reporting only.  These variables do not
+            // store any tokens and are not used in the algorithm j counts line comments
+            stats        = {
+                comma       : 0,
+                commentBlock: {
+                    chars: 0,
+                    token: 0
+                },
+                commentLine : {
+                    chars: 0,
+                    token: 0
+                },
+                container   : 0,
+                number      : {
+                    chars: 0,
+                    token: 0
+                },
+                operator    : {
+                    chars: 0,
+                    token: 0
+                },
+                regex       : {
+                    chars: 0,
+                    token: 0
+                },
+                semicolon   : 0,
+                server      : {
+                    chars: 0,
+                    token: 0
+                },
+                space       : {
+                    newline: 0,
+                    other  : 0,
+                    space  : 0,
+                    tab    : 0
+                },
+                string      : {
+                    chars: 0,
+                    quote: 0,
+                    token: 0
+                },
+                word        : {
+                    chars: 0,
+                    token: 0
+                }
+            },
+            result       = "",
+            objsortop    = false,
+            verticalop   = false,
+            originalSize = options.source.length,
+            lf           = (options.crlf === true || options.crlf === "true")
+                ? "\r\n"
+                : "\n",
+            extlib       = function jspretty__extlib(ops) {
+                var item = (ops === undefined)
+                    ? global
+                        .prettydiff
+                        .markuppretty(ops)
+                    : global
+                        .prettydiff
+                        .markuppretty(options);
+                if (options.nodeasync === true) {
+                    if (globalerror === "") {
+                        globalerror = item[1];
+                    }
+                    return item[0];
+                }
+                return item;
+            };
+        (function jspretty__options() {
+            var styleguide  = {},
+                brace_style = {};
+            if (options.mode === "beautify" || options.mode === "diff" || options.mode === "minify") {
+                objsortop  = (
+                    options.objsort === true || options.objsort === "true" || options.objsort === "all" || options.objsort === "js" || options.objsort === "jsonly"
+                );
+                verticalop = (
+                    options.vertical === true || options.vertical === "true" || options.vertical === "all" || options.vertical === "js"
+                );
+            }
+            options.source                          = (
+                typeof options.source === "string" && options.source.length > 0
+            )
+                ? options
+                    .source
+                    .replace(/\r\n?/g, "\n") + " "
+                : "Error: no source code supplied to jspretty!";
+            options.titanium                        = (options.titanium === true || options.titanium === "true")
+                ? (function jspretty__options_titanium() {
+                    options.correct  = false;
+                    options.titanium = true;
+                    token.push("x{");
+                    types.push("start");
+                    lines.push(0);
+                    depth.push("global");
+                    begin.push(0);
+                    return true;
+                }())
+                : false;
+            styleguide.airbnb                       = function jspretty__options_styleairbnb() {
+                options.bracepadding = true;
+                options.correct      = true;
+                options.endcomma     = "always";
+                options.inchar       = " ";
+                options.insize       = 2;
+                options.preserve     = 1;
+                options.quoteConvert = "single";
+                options.varword      = "each";
+                options.wrap         = 80;
+            };
+            styleguide.crockford                    = function jspretty__options_stylecrockford() {
+                options.bracepadding  = false;
+                options.correct       = true;
+                options.elseline      = false;
+                options.endcomma      = "never";
+                options.inchar        = " ";
+                options.insize        = 4;
+                options.nocaseindent  = true;
+                options.nochainindent = false;
+                options.space         = true;
+                options.varword       = "each";
+                verticalop            = false;
+            };
+            styleguide.google                       = function jspretty__options_stylegoogle() {
+                options.correct      = true;
+                options.inchar       = " ";
+                options.insize       = 4;
+                options.preserve     = 1;
+                options.quoteConvert = "single";
+                verticalop           = false;
+                options.wrap         = -1;
+            };
+            styleguide.grunt                        = function jspretty__options_stylegrunt() {
+                options.inchar       = " ";
+                options.insize       = 2;
+                options.quoteConvert = "single";
+                options.varword      = "each";
+            };
+            styleguide.jquery                       = function jspretty__options_stylejquery() {
+                options.bracepadding = true;
+                options.correct      = true;
+                options.inchar       = "\u0009";
+                options.insize       = 1;
+                options.quoteConvert = "double";
+                options.varword      = "each";
+                options.wrap         = 80;
+            };
+            styleguide.jslint                       = styleguide.crockford;
+            styleguide.mrdoobs                      = function jspretty__options_stylemrdoobs() {
+                options.braceline    = true;
+                options.bracepadding = true;
+                options.correct      = true;
+                options.inchar       = "\u0009";
+                options.insize       = 1;
+                verticalop           = false;
+            };
+            styleguide.mediawiki                    = function jspretty__options_stylemediawiki() {
+                options.bracepadding = true;
+                options.correct      = true;
+                options.inchar       = "\u0009";
+                options.insize       = 1;
+                options.preserve     = 1;
+                options.quoteConvert = "single";
+                options.space        = false;
+                options.wrap         = 80;
+            };
+            styleguide.meteor                       = function jspretty__options_stylemeteor() {
+                options.correct = true;
+                options.inchar  = " ";
+                options.insize  = 2;
+                options.wrap    = 80;
+            };
+            styleguide.yandex                       = function jspretty__options_styleyandex() {
+                options.bracepadding = false;
+                options.correct      = true;
+                options.quoteConvert = "single";
+                options.varword      = "each";
+                verticalop           = false;
+            };
+            brace_style.collapse                    = function jspretty__options_collapse() {
+                options.braceline    = false;
+                options.bracepadding = false;
+                options.braces       = false;
+                options.formatObject = "indent";
+                options.neverflatten = true;
+            };
+            brace_style["collapse-preserve-inline"] = function jspretty__options_collapseInline() {
+                options.braceline    = false;
+                options.bracepadding = true;
+                options.braces       = false;
+                options.formatObject = "inline";
+                options.neverflatten = false;
+            };
+            brace_style.expand                      = function jspretty__options_expand() {
+                options.braceline    = false;
+                options.bracepadding = false;
+                options.braces       = true;
+                options.formatObject = "indent";
+                options.neverflatten = true;
+            };
+            if (styleguide[options.styleguide] !== undefined) {
+                styleguide[options.styleguide]();
+            }
+            if (brace_style[options.brace_style] !== undefined) {
+                brace_style[options.brace_style]();
+            }
+            if (json === true) {
+                options.wrap = 0;
+            }
+        }());
+        if (options.source === "Error: no source code supplied to jspretty!") {
+            return options.source;
+        }
+
+        (function jspretty__tokenize() {
+            var a              = 0,
+                b              = options.source.length,
+                c              = options
+                    .source
+                    .split(""),
+                ltoke          = "",
+                ltype          = "",
+                lword          = [],
+                brace          = [],
+                pword          = [],
+                lengtha        = 0,
+                lengthb        = 0,
+                wordTest       = -1,
+                paren          = -1,
+                classy         = [],
+                depthlist      = [
+                    ["global", 0]
+                ],
+                tempstore      = [],
+                pdepth         = [],
+                //depth and status of templateStrings
+                templateString = [],
+                //identify variable declarations
+                vart           = {
+                    count: [],
+                    index: [],
+                    word : [],
+                    len  : -1
+                },
+                //operations for start types: (, [, {
+                start          = function jspretty__tokenize_startInit() {
+                    return;
+                },
+                //peek at whats up next
+                nextchar       = function jspretty__tokenize_nextchar(len, current) {
+                    var cc    = 0,
+                        dd    = "",
+                        front = (current === true)
+                            ? a
+                            : a + 1;
+                    if (typeof len !== "number" || len < 1) {
+                        len = 1;
+                    }
+                    if (c[a] === "/") {
+                        if (c[a + 1] === "/") {
+                            dd = "\n";
+                        } else if (c[a + 1] === "*") {
+                            dd = "/";
+                        }
+                    }
+                    for (cc = front; cc < b; cc = cc + 1) {
+                        if ((/\s/).test(c[cc]) === false) {
+                            if (c[cc] === "/") {
+                                if (dd === "") {
+                                    if (c[cc + 1] === "/") {
+                                        dd = "\n";
+                                    } else if (c[cc + 1] === "*") {
+                                        dd = "/";
+                                    }
+                                } else if (dd === "/" && c[cc - 1] === "*") {
+                                    dd = "";
+                                }
+                            }
+                            if (dd === "" && c[cc - 1] + c[cc] !== "*/") {
+                                return c
+                                    .slice(cc, cc + len)
+                                    .join("");
+                            }
+                        } else if (dd === "\n" && c[cc] === "\n") {
+                            dd = "";
+                        }
+                    }
+                    return "";
+                },
+                //cleans up improperly applied ASI
+                asifix         = function jspretty__tokenize_asifix() {
+                    var len = types.length;
+                    do {
+                        len = len - 1;
+                    } while (
+                        len > 0 && (types[len] === "comment" || types[len] === "comment-inline")
+                    );
+                    if (token[len] === "from") {
+                        len = len - 2;
+                    }
+                    if (token[len] === "x;") {
+                        token.splice(len, 1);
+                        types.splice(len, 1);
+                        lines.splice(len, 1);
+                        depth.splice(len, 1);
+                        begin.splice(len, 1);
+                    }
+                },
+                //determine the definition of containment by depth
+                depthPush      = function jspretty__tokenize_depthPush() {
+                    // * block      : if, for, while, catch, function, class, map
+                    // * immediates : else, do, try, finally, switch
+                    // * paren based: method, expression, paren
+                    // * data       : array, object
+                    var last  = 0,
+                        aa    = 0,
+                        wordx = "",
+                        wordy = "",
+                        bpush = false;
+                    lengtha = token.length;
+                    last    = lengtha - 1;
+                    aa      = last - 1;
+                    wordx   = token[aa];
+                    wordy   = (depth[aa] === undefined)
+                        ? ""
+                        : token[begin[aa] - 1];
+                    if (types[aa] === "comment" || types[aa] === "comment-inline") {
+                        do {
+                            aa = aa - 1;
+                        } while (aa > 0 && (types[aa] === "comment" || types[aa] === "comment-inline"));
+                        wordx = token[aa];
+                    }
+                    if ((token[last] === "{" || token[last] === "x{") && ((wordx === "else" && token[last] !== "if") || wordx === "do" || wordx === "try" || wordx === "finally" || wordx === "switch")) {
+                        depth.push(wordx);
+                    } else if (token[last] === "{" || token[last] === "x{") {
+                        if (lengtha === 1 && options.jsx === true) {
+                            depth.push("global");
+                        } else if (classy[classy.length - 1] === 0 && wordx !== "return") {
+                            classy.pop();
+                            depth.push("class");
+                        } else if (token[aa - 1] === "class") {
+                            depth.push("class");
+                        } else if (token[aa] === "]" && token[aa - 1] === "[") {
+                            depth.push("array");
+                        } else if (types[aa] === "word" && (types[aa - 1] === "word" || (token[aa - 1] === "?" && types[aa - 2] === "word")) && token[aa] !== "in" && token[aa - 1] !== "export" && token[aa - 1] !== "import") {
+                            depth.push("map");
+                        } else if (depth[aa] === "method" && types[aa] === "end" && types[begin[aa] - 1] === "word" && token[begin[aa] - 2] === "new") {
+                            depth.push("initializer");
+                        } else if (token[last] === "{" && (wordx === ")" || wordx === "x)") && (types[begin[aa] - 1] === "word" || token[begin[aa] - 1] === "]")) {
+                            if (wordy === "if") {
+                                depth.push("if");
+                            } else if (wordy === "for") {
+                                depth.push("for");
+                            } else if (wordy === "while") {
+                                depth.push("while");
+                            } else if (wordy === "class") {
+                                depth.push("class");
+                            } else if (wordy === "switch" || token[begin[aa] - 1] === "switch") {
+                                depth.push("switch");
+                            } else if (wordy === "catch") {
+                                depth.push("catch");
+                            } else {
+                                depth.push("function");
+                            }
+                        } else if (token[last] === "{" && (wordx === ";" || wordx === "x;")) {
+                            //ES6 block
+                            depth.push("block");
+                        } else if (token[last] === "{" && token[aa] === ":" && depth[aa] === "switch") {
+                            //ES6 block
+                            depth.push("block");
+                        } else if (token[aa - 1] === "import" || token[aa - 2] === "import" || token[aa - 1] === "export" || token[aa - 2] === "export") {
+                            depth.push("object");
+                        } else if (wordx === ")" && (pword[0] === "function" || pword[0] === "if" || pword[0] === "for" || pword[0] === "class" || pword[0] === "while" || pword[0] === "switch" || pword[0] === "catch")) {
+                            // if preceeded by a paren the prior containment is preceeded by a keyword if
+                            // (...) {
+                            depth.push(pword[0]);
+                        } else if (depth[aa] === "notation") {
+                            //if following a TSX array type declaration
+                            depth.push("function");
+                        } else if ((types[aa] === "literal" || types[aa] === "word") && types[aa - 1] === "word" && token[begin[aa] - 1] !== "for") {
+                            //if preceed by a word and either string or word public class {
+                            depth.push("function");
+                        } else if (depthlist.length > 0 && token[aa] !== ":" && depthlist[depthlist.length - 1][0] === "object" && (
+                            token[begin[aa] - 2] === "{" || token[begin[aa] - 2] === ","
+                        )) {
+                            // if an object wrapped in some containment which is itself preceeded by a curly
+                            // brace or comma var a={({b:{cat:"meow"}})};
+                            depth.push("function");
+                        } else if (types[pword[1] - 1] === "markup" && token[pword[1] - 3] === "function") {
+                            //checking for TSX function using an angle brace name
+                            depth.push("function");
+                        } else if (wordx === "=>") {
+                            //checking for fat arrow assignment
+                            depth.push("function");
+                        } else if (wordx === ")" && depth[aa] === "method" && types[begin[aa] - 1] === "word") {
+                            depth.push("function");
+                        } else if (types[last - 1] === "word" && token[last] === "{" && token[last - 1] !== "return" && token[last - 1] !== "in" && token[last - 1] !== "import" && token[last - 1] !== "const" && token[last - 1] !== "let" && token[last - 1] !== "") {
+                            //ES6 block
+                            depth.push("block");
+                        } else {
+                            depth.push("object");
+                        }
+                    } else if (token[last] === "[") {
+                        if ((/\s/).test(c[a - 1]) === true && types[aa] === "word" && wordx !== "return" && options.twig === false) {
+                            depth.push("notation");
+                        } else {
+                            depth.push("array");
+                        }
+                    } else if (token[last] === "(" || token[last] === "x(") {
+                        if (types[aa] === "generic") {
+                            depth.push("method");
+                        } else if (token[aa] === "}" && depth[aa] === "function") {
+                            depth.push("method");
+                        } else if (wordx === "if" || wordx === "for" || wordx === "function" || wordx === "class" || wordx === "while" || wordx === "catch" || wordx === "switch" || wordx === "with") {
+                            depth.push("expression");
+                        } else if ((types[aa] === "word" && wordx !== "return") || (wordx === "}" && (depth[aa] === "function" || depth[aa] === "class"))) {
+                            depth.push("method");
+                        } else {
+                            depth.push("paren");
+                        }
+                    } else if (ltoke === ":" && types[aa] === "word" && token[aa - 1] === "[") {
+                        depth[aa]     = "attribute";
+                        depth[aa - 1] = "attribute";
+                        depth.push("attribute");
+                        depthlist[depthlist.length - 1][0] = "attribute";
+                    } else if (depthlist.length === 0) {
+                        depth.push("global");
+                        begin.push(0);
+                        bpush = true;
+                    } else {
+                        depth.push(depthlist[depthlist.length - 1][0]);
+                        begin.push(depthlist[depthlist.length - 1][1]);
+                        bpush = true;
+                    }
+                    if (bpush === false) {
+                        begin.push(last);
+                    }
+                },
+                tokenpop       = function jspretty__tokenize_tokenpop() {
+                    lengtha   = lengtha - 1;
+                    lengthb   = lengthb - 1;
+                    tempstore = [token.pop(), types.pop(), lines.pop(), depth.pop(), begin.pop()];
+                },
+                //reinsert the prior popped token
+                temppush       = function jspretty__tokenize_temppush() {
+                    token.push(tempstore[0]);
+                    types.push(tempstore[1]);
+                    lines.push(tempstore[2]);
+                    depth.push(tempstore[3]);
+                    begin.push(tempstore[4]);
+                    lengtha = lengtha + 1;
+                },
+                //populate various parallel arrays
+                tokenpush      = function jspretty__tokenize_tokenpush(comma, lin) {
+                    if (comma === true) {
+                        token.push(",");
+                        types.push("separator");
+                    } else {
+                        token.push(ltoke);
+                        types.push(ltype);
+                    }
+                    lengtha = token.length;
+                    lines.push(lin);
+                    depthPush();
+                },
+                //inserts ending curly brace
+                blockinsert    = function jspretty__tokenize_blockinsert() {
+                    var next = nextchar(5, false),
+                        g    = lengtha - 1;
+                    if (json === true) {
+                        return;
+                    }
+                    if (depth[lengtha - 1] === "do" && next === "while" && token[lengtha - 1] === "}") {
+                        return;
+                    }
+                    next = next.slice(0, 4);
+                    if (ltoke === ";" && token[g - 1] === "x{") {
+                        //to prevent the semicolon from inserting between the braces --> while (x) {};
+                        tokenpop();
+                        ltoke = "x}";
+                        ltype = "end";
+                        tokenpush(false, 0);
+                        brace.pop();
+                        pdepth = depthlist.pop();
+                        ltoke  = ";";
+                        ltype  = "end";
+                        temppush();
+                        return;
+                    }
+                    ltoke = "x}";
+                    ltype = "end";
+                    if (token[lengtha - 1] === "x}") {
+                        return;
+                    }
+                    if (depth[lengtha - 1] === "if" && (token[lengtha - 1] === ";" || token[lengtha - 1] === "x;") && next === "else") {
+                        tokenpush(false, 0);
+                        brace.pop();
+                        pdepth = depthlist.pop();
+                        return;
+                    }
+                    do {
+                        tokenpush(false, 0);
+                        brace.pop();
+                        pdepth = depthlist.pop();
+                    } while (brace[brace.length - 1] === "x{");
+                },
+                //remove "vart" object data
+                vartpop        = function jspretty__tokenize_vartpop() {
+                    vart
+                        .count
+                        .pop();
+                    vart
+                        .index
+                        .pop();
+                    vart
+                        .word
+                        .pop();
+                    vart.len = vart.len - 1;
+                },
+                logError       = function jspretty__tokenize_logError(message, start) {
+                    var f = a,
+                        g = types.length;
+                    if (error.length > 0) {
+                        return;
+                    }
+                    error.push(message);
+                    do {
+                        f = f - 1;
+                    } while (c[f] !== "\n" && f > 0);
+                    error.push(c.slice(f, start).join(""));
+                    if (g > 1) {
+                        do {
+                            g = g - 1;
+                        } while (g > 0 && types[g] !== "comment");
+                    }
+                    if (g > -1 && g < token.length && token[g].indexOf("//") === 0 && error[1].replace(/^\s+/, "").indexOf(token[g + 1]) === 0 && (token[g].split("\"").length % 2 === 1 || token[g].split("'").length % 2 === 1)) {
+                        error = [
+                            message, token[g] + error[1]
+                        ];
+                    } else {
+                        error = [
+                            message, error[1]
+                        ];
+                    }
+                    if (globalerror === "") {
+                        globalerror = message + ":" + error[1];
+                    }
+                },
+                //A tokenizer for keywords, reserved words, and variables
+                word           = function jspretty__tokenize_word() {
+                    var f        = wordTest,
+                        g        = 1,
+                        build    = [],
+                        output   = "",
+                        nextitem = "",
+                        elsefix  = function jspretty__tokenize_word_elsefix() {
+                            brace.push("x{");
+                            depthlist.push(["else", lengtha]);
+                            token.splice(lengtha - 3, 1);
+                            types.splice(lengtha - 3, 1);
+                            lines.splice(lengtha - 3, 1);
+                            depth.splice(lengtha - 3, 1);
+                            begin.splice(lengtha - 3, 1);
+                        };
+                    do {
+                        build.push(c[f]);
+                        if (c[f] === "\\") {
+                            logError("Illegal escape in JavaScript", a);
+                        }
+                        f = f + 1;
+                    } while (f < a);
+                    output   = build.join("");
+                    wordTest = -1;
+                    if (types.length > 1 && output === "function" && token[lengtha - 1] === "(" && (token[token.length - 2] === "{" || token[token.length - 2] === "x{")) {
+                        types[types.length - 1] = "start";
+                    }
+                    if (types.length > 2 && output === "function" && ltoke === "(" && (token[token.length - 2] === "}" || token[token.length - 2] === "x}")) {
+                        if (token[token.length - 2] === "}") {
+                            for (f = token.length - 3; f > -1; f = f - 1) {
+                                if (types[f] === "end") {
+                                    g = g + 1;
+                                } else if (types[f] === "start" || types[f] === "end") {
+                                    g = g - 1;
+                                }
+                                if (g === 0) {
+                                    break;
+                                }
+                            }
+                            if (token[f] === "{" && token[f - 1] === ")") {
+                                g = 1;
+                                for (f = f - 2; f > -1; f = f - 1) {
+                                    if (types[f] === "end") {
+                                        g = g + 1;
+                                    } else if (types[f] === "start" || types[f] === "end") {
+                                        g = g - 1;
+                                    }
+                                    if (g === 0) {
+                                        break;
+                                    }
+                                }
+                                if (token[f - 1] !== "function" && token[f - 2] !== "function") {
+                                    types[types.length - 1] = "start";
+                                }
+                            }
+                        } else {
+                            types[types.length - 1] = "start";
+                        }
+                    }
+                    if (options.correct === true && (output === "Object" || output === "Array") && c[a + 1] === "(" && c[a + 2] === ")" && token[lengtha - 2] === "=" && token[lengtha - 1] === "new") {
+                        if (output === "Object") {
+                            token[lengtha - 1]                 = "{";
+                            ltoke                              = "}";
+                            depth[a - 1]                       = "object";
+                            depthlist[depthlist.length - 1][0] = "object";
+                        } else {
+                            token[lengtha - 1]                 = "[";
+                            ltoke                              = "]";
+                            depth[a - 1]                       = "array";
+                            depthlist[depthlist.length - 1][0] = "array";
+                        }
+                        types[lengtha - 1] = "start";
+                        ltype              = "end";
+                        c[a + 1]           = "";
+                        c[a + 2]           = "";
+                        stats.container    = stats.container + 2;
+                        a                  = a + 2;
+                    } else {
+                        g = types.length - 1;
+                        f = g;
+                        if (options.varword !== "none" && (output === "var" || output === "let" || output === "const")) {
+                            if (types[g] === "comment" || types[g] === "comment-inline") {
+                                do {
+                                    g = g - 1;
+                                } while (g > 0 && (types[g] === "comment" || types[g] === "comment-inline"));
+                            }
+                            if (options.varword === "list" && vart.len > -1 && vart.index[vart.len] === g && output === vart.word[vart.len]) {
+                                stats.word.token     = stats.word.token + 1;
+                                stats.word.chars     = stats.word.chars + output.length;
+                                ltoke                = ",";
+                                ltype                = "separator";
+                                token[g]             = ltoke;
+                                types[g]             = ltype;
+                                vart.count[vart.len] = 0;
+                                vart.index[vart.len] = g;
+                                vart.word[vart.len]  = output;
+                                return;
+                            }
+                            vart.len = vart.len + 1;
+                            vart
+                                .count
+                                .push(0);
+                            vart
+                                .index
+                                .push(g);
+                            vart
+                                .word
+                                .push(output);
+                            g = f;
+                        } else if (vart.len > -1 && output !== vart.word[vart.len] && token.length === vart.index[vart.len] + 1 && token[vart.index[vart.len]] === ";" && ltoke !== vart.word[vart.len] && options.varword === "list") {
+                            vartpop();
+                        }
+                        if (output === "else" && (types[g] === "comment" || types[g] === "comment-inline")) {
+                            do {
+                                f = f - 1;
+                            } while (f > -1 && (types[f] === "comment" || types[f] === "comment-inline"));
+                            if (token[f] === "x;" && (token[f - 1] === "}" || token[f - 1] === "x}")) {
+                                token.splice(f, 1);
+                                types.splice(f, 1);
+                                lines.splice(f, 1);
+                                depth.splice(f, 1);
+                                begin.splice(f, 1);
+                                g = g - 1;
+                                f = f - 1;
+                            }
+                            do {
+                                build = [
+                                    token[g], types[g], lines[g], depth[g], begin[g]
+                                ];
+                                tokenpop();
+                                token.splice(g - 3, 0, build[0]);
+                                types.splice(g - 3, 0, build[1]);
+                                lines.splice(g - 3, 0, build[2]);
+                                depth.splice(g - 3, 0, build[3]);
+                                begin.splice(g - 3, 0, build[4]);
+                                f = f + 1;
+                            } while (f < g);
+                        }
+                        if (output === "from" && token[lengtha - 1] === "x;" && token[lengtha - 2] === "}") {
+                            asifix();
+                        }
+                        if (output === "while" && token[lengtha - 1] === "x;" && token[lengtha - 2] === "}") {
+                            (function jspretty__tokenize_word_whilefix() {
+                                var d = 0,
+                                    e = 0;
+                                for (e = lengtha - 3; e > -1; e = e - 1) {
+                                    if (types[e] === "end") {
+                                        d = d + 1;
+                                    } else if (types[e] === "start") {
+                                        d = d - 1;
+                                    }
+                                    if (d < 0) {
+                                        if (token[e] === "{" && token[e - 1] === "do") {
+                                            asifix();
+                                        }
+                                        return;
+                                    }
+                                }
+                            }());
+                        }
+                        ltoke            = output;
+                        ltype            = "word";
+                        stats.word.token = stats.word.token + 1;
+                        stats.word.chars = stats.word.chars + output.length;
+                        if (output === "from" && token[lengtha - 1] === "}") {
+                            asifix();
+                        }
+                    }
+                    tokenpush(false, 0);
+                    if (output === "class") {
+                        classy.push(0);
+                    }
+                    if (output === "do") {
+                        nextitem = nextchar(1, true);
+                        if (nextitem !== "{") {
+                            ltoke = "x{";
+                            ltype = "start";
+                            brace.push("x{");
+                            tokenpush(false, 0);
+                            depthlist.push([
+                                "do", lengtha - 1
+                            ]);
+                        }
+                    }
+                    if (output === "else") {
+                        nextitem = nextchar(2, true);
+                        if (nextitem !== "if" && nextitem.charAt(0) !== "{") {
+                            ltoke = "x{";
+                            ltype = "start";
+                            brace.push("x{");
+                            tokenpush(false, 0);
+                            depthlist.push([
+                                "else", lengtha - 1
+                            ]);
+                        }
+                        if (token[lengtha - 3] === "x}") {
+                            if (token[lengtha - 2] === "else") {
+                                if (token[lengtha - 4] === "x}" && pdepth[0] !== "if" && depth[depth.length - 2] === "else") {
+                                    elsefix();
+                                } else if (token[lengtha - 4] === "}" && depth[lengtha - 4] === "if" && pdepth[0] === "if" && token[pdepth[1] - 1] !== "if" && token[begin[lengtha - 3]] === "x{") {
+                                    //fixes when "else" is following a block that isn't "if"
+                                    elsefix();
+                                }
+                            } else if (token[lengtha - 2] === "x}" && depth[depth.length - 2] === "if") {
+                                elsefix();
+                            }
+                        }
+                    }
+                    if ((output === "for" || output === "if" || output === "switch" || output === "catch") && options.twig === false && token[lengtha - 2] !== ".") {
+                        nextitem = nextchar(1, true);
+                        if (nextitem !== "(") {
+                            paren = lengtha - 1;
+                            start("x(");
+                        }
+                    }
+                },
+                //sort object properties
+                objSort        = function jspretty__tokenize_objSort() {
+                    var cc        = 0,
+                        dd        = 0,
+                        ee        = 0,
+                        startlen  = token.length - 1,
+                        behind    = startlen,
+                        keys      = [],
+                        keylen    = 0,
+                        keyend    = 0,
+                        front     = 0,
+                        sort      = function jspretty__tokenize_objSort_sort(x, y) {
+                            var xx = x[0],
+                                yy = y[0];
+                            if (types[xx] === "comment" || types[xx] === "comment-inline") {
+                                do {
+                                    xx = xx + 1;
+                                } while (
+                                    xx < startlen && (types[xx] === "comment" || types[xx] === "comment-inline")
+                                );
+                            }
+                            if (types[yy] === "comment" || types[yy] === "comment-inline") {
+                                do {
+                                    yy = yy + 1;
+                                } while (
+                                    yy < startlen && (types[yy] === "comment" || types[yy] === "comment-inline")
+                                );
+                            }
+                            if (token[xx].toLowerCase() > token[yy].toLowerCase()) {
+                                return 1;
+                            }
+                            return -1;
+                        },
+                        commaTest = true,
+                        pairToken = [],
+                        pairTypes = [],
+                        pairLines = [],
+                        pairDepth = [],
+                        pairBegin = [];
+                    if (token[behind] === "," || types[behind] === "comment") {
+                        do {
+                            behind = behind - 1;
+                        } while (behind > 0 && (token[behind] === "," || types[behind] === "comment"));
+                    }
+                    for (cc = behind; cc > -1; cc = cc - 1) {
+                        if (types[cc] === "end") {
+                            dd = dd + 1;
+                        }
+                        if (types[cc] === "start") {
+                            dd = dd - 1;
+                        }
+                        if (dd === 0) {
+                            if (types[cc].indexOf("template") > -1) {
+                                return;
+                            }
+                            if (token[cc] === ",") {
+                                commaTest = true;
+                                front     = cc + 1;
+                            }
+                            if (commaTest === true && token[cc] === "," && front < behind) {
+                                if (token[behind] !== ",") {
+                                    behind = behind + 1;
+                                }
+                                if (types[front] === "comment-inline") {
+                                    front = front + 1;
+                                }
+                                keys.push([front, behind]);
+                                behind = front - 1;
+                            }
+                        }
+                        if (dd < 0 && cc < startlen) {
+                            if (keys.length > 0 && keys[keys.length - 1][0] > cc + 1) {
+                                ee = keys[keys.length - 1][0];
+                                if (types[ee - 1] !== "comment-inline") {
+                                    ee = ee - 1;
+                                }
+                                keys.push([
+                                    cc + 1,
+                                    ee
+                                ]);
+                            }
+                            if (token[cc - 1] === "=" || token[cc - 1] === ":" || token[cc - 1] === "(" || token[cc - 1] === "[" || token[cc - 1] === "," || types[cc - 1] === "word" || cc === 0) {
+                                if (keys.length > 1) {
+                                    keys.sort(sort);
+                                    keylen    = keys.length;
+                                    commaTest = false;
+                                    for (dd = 0; dd < keylen; dd = dd + 1) {
+                                        keyend = keys[dd][1];
+                                        if (lines[keys[dd][0] - 1] > 1 && pairLines.length > 0) {
+                                            pairLines[pairLines.length - 1] = lines[keys[dd][0] - 1];
+                                        }
+                                        for (ee = keys[dd][0]; ee < keyend; ee = ee + 1) {
+                                            pairToken.push(token[ee]);
+                                            pairTypes.push(types[ee]);
+                                            pairLines.push(lines[ee]);
+                                            pairDepth.push(depth[ee]);
+                                            pairBegin.push(begin[ee]);
+
+                                            //remove extra commas
+                                            if (token[ee] === ",") {
+                                                commaTest = true;
+                                            } else if (token[ee] !== "," && types[ee] !== "comment" && types[ee] !== "comment-inline") {
+                                                commaTest = false;
+                                            }
+                                        }
+                                        if (commaTest === false) {
+                                            ee = pairTypes.length - 1;
+                                            if (pairTypes[ee] === "comment" || pairTypes[ee] === "comment-inline") {
+                                                do {
+                                                    ee = ee - 1;
+                                                } while (
+                                                    ee > 0 && (pairTypes[ee] === "comment" || pairTypes[ee] === "comment-inline")
+                                                );
+                                            }
+                                            ee = ee + 1;
+                                            pairToken.splice(ee, 0, ",");
+                                            pairTypes.splice(ee, 0, "separator");
+                                            pairLines.splice(ee, 0, pairLines[ee - 1]);
+                                            pairDepth.splice(ee, 0, "object");
+                                            pairBegin.splice(ee, 0, cc);
+                                            pairLines[ee - 1] = 0;
+                                        }
+                                    }
+                                    ee = pairTypes.length;
+                                    do {
+                                        ee = ee - 1;
+                                    } while (
+                                        ee > 0 && (pairTypes[ee] === "comment" || pairTypes[ee] === "comment-inline")
+                                    );
+                                    if (options.endcomma === "never" || options.endcomma === "multiline") {
+                                        pairToken.splice(ee, 1);
+                                        pairTypes.splice(ee, 1);
+                                        pairLines.splice(ee, 1);
+                                        pairDepth.splice(ee, 1);
+                                        pairBegin.splice(ee, 1);
+                                    }
+                                    keylen = token.length - (cc + 1);
+                                    token.splice(cc + 1, keylen);
+                                    types.splice(cc + 1, keylen);
+                                    lines.splice(cc + 1, keylen);
+                                    depth.splice(cc + 1, keylen);
+                                    begin.splice(cc + 1, keylen);
+                                    token     = token.concat(pairToken);
+                                    types     = types.concat(pairTypes);
+                                    lines     = lines.concat(pairLines);
+                                    depth     = depth.concat(pairDepth);
+                                    begin     = begin.concat(pairBegin);
+                                    lengtha   = token.length;
+                                    pairToken = [cc];
+                                    for (cc = cc + 1; cc < lengtha; cc = cc + 1) {
+                                        if (types[cc] === "start") {
+                                            pairToken.push(cc);
+                                        }
+                                        begin[cc] = pairToken[pairToken.length - 1];
+                                        if (types[cc] === "end") {
+                                            pairToken.pop();
+                                        }
+                                    }
+                                } else if (options.endcomma === "always" && types[lengtha - 1] !== "start") {
+                                    tokenpush(true, 0);
+                                }
+                            }
+                            return;
+                        }
+                    }
+                },
+                slashes        = function jspretty__tokenize_slashes(index) {
+                    var slashy = index;
+                    do {
+                        slashy = slashy - 1;
+                    } while (c[slashy] === "\\" && slashy > 0);
+                    if ((index - slashy) % 2 === 1) {
+                        return true;
+                    }
+                    return false;
+                },
+                // commaComment ensures that commas immediately precede comments instead of
+                // immediately follow
+                commaComment   = function jspretty__tokenize_commacomment() {
+                    var x = types.length;
+                    if (depth[lengtha - 1] === "object" && objsortop === true) {
+                        ltoke = ",";
+                        ltype = "separator";
+                        asifix();
+                        tokenpush(false, 0);
+                    } else {
+                        do {
+                            x = x - 1;
+                        } while (
+                            x > 0 && (types[x - 1] === "comment" || types[x - 1] === "comment-inline")
+                        );
+                        token.splice(x, 0, ",");
+                        types.splice(x, 0, "separator");
+                        lines.splice(x, 0, 0);
+                        depthPush();
+                    }
+                },
+                //injects a comma into the end of arrays for use with endcomma option
+                endCommaArray  = function jspretty__tokenize_endCommaArray() {
+                    var d = 0,
+                        e = 0;
+                    for (d = lengtha; d > 0; d = d - 1) {
+                        if (types[d] === "end") {
+                            e = e + 1;
+                        } else if (types[d] === "start") {
+                            e = e - 1;
+                        }
+                        if (e < 0) {
+                            return;
+                        }
+                        if (e === 0 && token[d] === ",") {
+                            return tokenpush(true, 0);
+                        }
+                    }
+                },
+                //automatic semicolon insertion
+                asi            = function jspretty__tokenize_asi(isEnd) {
+                    var len   = token.length - 1,
+                        aa    = 0,
+                        next  = nextchar(1, false),
+                        tokel = token[len],
+                        typel = types[len],
+                        deepl = depth[len],
+                        begnl = begin[len],
+                        clist = (depthlist.length === 0)
+                            ? ""
+                            : depthlist[depthlist.length - 1][0];
+                    if (json === true || tokel === ";" || tokel === "," || next === "{" || deepl === "class" || deepl === "map" || deepl === "attribute" || clist === "initializer" || types[begnl - 1] === "generic") {
+                        return;
+                    }
+                    if (((deepl === "global" && typel !== "end") || (typel === "end" && depth[begnl - 1] === "global")) && (next === "" || next === "}") && deepl === depth[lengtha - 2] && options.jsx === true) {
+                        return;
+                    }
+                    if (deepl === "array" && tokel !== "]") {
+                        return;
+                    }
+                    if (typel !== undefined && typel.indexOf("template") > -1) {
+                        return;
+                    }
+                    if (next === ";" && isEnd === false) {
+                        return;
+                    }
+                    if (options.qml === true) {
+                        if (typel === "start") {
+                            return;
+                        }
+                        ltoke = "x;";
+                        ltype = "separator";
+                        tokenpush(false, 0);
+                        if (brace[brace.length - 1] === "x{" && nextchar !== "}") {
+                            blockinsert();
+                        }
+                        return;
+                    }
+                    if (tokel === "}" && (deepl === "function" || deepl === "if" || deepl === "else" || deepl === "for" || deepl === "do" || deepl === "while" || deepl === "switch" || deepl === "class" || deepl === "try" || deepl === "catch" || deepl === "finally" || deepl === "block")) {
+                        if (token[begnl - 1] === ")") {
+                            aa = begin[begnl - 1] - 1;
+                            if (token[aa - 1] === "function") {
+                                aa = aa - 1;
+                            }
+                            if (depth[aa - 1] === "object" || depth[aa - 1] === "switch") {
+                                return;
+                            }
+                            if (token[aa - 1] !== "=" && token[aa - 1] !== "return" && token[aa - 1] !== ":") {
+                                return;
+                            }
+                        } else {
+                            return;
+                        }
+                    }
+                    if (typel === "comment" || typel === "comment-inline" || clist === "method" || clist === "paren" || clist === "expression" || clist === "array" || clist === "object" || (clist === "switch" && deepl !== "method" && token[begin[lengtha - 1]] === "(")) {
+                        return;
+                    }
+                    if (depth[lengtha - 1] === "expression" && (token[begin[lengtha - 1] - 1] !== "while" || (token[begin[lengtha - 1] - 1] === "while" && depth[begin[lengtha - 1] - 2] !== "do"))) {
+                        return;
+                    }
+                    if (next !== "" && "=<>+*?|^:&%~,.()]".indexOf(next) > -1 && isEnd === false) {
+                        return;
+                    }
+                    if (typel === "comment" || typel === "comment-inline") {
+                        do {
+                            len = len - 1;
+                        } while (
+                            len > 0 && (types[len] === "comment" || types[len] === "comment-inline")
+                        );
+                        if (len < 1) {
+                            return;
+                        }
+                        tokel = token[len];
+                        typel = types[len];
+                        deepl = depth[len];
+                    }
+                    if (tokel === undefined || typel === "start" || typel === "separator" || (typel === "operator" && tokel !== "++" && tokel !== "--") || tokel === "x}" || tokel === "var" || tokel === "let" || tokel === "const" || tokel === "else" || tokel.indexOf("#!/") === 0 || tokel === "instanceof") {
+                        return;
+                    }
+                    if (deepl === "method" && (token[begnl - 1] === "function" || token[begnl - 2] === "function")) {
+                        return;
+                    }
+                    if (options.varword === "list") {
+                        vart.index[vart.len] = token.length;
+                    }
+                    ltoke = ";";
+                    ltype = "separator";
+                    token.splice(len + 1, 0, "x;");
+                    types.splice(len + 1, 0, "separator");
+                    lines.splice(len, 0, 0);
+                    depthPush();
+                    if (brace[brace.length - 1] === "x{" && nextchar !== "}") {
+                        blockinsert();
+                    }
+                },
+                //convert ++ and -- into "= x +"  and "= x -" in most cases
+                plusplus = function jspretty__tokenize_plusplus() {
+                    var store      = [],
+                        pre        = true,
+                        toke       = "+",
+                        tokea      = "",
+                        tokeb      = "",
+                        tokec      = "",
+                        inc        = 0,
+                        ind        = 0,
+                        walk       = 0,
+                        end        = function jspretty__tokenize_plusplus_endInit() {
+                            return;
+                        },
+                        period     = function jspretty__tokenize_plusplus_periodInit() {
+                            return;
+                        },
+                        applyStore = function jspretty__tokenize_plusplus_applyStore() {
+                            var x = 0,
+                                y = store[0].length;
+                            do {
+                                token.push(store[0][x]);
+                                types.push(store[1][x]);
+                                lines.push(store[2][x]);
+                                depth.push(store[3][x]);
+                                begin.push(store[4][x]);
+                                x = x + 1;
+                            } while (x < y);
+                        },
+                        next       = "";
+                    lengtha = token.length;
+                    tokea   = token[lengtha - 1];
+                    tokeb   = token[lengtha - 2];
+                    tokec   = token[lengtha - 3];
+                    end     = function jspretty__tokenize_plusplus_end() {
+                        walk = begin[walk] - 1;
+                        if (types[walk] === "end") {
+                            jspretty__tokenize_plusplus_end();
+                        } else if (token[walk - 1] === ".") {
+                            period();
+                        }
+                    };
+                    period  = function jspretty__tokenize_plusplus_period() {
+                        walk = walk - 2;
+                        if (types[walk] === "end") {
+                            end();
+                        } else if (token[walk - 1] === ".") {
+                            jspretty__tokenize_plusplus_period();
+                        }
+                    };
+                    if (tokea !== "++" && tokea !== "--" && tokeb !== "++" && tokeb !== "--") {
+                        walk = lengtha - 1;
+                        if (types[walk] === "end") {
+                            end();
+                        } else if (token[walk - 1] === ".") {
+                            period();
+                        }
+                    }
+                    if (token[walk - 1] === "++" || token[walk - 1] === "--") {
+                        if ("startendoperator".indexOf(types[walk - 2]) > -1) {
+                            return;
+                        }
+                        store.push(token.slice(walk));
+                        store.push(types.slice(walk));
+                        store.push(lines.slice(walk));
+                        store.push(depth.slice(walk));
+                        store.push(begin.slice(walk));
+                        token.splice(walk, lengtha - walk);
+                        types.splice(walk, lengtha - walk);
+                        lines.splice(walk, lengtha - walk);
+                        depth.splice(walk, lengtha - walk);
+                        begin.splice(walk, lengtha - walk);
+                    } else {
+                        if (options.correct === false || (tokea !== "++" && tokea !== "--" && tokeb !== "++" && tokeb !== "--")) {
+                            return;
+                        }
+                        next = nextchar(1, false);
+                        if ((tokea === "++" || tokea === "--") && (c[a] === ";" || next === ";" || c[a] === "}" || next === "}" || c[a] === ")" || next === ")")) {
+                            toke = depth[lengtha - 1];
+                            if (toke === "array" || toke === "method" || toke === "object" || toke === "paren" || toke === "notation" || (token[begin[lengtha - 1] - 1] === "while" && toke !== "while")) {
+                                return;
+                            }
+                            inc = lengtha - 1;
+                            do {
+                                inc = inc - 1;
+                                if (token[inc] === "return") {
+                                    return;
+                                }
+                                if (types[inc] === "end") {
+                                    do {
+                                        inc = begin[inc] - 1;
+                                    } while (types[inc] === "end" && inc > 0);
+                                }
+                            } while (
+                                inc > 0 && (token[inc] === "." || types[inc] === "word" || types[inc] === "end")
+                            );
+                            if (token[inc] === "," && c[a] !== ";" && next !== ";" && c[a] !== "}" && next !== "}" && c[a] !== ")" && next !== ")") {
+                                return;
+                            }
+                            if (types[inc] === "operator") {
+                                if (depth[inc] === "switch" && token[inc] === ":") {
+                                    do {
+                                        inc = inc - 1;
+                                        if (types[inc] === "start") {
+                                            ind = ind - 1;
+                                            if (ind < 0) {
+                                                break;
+                                            }
+                                        } else if (types[inc] === "end") {
+                                            ind = ind + 1;
+                                        }
+                                        if (token[inc] === "?" && ind === 0) {
+                                            return;
+                                        }
+                                    } while (inc > 0);
+                                } else {
+                                    return;
+                                }
+                            }
+                            pre = false;
+                            if (tokea === "--") {
+                                toke = "-";
+                            } else {
+                                toke = "+";
+                            }
+                        } else if (tokec === "[" || tokec === ";" || tokec === "x;" || tokec === "}" || tokec === "{" || tokec === "(" || tokec === ")" || tokec === "," || tokec === "return") {
+                            if (tokea === "++" || tokea === "--") {
+                                if (tokec === "[" || tokec === "(" || tokec === "," || tokec === "return") {
+                                    return;
+                                }
+                                if (tokea === "--") {
+                                    toke = "-";
+                                }
+                                pre = false;
+                            } else if (tokeb === "--" || tokea === "--") {
+                                toke = "-";
+                            }
+                        } else {
+                            return;
+                        }
+                        if (pre === false) {
+                            tokenpop();
+                        }
+                        walk = lengtha - 1;
+                        if (types[walk] === "end") {
+                            end();
+                        } else if (token[walk - 1] === ".") {
+                            period();
+                        }
+                        store.push(token.slice(walk));
+                        store.push(types.slice(walk));
+                        store.push(lines.slice(walk));
+                        store.push(depth.slice(walk));
+                        store.push(begin.slice(walk));
+                    }
+                    if (pre === true) {
+                        token.splice(walk - 1, 1);
+                        types.splice(walk - 1, 1);
+                        lines.splice(walk - 1, 1);
+                        depth.splice(walk - 1, 1);
+                        begin.splice(walk - 1, 1);
+                        ltoke = "=";
+                        ltype = "operator";
+                        tokenpush(false, 0);
+                        applyStore();
+                        ltoke = toke;
+                        ltype = "operator";
+                        tokenpush(false, 0);
+                        ltoke = "1";
+                        ltype = "literal";
+                        tokenpush(false, 0);
+                    } else {
+                        ltoke = "=";
+                        ltype = "operator";
+                        tokenpush(false, 0);
+                        applyStore();
+                        ltoke = toke;
+                        ltype = "operator";
+                        tokenpush(false, 0);
+                        ltoke = "1";
+                        ltype = "literal";
+                        tokenpush(false, 0);
+                    }
+                    ltoke = token[lengtha - 1];
+                    ltype = types[lengtha - 1];
+                    if (next === "}" && c[a] !== ";") {
+                        asi(false);
+                    }
+                },
+                //converts "+=" and "-=" to "x = x + 1"
+                plusequal = function jspretty__tokenize_plusequal(op) {
+                    var toke       = op.charAt(0),
+                        walk       = lengtha - 1,
+                        store      = [],
+                        end        = function jspretty__tokenize_plusequal_endInit() {
+                            return;
+                        },
+                        period     = function jspretty__tokenize_plusequal_periodInit() {
+                            return;
+                        },
+                        applyStore = function jspretty__tokenize_plusplus_applyStore() {
+                            var x = 0,
+                                y = store[0].length;
+                            do {
+                                token.push(store[0][x]);
+                                types.push(store[1][x]);
+                                lines.push(store[2][x]);
+                                depth.push(store[3][x]);
+                                begin.push(store[4][x]);
+                                x = x + 1;
+                            } while (x < y);
+                        };
+                    end    = function jspretty__tokenize_plusequal_end() {
+                        walk = begin[walk] - 1;
+                        if (types[walk] === "end") {
+                            jspretty__tokenize_plusequal_end();
+                        } else if (token[walk - 1] === ".") {
+                            period();
+                        }
+                    };
+                    period = function jspretty__tokenize_plusequal_period() {
+                        walk = walk - 2;
+                        if (types[walk] === "end") {
+                            end();
+                        } else if (token[walk - 1] === ".") {
+                            jspretty__tokenize_plusequal_period();
+                        }
+                    };
+                    if (types[walk] === "end") {
+                        end();
+                    } else if (token[walk - 1] === ".") {
+                        period();
+                    }
+                    store.push(token.slice(walk));
+                    store.push(types.slice(walk));
+                    store.push(lines.slice(walk));
+                    store.push(depth.slice(walk));
+                    store.push(begin.slice(walk));
+                    ltoke = "=";
+                    ltype = "operator";
+                    tokenpush(false, 0);
+                    applyStore();
+                    return toke;
+                },
+                //fixes asi location if inserted after an inserted brace
+                asibrace       = function jspretty__tokenize_asibrace() {
+                    var aa = token.length;
+                    do {
+                        aa = aa - 1;
+                    } while (aa > -1 && token[aa] === "x}");
+                    if (depth[aa] === "else") {
+                        return tokenpush(false, 0);
+                    }
+                    aa = aa + 1;
+                    token.splice(aa, 0, ltoke);
+                    types.splice(aa, 0, ltype);
+                    lines.push(0);
+                    depthPush();
+                },
+                //convert double quotes to single or the opposite
+                quoteConvert   = function jspretty__tokenize_quoteConvert(item) {
+                    var dub   = (options.quoteConvert === "double"),
+                        qchar = (dub === true)
+                            ? "\""
+                            : "'";
+                    item = item.slice(1, item.length - 1);
+                    if (dub === true) {
+                        item = item.replace(/"/g, "'");
+                    } else {
+                        item = item.replace(/'/g, "\"");
+                    }
+                    return qchar + item + qchar;
+                },
+                //manage comment wrapping
+                commentwrap    = function jspretty__tokenize_commentwrap(comment, line) {
+                    var prior        = "",
+                        ptype        = "",
+                        xblock       = (function jspretty__tokenize_commentLine_xblock() {
+                            if (token[lengtha - 1] !== "x}" || (lines[lengtha - 1] > 0 && nextchar(4, false) !== "else") || (token[lengtha - 1] === "x}" && (token[lengtha - 2] === "}" || token[lengtha - 2] === "x}"))) {
+                                return false;
+                            }
+                            tokenpop();
+                            return true;
+                        }()),
+                        ind          = 0,
+                        vartest      = "",
+                        cstart       = (line === true)
+                            ? "// "
+                            : " * ",
+                        empty        = (/^(\/\/\s*)$/),
+                        list         = (
+                            /^(\/\/\s*(\*|-|@|\=|(\d+(\.|(\s*-))))(?!(\*|-|@|\=|(\d+(\.|(\s*-))))))/
+                        ),
+                        hrule        = (/^(\/\/\s*---+\s*)$/),
+                        remind       = (/^(\/\/\s*((todo)|(note:)))/i),
+                        commentSplit = function jspretty__tokenize_commentLine_commentSplit() {
+                            var endi    = options.wrap - 3,
+                                starti  = 0,
+                                spacely = (comment.indexOf(" ") > 0),
+                                len     = 0,
+                                block   = [];
+                            if (line === true) {
+                                comment = comment.slice(2);
+                                if (spacely === true) {
+                                    do {
+                                        //split comments by word if possible
+                                        len    = comment.length;
+                                        starti = 0;
+                                        if ((/\s/).test(comment.charAt(0)) === true) {
+                                            do {
+                                                starti = starti + 1;
+                                            } while (starti < len && (/\s/).test(comment.charAt(starti)) === true);
+                                        }
+                                        comment = comment.slice(starti);
+                                        len     = comment.length;
+                                        endi    = (options.wrap - 3);
+                                        if ((/\s/).test(comment.slice(0, endi + 1)) === true && endi < len) {
+                                            endi = endi + 1;
+                                            do {
+                                                endi = endi - 1;
+                                            } while (endi > 0 && (/\s/).test(comment.charAt(endi)) === false);
+                                        } else if ((/\s/).test(comment) === true && endi < len) {
+                                            do {
+                                                endi = endi + 1;
+                                            } while (endi < len && (/\s/).test(comment.charAt(endi)) === false);
+                                        } else {
+                                            endi = len;
+                                        }
+                                        ltoke = cstart + comment
+                                            .slice(0, endi)
+                                            .replace(/(\s+)$/, "");
+                                        tokenpush(false, 0);
+                                        comment = comment.slice(endi);
+                                    } while (comment.length > endi);
+                                    if (comment !== "") {
+                                        len    = comment.length;
+                                        starti = 0;
+                                        if ((/\s/).test(comment.charAt(0)) === true) {
+                                            do {
+                                                starti = starti + 1;
+                                            } while (starti < len && (/\s/).test(comment.charAt(starti)) === true);
+                                        }
+                                        ltoke = cstart + comment.slice(starti);
+                                        ltoke = ltoke.replace(/(\s+)$/, "");
+                                        tokenpush(false, 0);
+                                    }
+                                } else {
+                                    if (prior.indexOf("//") === 0 && prior.length < endi && prior.indexOf(" ") === -1 && comment.indexOf(" ") === -1) {
+                                        endi               = endi - prior.length;
+                                        token[lengtha - 1] = prior + comment.slice(0, endi);
+                                        comment            = comment.slice(endi);
+                                        endi               = options.wrap;
+                                    }
+                                    endi = endi - 2;
+                                    do {
+                                        ltoke = cstart + comment.slice(0, endi);
+                                        ltoke = ltoke.replace(/(\s+)$/, "");
+                                        tokenpush(false, 0);
+                                        comment = comment.slice(endi);
+                                    } while (comment.length > endi);
+                                    if (comment !== "") {
+                                        ltoke = cstart + comment.slice(0, endi);
+                                        ltoke = ltoke.replace(/(\s+)$/, "");
+                                        tokenpush(false, 0);
+                                    }
+                                }
+                            } else {
+                                // the functionality for wrapping block comments is written here, but currently
+                                // disabled.  It demands a bit more finesse to prevent violation of JSLint and
+                                // some mutilation of white space styles
+                                if (spacely === true) {
+                                    len    = comment.length;
+                                    starti = 0;
+                                    if ((/\s/).test(comment.charAt(0)) === true) {
+                                        do {
+                                            starti = starti + 1;
+                                        } while (starti < len && (/\s/).test(comment.charAt(starti)) === true);
+                                    }
+                                    endi = (options.wrap - 3) + starti;
+                                    if ((/\s/).test(comment.charAt(endi)) === false && endi < len) {
+                                        do {
+                                            endi = endi - 1;
+                                        } while (endi > starti && (/\s/).test(comment.charAt(endi)) === false);
+                                    }
+                                    if (endi > 0) {
+                                        block.push("/* " + comment.slice(starti, endi));
+                                        do {
+                                            starti = endi;
+                                            if ((/\s/).test(comment.charAt(starti)) === true) {
+                                                do {
+                                                    starti = starti + 1;
+                                                } while (starti < len && (/\s/).test(comment.charAt(starti)) === true);
+                                            }
+                                            endi = (options.wrap - 3) + starti;
+                                            if ((/\s/).test(comment.charAt(endi)) === false && endi < len) {
+                                                do {
+                                                    endi = endi - 1;
+                                                } while (
+                                                    endi > 0 && endi > starti && (/\s/).test(comment.charAt(endi)) === false
+                                                );
+                                            }
+                                            block.push(cstart + comment.slice(starti, endi).replace(/(\s+)$/, ""));
+                                        } while (endi > 0 && endi < len);
+                                        block.push(" */");
+                                        ltoke = block.join(lf);
+                                    } else {
+                                        ltoke = "/* " + comment.replace(/(\s+)$/, "") + " */";
+                                    }
+                                    tokenpush(false, 0);
+                                } else {
+                                    len  = comment.length;
+                                    endi = options.wrap - 3;
+                                    block.push("/* " + comment.slice(0, endi));
+                                    do {
+                                        starti = endi;
+                                        endi   = starti + (options.wrap - 3);
+                                        block.push(cstart + comment.slice(starti, endi));
+                                    } while (endi < len);
+                                    block.push(" */");
+                                    ltoke = block.join(lf);
+                                    tokenpush(false, 0);
+                                }
+                            }
+                        };
+
+                    if (lines[lines.length - 1] === 0 && ltype !== "comment" && ltype !== "comment-inline" && options.styleguide !== "mrdoobs") {
+                        ltype = "comment-inline";
+                    } else {
+                        ltype = "comment";
+                    }
+                    if (options.preserveComment === true) {
+                        return tokenpush(false, 0);
+                    }
+                    if (hrule.test(comment) === true) {
+                        if (comment.charAt(2) !== " ") {
+                            comment = "// " + comment.slice(2);
+                        }
+                        ltoke = comment;
+                        return tokenpush(false, 0);
+                    }
+                    lengtha = token.length;
+                    if (comment.indexOf("/*global") === 0) {
+                        return tokenpush(false, 0);
+                    }
+                    if (line === true) {
+                        comment = comment
+                            .replace(/\s\/\//g, " ")
+                            .replace(/(\s+)$/, "");
+                    } else {
+                        if (comment.indexOf("/**") === 0) {
+                            return tokenpush(false, 0);
+                        }
+                        if (comment.indexOf("\n") < 0 && comment.indexOf(":") > 0 && comment.indexOf(",") > 0) {
+                            return tokenpush(false, 0);
+                        }
+                        if ((/\n(\u0020|\t)/).test(comment) === true && ((/\n\u0020\*(\u0020|\/)/).test(comment) === false || (/\n(?!(\u0020\*(\u0020|\/)))/).test(comment) === true)) {
+                            return tokenpush(false, 0);
+                        }
+                        if (comment.length < options.wrap - 3) {
+                            return tokenpush(false, 0);
+                        }
+                        if ((/^(\/\*\u0020)/).test(comment) === true && (/\n\u0020\*\u0020/).test(comment) === true) {
+                            comment = comment.replace("/* ", "/*");
+                        }
+                        comment = comment
+                            .replace(/\n\u0020\*\u0020/g, " ")
+                            .replace(/\n(\u0020|\t)+/g, "\n");
+                        comment = comment.slice(2, comment.length - 2);
+                    }
+                    if (lengtha > 0) {
+                        prior = token[lengtha - 1];
+                        ptype = types[lengtha - 1];
+                    }
+                    if (ltype === "comment" && ptype !== "comment-inline" && options.wrap > 0 && empty.test(comment) === false && (comment.length > options.wrap || prior.indexOf("//") === 0)) {
+                        if (lengtha > 0 && token[lengtha - 1].indexOf("//") === 0 && empty.test(token[lengtha - 1]) === false && hrule.test(token[lengtha - 1]) === false && list.test(comment) === false && remind.test(comment) === false) {
+                            if (comment.charAt(2) !== " ") {
+                                comment = prior + " " + comment.slice(2);
+                            } else {
+                                comment = prior + comment.slice(2);
+                            }
+                            tokenpop();
+                        }
+                        if (token[lengtha - 1] === "var" || token[lengtha - 1] === "let" || token[lengtha - 1] === "const") {
+                            tokenpop();
+                            vartest = token[lengtha - 1];
+                        }
+                        if (comment.length > options.wrap - 2) {
+                            commentSplit();
+                        } else {
+                            if (line === true) {
+                                ltoke = comment;
+                            } else {
+                                ltoke = "/* " + comment
+                                    .replace(/^(\s+)/, "")
+                                    .replace(/(\s+)$/, "") + " */";
+                            }
+                            tokenpush(false, 0);
+                        }
+                        if (vartest !== "") {
+                            temppush();
+                            ind = lengtha - 1;
+                            do {
+                                ind = ind - 1;
+                            } while (types[ind] === "comment");
+                            lines[ind]         = lines[lengtha - 1];
+                            lines[lengtha - 1] = 0;
+                        }
+                    } else if (options.wrap < 0 && prior.indexOf("//") === 0) {
+                        if (comment.charAt(2) !== " ") {
+                            token[lengtha - 1] = prior + " " + comment.slice(2);
+                        } else {
+                            token[lengtha - 1] = prior + comment.slice(2);
+                        }
+                    } else {
+                        if (token[lengtha - 1] === "var" || token[lengtha - 1] === "let" || token[lengtha - 1] === "const") {
+                            tokenpop();
+                            vartest = token[lengtha - 1];
+                        }
+                        if (line === true) {
+                            ltoke = comment;
+                        } else {
+                            ltoke = "/* " + comment
+                                .replace(/^(\s+)/, "")
+                                .replace(/(\s+)$/, "") + " */";
+                        }
+                        tokenpush(false, 0);
+                        if (vartest !== "") {
+                            temppush();
+                            ind = lengtha - 1;
+                            do {
+                                ind = ind - 1;
+                            } while (types[ind] === "comment");
+                            lines[ind]         = lines[lengtha - 1];
+                            lines[lengtha - 1] = 0;
+                        }
+                    }
+                    if (xblock === true) {
+                        token.push("x}");
+                        types.push("end");
+                        lines.push(0);
+                        depth[lengtha - 1] = pdepth[0];
+                        begin[lengtha - 1] = pdepth[1];
+                        depth.push(pdepth[0]);
+                        begin.push(pdepth[1]);
+                    }
+                },
+                //merges strings separated by "+" if options.wrap is less than 0
+                strmerge       = function jspretty__tokenize_strmerge() {
+                    var aa   = 0,
+                        bb   = "",
+                        item = ltoke.slice(1, ltoke.length - 1);
+                    tokenpop();
+                    aa        = token.length - 1;
+                    bb        = token[aa];
+                    token[aa] = bb.slice(0, bb.length - 1) + item + bb.charAt(0);
+                },
+                // the generic function is a generic tokenizer start argument contains the
+                // token's starting syntax offset argument is length of start minus control
+                // chars end is how is to identify where the token ends
+                generic        = function jspretty__tokenize_genericBuilder(starting, ending) {
+                    var ee     = 0,
+                        ender  = ending.split(""),
+                        endlen = ender.length,
+                        jj     = b,
+                        build  = [starting],
+                        base   = a + starting.length,
+                        output = "",
+                        escape = false;
+                    if (wordTest > -1) {
+                        word();
+                    }
+                    // this insanity is for JSON where all the required quote characters are
+                    // escaped.
+                    if (c[a - 1] === "\\" && slashes(a - 1) === true && (c[a] === "\"" || c[a] === "'")) {
+                        tokenpop();
+                        if (token[0] === "{") {
+                            if (c[a] === "\"") {
+                                starting = "\"";
+                                ending   = "\\\"";
+                                build    = ["\""];
+                            } else {
+                                starting = "'";
+                                ending   = "\\'";
+                                build    = ["'"];
+                            }
+                            escape = true;
+                        } else {
+                            if (c[a] === "\"") {
+                                return "\\\"";
+                            }
+                            return "\\'";
+                        }
+                    }
+                    for (ee = base; ee < jj; ee = ee + 1) {
+                        if (ee > a + 1) {
+                            if (c[ee] === "<" && c[ee + 1] === "?" && c[ee + 2] === "p" && c[ee + 3] === "h" && c[ee + 4] === "p" && c[ee + 5] !== starting && starting !== "//" && starting !== "/*") {
+                                a = ee;
+                                build.push(jspretty__tokenize_genericBuilder("<?php", "?>"));
+                                ee = ee + build[build.length - 1].length - 1;
+                            } else if (c[ee] === "<" && c[ee + 1] === "%" && c[ee + 2] !== starting && starting !== "//" && starting !== "/*") {
+                                a = ee;
+                                build.push(jspretty__tokenize_genericBuilder("<%", "%>"));
+                                ee = ee + build[build.length - 1].length - 1;
+                            } else if (c[ee] === "{" && c[ee + 1] === "%" && c[ee + 2] !== starting && starting !== "//" && starting !== "/*") {
+                                a = ee;
+                                build.push(jspretty__tokenize_genericBuilder("{%", "%}"));
+                                ee = ee + build[build.length - 1].length - 1;
+                            } else if (c[ee] === "{" && c[ee + 1] === "{" && c[ee + 2] === "{" && c[ee + 3] !== starting && starting !== "//" && starting !== "/*") {
+                                a = ee;
+                                build.push(jspretty__tokenize_genericBuilder("{{{", "}}}"));
+                                ee = ee + build[build.length - 1].length - 1;
+                            } else if (c[ee] === "{" && c[ee + 1] === "{" && c[ee + 2] !== starting && starting !== "//" && starting !== "/*") {
+                                a = ee;
+                                build.push(jspretty__tokenize_genericBuilder("{{", "}}"));
+                                ee = ee + build[build.length - 1].length - 1;
+                            } else if (c[ee] === "<" && c[ee + 1] === "!" && c[ee + 2] === "-" && c[ee + 3] === "-" && c[ee + 4] === "#" && c[ee + 5] !== starting && starting !== "//" && starting !== "/*") {
+                                a = ee;
+                                build.push(jspretty__tokenize_genericBuilder("<!--#", "-->"));
+                                ee = ee + build[build.length - 1].length - 1;
+                            } else {
+                                build.push(c[ee]);
+                            }
+                        } else {
+                            build.push(c[ee]);
+                        }
+                        if ((starting === "\"" || starting === "'") && json === false && c[ee - 1] !== "\\" && (c[ee] === "\n" || ee === jj - 1)) {
+                            logError("Unterminated string in JavaScript", ee);
+                            break;
+                        }
+                        if (c[ee] === ender[endlen - 1] && (c[ee - 1] !== "\\" || slashes(ee - 1) === false)) {
+                            if (endlen === 1) {
+                                break;
+                            }
+                            // `ee - base` is a cheap means of computing length of build array the `ee -
+                            // base` and `endlen` are both length based values, so adding two (1 for each)
+                            // provides an index based number
+                            if (build[ee - base] === ender[0] && build.slice(ee - base - endlen + 2).join("") === ending) {
+                                break;
+                            }
+                        }
+                    }
+                    if (escape === true) {
+                        output = build[build.length - 1];
+                        build.pop();
+                        build.pop();
+                        build.push(output);
+                    }
+                    a = ee;
+                    if (starting === "//") {
+                        stats.space.newline = stats.space.newline + 1;
+                        build.pop();
+                    }
+                    output = build.join("");
+                    if (starting === "//") {
+                        output = output.replace(/(\s+)$/, "");
+                    } else if (starting === "/*") {
+                        build = output.split(lf);
+                        for (ee = build.length - 1; ee > -1; ee = ee - 1) {
+                            build[ee] = build[ee].replace(/(\s+)$/, "");
+                        }
+                        output = build.join(lf);
+                    }
+                    if (options.jsscope !== "none") {
+                        output = output
+                            .replace(/&/g, "&amp;")
+                            .replace(/</g, "&lt;")
+                            .replace(/>/g, "&gt;");
+                    }
+                    if (starting === "{%") {
+                        if (output.indexOf("{%-") < 0) {
+                            output = output
+                                .replace(/^(\{%\s*)/, "{% ")
+                                .replace(/(\s*%\})$/, " %}");
+                        } else {
+                            output = output
+                                .replace(/^(\{%-\s*)/, "{%- ")
+                                .replace(/(\s*-%\})$/, " -%}");
+                        }
+                    }
+                    if (output.indexOf("#region") === 0 || output.indexOf("#endregion") === 0) {
+                        output = output.replace(/(\s+)$/, "");
+                    }
+                    return output;
+                },
+                //a tokenizer for regular expressions
+                regex          = function jspretty__tokenize_regex() {
+                    var ee     = 0,
+                        f      = b,
+                        h      = 0,
+                        i      = 0,
+                        build  = ["/"],
+                        output = "",
+                        square = false;
+                    for (ee = a + 1; ee < f; ee = ee + 1) {
+                        build.push(c[ee]);
+                        if (c[ee - 1] !== "\\" || c[ee - 2] === "\\") {
+                            if (c[ee] === "[") {
+                                square = true;
+                            }
+                            if (c[ee] === "]") {
+                                square = false;
+                            }
+                        }
+                        if (c[ee] === "/" && square === false) {
+                            if (c[ee - 1] === "\\") {
+                                i = 0;
+                                for (h = ee - 1; h > 0; h = h - 1) {
+                                    if (c[h] === "\\") {
+                                        i = i + 1;
+                                    } else {
+                                        break;
+                                    }
+                                }
+                                if (i % 2 === 0) {
+                                    break;
+                                }
+                            } else {
+                                break;
+                            }
+                        }
+                    }
+                    if (c[ee + 1] === "g" || c[ee + 1] === "i" || c[ee + 1] === "m" || c[ee + 1] === "y") {
+                        build.push(c[ee + 1]);
+                        if (c[ee + 2] !== c[ee + 1] && (c[ee + 2] === "g" || c[ee + 2] === "i" || c[ee + 2] === "m" || c[ee + 2] === "y")) {
+                            build.push(c[ee + 2]);
+                            if (c[ee + 3] !== c[ee + 1] && c[ee + 3] !== c[ee + 2] && (c[ee + 3] === "g" || c[ee + 3] === "i" || c[ee + 3] === "m" || c[ee + 3] === "y")) {
+                                build.push(c[ee + 3]);
+                                if (c[ee + 4] !== c[ee + 1] && c[ee + 4] !== c[ee + 2] && c[ee + 4] !== c[ee + 3] && (c[ee + 4] === "g" || c[ee + 4] === "i" || c[ee + 4] === "m" || c[ee + 4] === "y")) {
+                                    build.push(c[ee + 4]);
+                                    a = ee + 4;
+                                } else {
+                                    a = ee + 3;
+                                }
+                            } else {
+                                a = ee + 2;
+                            }
+                        } else {
+                            a = ee + 1;
+                        }
+                    } else {
+                        a = ee;
+                    }
+                    output = build.join("");
+                    if (options.jsscope !== "none") {
+                        output = output
+                            .replace(/&/g, "&amp;")
+                            .replace(/</g, "&lt;")
+                            .replace(/>/g, "&gt;");
+                    }
+                    return output;
+                },
+                //a unique tokenizer for operator characters
+                operator       = function jspretty__tokenize_operator() {
+                    var syntax = [
+                            "=",
+                            "<",
+                            ">",
+                            "+",
+                            "*",
+                            "?",
+                            "|",
+                            "^",
+                            ":",
+                            "&",
+                            "%",
+                            "~"
+                        ],
+                        g      = 0,
+                        h      = 0,
+                        jj     = b,
+                        build  = [c[a]],
+                        synlen = syntax.length,
+                        output = "";
+                    if (wordTest > -1) {
+                        word();
+                    }
+                    if (c[a] === "/" && (lengtha > 0 && (ltype !== "word" || ltoke === "typeof" || ltoke === "return" || ltoke === "else") && ltype !== "literal" && ltype !== "end")) {
+                        if (ltoke === "return" || ltoke === "typeof" || ltoke === "else" || ltype !== "word") {
+                            ltoke             = regex();
+                            ltype             = "regex";
+                            stats.regex.token = stats.regex.token + 1;
+                            stats.regex.chars = stats.regex.chars + ltoke.length;
+                        } else {
+                            stats.operator.token = stats.operator.token + 1;
+                            stats.operator.chars = stats.operator.token + 1;
+                            ltoke                = "/";
+                            ltype                = "operator";
+                        }
+                        tokenpush(false, 0);
+                        return "regex";
+                    }
+                    if (c[a] === "?" && ("+-*/".indexOf(c[a + 1]) > -1 || (c[a + 1] === ":" && syntax.join("").indexOf(c[a + 2]) < 0))) {
+                        return "?";
+                    }
+                    if (c[a] === ":" && "+-*/".indexOf(c[a + 1]) > -1) {
+                        return ":";
+                    }
+                    if (a < b - 1) {
+                        if (c[a] !== "<" && c[a + 1] === "<") {
+                            return c[a];
+                        }
+                        if (c[a] === "!" && c[a + 1] === "/") {
+                            return "!";
+                        }
+                        if (c[a] === "-") {
+                            if (c[a + 1] === "-") {
+                                output = "--";
+                            } else if (c[a + 1] === "=") {
+                                output = "-=";
+                            } else if (c[a + 1] === ">") {
+                                output = "->";
+                            }
+                            if (output === "") {
+                                return "-";
+                            }
+                        }
+                        if (c[a] === "+") {
+                            if (c[a + 1] === "+") {
+                                output = "++";
+                            } else if (c[a + 1] === "=") {
+                                output = "+=";
+                            }
+                            if (output === "") {
+                                return "+";
+                            }
+                        }
+                        if (c[a] === "=" && c[a + 1] !== "=" && c[a + 1] !== "!" && c[a + 1] !== ">") {
+                            return "=";
+                        }
+                    }
+                    if (output === "") {
+                        if ((c[a + 1] === "+" && c[a + 2] === "+") || (c[a + 1] === "-" && c[a + 2] === "-")) {
+                            output = c[a];
+                        } else {
+                            for (g = a + 1; g < jj; g = g + 1) {
+                                if ((c[g] === "+" && c[g + 1] === "+") || (c[g] === "-" && c[g + 1] === "-")) {
+                                    break;
+                                }
+                                for (h = 0; h < synlen; h = h + 1) {
+                                    if (c[g] === syntax[h]) {
+                                        build.push(syntax[h]);
+                                        break;
+                                    }
+                                }
+                                if (h === synlen) {
+                                    break;
+                                }
+                            }
+                            output = build.join("");
+                        }
+                    }
+                    a = a + (output.length - 1);
+                    if (options.jsscope !== "none") {
+                        output = output
+                            .replace(/&/g, "&amp;")
+                            .replace(/</g, "&lt;")
+                            .replace(/>/g, "&gt;");
+                    }
+                    if (output === "=>" && ltoke === ")") {
+                        g  = token.length - 1;
+                        jj = begin[g];
+                        do {
+                            if (begin[g] === jj) {
+                                depth[g] = "method";
+                            }
+                            g = g - 1;
+                        } while (g > jj - 1);
+                    }
+                    if (output.length === 2 && output.charAt(1) === "=" && "!=<>|&?".indexOf(output.charAt(0)) < 0 && options.correct === true) {
+                        return plusequal(output);
+                    }
+                    return output;
+                },
+                //ES6 template string support
+                tempstring     = function jspretty__tokenize_tempstring() {
+                    var output = [c[a]];
+                    for (a = a + 1; a < b; a = a + 1) {
+                        output.push(c[a]);
+                        if (c[a] === "`" && (c[a - 1] !== "\\" || slashes(a - 1) === false)) {
+                            templateString.pop();
+                            break;
+                        }
+                        if (c[a - 1] === "$" && c[a] === "{" && (c[a - 2] !== "\\" || slashes(a - 2) === false)) {
+                            templateString[templateString.length - 1] = true;
+                            break;
+                        }
+                    }
+                    return output.join("");
+                },
+                //a tokenizer for numbers
+                numb           = function jspretty__tokenize_number() {
+                    var ee    = 0,
+                        f     = b,
+                        build = [c[a]],
+                        test  = /zz/,
+                        dot   = (build[0] === ".");
+                    if (a < b - 2 && c[a] === "0") {
+                        if (c[a + 1] === "x") {
+                            test = /[0-9a-fA-F]/;
+                        } else if (c[a + 1] === "o") {
+                            test = /[0-9]/;
+                        } else if (c[a + 1] === "b") {
+                            test = /0|1/;
+                        }
+                        if (test.test(c[a + 2]) === true) {
+                            build.push(c[a + 1]);
+                            ee = a + 1;
+                            do {
+                                ee = ee + 1;
+                                build.push(c[ee]);
+                            } while (test.test(c[ee + 1]) === true);
+                            a = ee;
+                            return build.join("");
+                        }
+                    }
+                    for (ee = a + 1; ee < f; ee = ee + 1) {
+                        if ((/[0-9]/).test(c[ee]) || (c[ee] === "." && dot === false)) {
+                            build.push(c[ee]);
+                            if (c[ee] === ".") {
+                                dot = true;
+                            }
+                        } else {
+                            break;
+                        }
+                    }
+                    if (ee < f - 1 && ((/\d/).test(c[ee - 1]) === true || ((/\d/).test(c[ee - 2]) === true && (c[ee - 1] === "-" || c[ee - 1] === "+"))) && (c[ee] === "e" || c[ee] === "E")) {
+                        build.push(c[ee]);
+                        if (c[ee + 1] === "-" || c[ee + 1] === "+") {
+                            build.push(c[ee + 1]);
+                            ee = ee + 1;
+                        }
+                        dot = false;
+                        for (ee = ee + 1; ee < f; ee = ee + 1) {
+                            if ((/[0-9]/).test(c[ee]) || (c[ee] === "." && dot === false)) {
+                                build.push(c[ee]);
+                                if (c[ee] === ".") {
+                                    dot = true;
+                                }
+                            } else {
+                                break;
+                            }
+                        }
+                    }
+                    a = ee - 1;
+                    return build.join("");
+                },
+                // Not a tokenizer.  This counts white space characters and determines if there
+                // are empty lines to be preserved
+                space          = function jspretty__tokenize_space() {
+                    var schars    = [],
+                        f         = 0,
+                        locallen  = b,
+                        emptyline = 1,
+                        output    = "",
+                        stest     = (/\s/),
+                        asitest   = false;
+                    for (f = a; f < locallen; f = f + 1) {
+                        if (c[f] === "\n") {
+                            stats.space.newline = stats.space.newline + 1;
+                            asitest             = true;
+                        } else if (c[f] === " ") {
+                            stats.space.space = stats.space.space + 1;
+                        } else if (c[f] === "\t") {
+                            stats.space.tab = stats.space.tab + 1;
+                        } else if (stest.test(c[f]) === true) {
+                            stats.space.other = stats.space.other + 1;
+                        } else {
+                            break;
+                        }
+                        schars.push(c[f]);
+                    }
+                    a = f - 1;
+                    if (token.length === 0) {
+                        return;
+                    }
+                    output = schars.join("");
+                    if (output.indexOf("\n") > -1 && token[token.length - 1].indexOf("#!/") !== 0) {
+                        schars = output.split("\n");
+                        if (schars.length > 2) {
+                            emptyline = schars.length - 1;
+                            if (token[lengtha - 1].indexOf("//") === 0) {
+                                emptyline = emptyline + 1;
+                            }
+                            if (emptyline > options.preserve + 1) {
+                                emptyline = options.preserve + 1;
+                            }
+                        } else if (token[lengtha - 1] !== undefined && token[lengtha - 1].indexOf("//") === 0) {
+                            emptyline = 2;
+                        }
+                        if (ltype === "comment" && ltoke.charAt(1) !== "*" && emptyline < 2) {
+                            lines[lines.length - 1] = emptyline + 1;
+                        } else {
+                            lines[lines.length - 1] = emptyline;
+                        }
+                    }
+                    if (asitest === true && ltoke !== ";" && lengthb < token.length && c[a + 1] !== "}") {
+                        asi(false);
+                        lengthb = token.length;
+                    }
+                },
+                // Identifies blocks of markup embedded within JavaScript for language supersets
+                // like React JSX.
+                markup         = function jspretty__tokenize_markup() {
+                    var output     = [],
+                        curlytest  = false,
+                        endtag     = false,
+                        anglecount = 0,
+                        curlycount = 0,
+                        tagcount   = 0,
+                        d          = 0,
+                        next       = "",
+                        syntaxnum  = "0123456789=<>+-*?|^:&.,;%(){}[]~",
+                        syntax     = "=<>+-*?|^:&.,;%(){}[]~";
+                    if (wordTest > -1) {
+                        word();
+                    }
+                    d = token.length - 1;
+                    if (types[d] === "comment" || types[d] === "comment-inline") {
+                        do {
+                            d = d - 1;
+                        } while (d > 0 && (types[d] === "comment" || types[d] === "comment-inline"));
+                    }
+                    if (c[a] === "<" && c[a + 1] === ">") {
+                        a     = a + 1;
+                        ltype = "generic";
+                        return "<>";
+                    }
+                    if ((c[a] !== "<" && syntaxnum.indexOf(c[a + 1]) > -1) || token[d] === "++" || token[d] === "--" || (/\s/).test(c[a + 1]) === true || ((/\d/).test(c[a + 1]) === true && (ltype === "operator" || ltype === "literal" || (ltype === "word" && ltoke !== "return")))) {
+                        ltype = "operator";
+                        return operator();
+                    }
+                    if (options.typescript === false && (token[d] === "return" || types[d] === "operator" || types[d] === "start" || types[d] === "separator" || (token[d] === "}" && depthlist[depthlist.length - 1][0] === "global"))) {
+                        ltype       = "markup";
+                        options.jsx = true;
+                    } else if (options.typescript === true || token[lengtha - 1] === "#include" || (((/\s/).test(c[a - 1]) === false || ltoke === "public" || ltoke === "private" || ltoke === "static" || ltoke === "final" || ltoke === "implements" || ltoke === "class" || ltoke === "void" || ltoke === "Promise") && syntaxnum.indexOf(c[a + 1]) < 0)) {
+                        //Java type generics
+                        return (function jspretty__tokenize_markup_generic() {
+                            var generics = [
+                                    "<",
+                                    c[a + 1]
+                                ],
+                                comma    = false,
+                                e        = 1,
+                                f        = 0;
+                            if (c[a + 1] === "<") {
+                                e = 2;
+                            }
+                            for (d = a + 2; d < b; d = d + 1) {
+                                generics.push(c[d]);
+                                if (c[d] === "?" && c[d + 1] === ">") {
+                                    generics.push(">");
+                                    d = d + 1;
+                                }
+                                if (c[d] === ",") {
+                                    comma = true;
+                                    if ((/\s/).test(c[d + 1]) === false) {
+                                        generics.push(" ");
+                                    }
+                                } else if (c[d] === "[") {
+                                    f = f + 1;
+                                } else if (c[d] === "]") {
+                                    f = f - 1;
+                                } else if (c[d] === "<") {
+                                    e = e + 1;
+                                } else if (c[d] === ">") {
+                                    e = e - 1;
+                                    if (e === 0 && f === 0) {
+                                        if ((/\s/).test(c[d - 1]) === true) {
+                                            ltype = "operator";
+                                            return operator();
+                                        }
+                                        ltype = "generic";
+                                        a     = d;
+                                        return generics
+                                            .join("")
+                                            .replace(/\s+/g, " ");
+                                    }
+                                }
+                                if ((syntax.indexOf(c[d]) > -1 && c[d] !== "," && c[d] !== "<" && c[d] !== ">" && c[d] !== "[" && c[d] !== "]") || (comma === false && (/\s/).test(c[d]) === true)) {
+                                    ltype = "operator";
+                                    return operator();
+                                }
+                            }
+                        }());
+                    } else {
+                        ltype = "operator";
+                        return operator();
+                    }
+                    for (a = a; a < b; a = a + 1) {
+                        output.push(c[a]);
+                        if (c[a] === "{") {
+                            curlycount = curlycount + 1;
+                            curlytest  = true;
+                        } else if (c[a] === "}") {
+                            curlycount = curlycount - 1;
+                            if (curlycount === 0) {
+                                curlytest = false;
+                            }
+                        } else if (c[a] === "<" && curlytest === false) {
+                            if (c[a + 1] === "<") {
+                                do {
+                                    output.push(c[a]);
+                                    a = a + 1;
+                                } while (c[a + 1] === "<");
+                            }
+                            anglecount = anglecount + 1;
+                            if (c[a + 1] === "/") {
+                                endtag = true;
+                            }
+                        } else if (c[a] === ">" && curlytest === false) {
+                            if (c[a + 1] === ">") {
+                                do {
+                                    output.push(c[a]);
+                                    a = a + 1;
+                                } while (c[a + 1] === ">");
+                            }
+                            anglecount = anglecount - 1;
+                            if (endtag === true) {
+                                tagcount = tagcount - 1;
+                            } else if (c[a - 1] !== "/") {
+                                tagcount = tagcount + 1;
+                            }
+                            if (anglecount === 0 && curlycount === 0 && tagcount < 1) {
+                                ltype = "markup";
+                                next  = nextchar(2, false);
+                                if (next.charAt(0) !== "<") {
+                                    return output.join("");
+                                }
+                                // catch additional trailing tag sets
+                                if (next.charAt(0) === "<" && syntaxnum.indexOf(next.charAt(1)) < 0 && (/\s/).test(next.charAt(1)) === false) {
+                                    // perform a minor safety test to verify if "<" is a tag start or a less than
+                                    // operator
+                                    d = a + 1;
+                                    do {
+                                        d = d + 1;
+                                        if (c[d] === ">" || ((/\s/).test(c[d - 1]) === true && syntaxnum.indexOf(c[d]) < 0)) {
+                                            break;
+                                        }
+                                        if (syntaxnum.indexOf(c[d]) > -1) {
+                                            return output.join("");
+                                        }
+                                    } while (d < b);
+                                } else {
+                                    return output.join("");
+                                }
+                            }
+                            endtag = false;
+                        }
+                    }
+                    ltype = "markup";
+                    return output.join("");
+                },
+                //operations for end types: ), ], }
+                end            = function jspretty__tokenize_end(x) {
+                    var insert   = false,
+                        next     = nextchar(1, false),
+                        newarray = function jspretty__tokenize_end_newarray() {
+                            var aa       = begin[lengtha - 1],
+                                bb       = 0,
+                                cc       = 0,
+                                ar       = (token[begin[lengtha - 1] - 1] === "Array"),
+                                startar  = (ar === true)
+                                    ? "["
+                                    : "{",
+                                endar    = (ar === true)
+                                    ? "]"
+                                    : "}",
+                                namear   = (ar === true)
+                                    ? "array"
+                                    : "object",
+                                arraylen = 0;
+                            tokenpop();
+                            cc = lengtha - 1;
+                            if (ar === true && token[cc - 1] === "(" && types[cc] === "literal" && token[cc].charAt(0) !== "\"" && token[cc].charAt(0) !== "'") {
+                                arraylen = token[cc] - 1;
+                                tokenpop();
+                                tokenpop();
+                                tokenpop();
+                                token[token.length - 1]         = "[";
+                                lengtha                         = token.length;
+                                types[types.length - 1]         = "start";
+                                lines[lines.length - 1]         = 0;
+                                depth[depth.length - 1]         = "array";
+                                begin[begin.length - 1]         = lengtha - 1;
+                                depthlist[depthlist.length - 1] = [
+                                    "array", lengtha - 1
+                                ];
+                                do {
+                                    tokenpush(true, 0);
+                                    arraylen = arraylen - 1;
+                                } while (arraylen > 0);
+                            } else {
+                                token[aa] = startar;
+                                types[aa] = "start";
+                                cc        = begin[aa];
+                                token.splice(aa - 2, 2);
+                                types.splice(aa - 2, 2);
+                                lines.splice(aa - 2, 2);
+                                depth.splice(aa - 2, 2);
+                                begin.splice(aa - 2, 2);
+                                lengtha                         = lengtha - 2;
+                                depthlist[depthlist.length - 1] = [
+                                    namear, aa - 2
+                                ];
+                                pdepth                          = [namear, aa];
+                                bb                              = lengtha - 1;
+                                do {
+                                    if (begin[bb] === cc) {
+                                        depth[bb] = namear;
+                                        begin[bb] = begin[bb] - 2;
+                                    }
+                                    bb = bb - 1;
+                                } while (bb > aa - 3);
+                            }
+                            ltoke = endar;
+                            ltype = "end";
+                            tokenpush(false, 0);
+                        };
+                    stats.container = stats.container + 1;
+                    if (wordTest > -1) {
+                        word();
+                    }
+                    if (classy.length > 0) {
+                        if (classy[classy.length - 1] === 0) {
+                            classy.pop();
+                        } else {
+                            classy[classy.length - 1] = classy[classy.length - 1] - 1;
+                        }
+                    }
+                    if (x === ")" || x === "x)" || x === "]") {
+                        plusplus();
+                        asifix();
+                    }
+                    if (x === ")" || x === "x)") {
+                        asi(false);
+                    }
+                    if (vart.len > -1) {
+                        if (x === "}" && ((options.varword === "list" && vart.count[vart.len] === 0) || (token[token.length - 1] === "x;" && options.varword === "each"))) {
+                            vartpop();
+                        }
+                        vart.count[vart.len] = vart.count[vart.len] - 1;
+                        if (vart.count[vart.len] < 0) {
+                            vartpop();
+                        }
+                    }
+                    if (ltoke === "," && depth[lengtha - 1] !== "initializer" && ((x === "]" && (options.endcomma === "never" || options.endcomma === "multiline" || token[lengtha - 2] === "[")) || x === "}")) {
+                        tokenpop();
+                    } else if ((x === "]" || x === "}") && options.endcomma === "always" && ltoke !== ",") {
+                        endCommaArray();
+                    }
+                    if (x === ")" || x === "x)") {
+                        ltoke = x;
+                        ltype = "end";
+                        if (lword.length > 0) {
+                            pword = lword[lword.length - 1];
+                            if (pword.length > 1 && next !== "{" && (pword[0] === "if" || pword[0] === "for" || (pword[0] === "while" && depth[pword[1] - 2] !== undefined && depth[pword[1] - 2] !== "do") || pword[0] === "with")) {
+                                insert = true;
+                            }
+                        }
+                    } else if (x === "]") {
+                        ltoke = "]";
+                        ltype = "end";
+                        pword = [];
+                    } else if (x === "}") {
+                        if (ltoke !== "," || options.endcomma === "always") {
+                            if (ltoke === ";" && options.mode === "minify") {
+                                token[token.length - 1] = "x;";
+                            }
+                            plusplus();
+                        }
+                        if (depthlist.length > 0 && depthlist[depthlist.length - 1][0] !== "object") {
+                            asi(true);
+                        } else if (objsortop === true) {
+                            objSort();
+                        }
+                        if (ltype === "comment" || ltype === "comment-inline") {
+                            lengtha = token.length;
+                            ltoke   = token[lengtha - 1];
+                            ltype   = types[lengtha - 1];
+                        }
+                        if (options.braceline === true) {
+                            lines[lines.length - 1] = 2;
+                        }
+                        ltoke = "}";
+                        ltype = "end";
+                        pword = [];
+                    }
+                    lword.pop();
+                    tokenpush(false, 0);
+                    if (x === ")" && options.correct === true && (token[begin[lengtha - 1] - 1] === "Array" || token[begin[lengtha - 1] - 1] === "Object") && token[begin[lengtha - 1] - 2] === "new") {
+                        newarray();
+                    }
+                    pdepth = depthlist.pop();
+                    if (brace[brace.length - 1] === "x{" && x === "}") {
+                        blockinsert();
+                    }
+                    brace.pop();
+                    if (brace[brace.length - 1] === "x{" && x === "}" && depth[lengtha - 1] !== "try") {
+                        if (next !== ":" && token[begin[a] - 1] !== "?") {
+                            blockinsert();
+                        }
+                    }
+                    if (insert === true) {
+                        ltoke = "x{";
+                        ltype = "start";
+                        tokenpush(false, 0);
+                        brace.push("x{");
+                        pword[1] = lengtha - 1;
+                        depthlist.push(pword);
+                    }
+                },
+                //determines tag names for {% %} based template tags and returns a type
+                tname          = function jspretty__tokenize_tname(x) {
+                    var sn       = 2,
+                        en       = 0,
+                        st       = x.slice(0, 2),
+                        len      = x.length,
+                        name     = "",
+                        namelist = [
+                            "autoescape",
+                            "block",
+                            "capture",
+                            "case",
+                            "comment",
+                            "embed",
+                            "filter",
+                            "for",
+                            "form",
+                            "if",
+                            "macro",
+                            "paginate",
+                            "raw",
+                            "sandbox",
+                            "spaceless",
+                            "tablerow",
+                            "unless",
+                            "verbatim"
+                        ];
+                    if (x.charAt(2) === "-") {
+                        sn = sn + 1;
+                    }
+                    if ((/\s/).test(x.charAt(sn)) === true) {
+                        do {
+                            sn = sn + 1;
+                        } while ((/\s/).test(x.charAt(sn)) === true && sn < len);
+                    }
+                    en = sn;
+                    do {
+                        en = en + 1;
+                    } while (
+                        (/\s/).test(x.charAt(en)) === false && x.charAt(en) !== "(" && en < len
+                    );
+                    if (en === len) {
+                        en = x.length - 2;
+                    }
+                    name = x.slice(sn, en);
+                    if (name === "else" || (st === "{%" && (name === "elseif" || name === "when" || name === "elif"))) {
+                        return "template_else";
+                    }
+                    if (st === "{{") {
+                        if (name === "end") {
+                            return "template_end";
+                        }
+                        if (name === "block" || name === "define" || name === "form" || name === "if" || name === "range" || name === "with") {
+                            return "template_start";
+                        }
+                        return "template";
+                    }
+                    for (en = namelist.length - 1; en > -1; en = en - 1) {
+                        if (name === namelist[en]) {
+                            return "template_start";
+                        }
+                        if (name === "end" + namelist[en]) {
+                            return "template_end";
+                        }
+                    }
+                    return "template";
+                };
+            start = function jspretty__tokenize_start(x) {
+                brace.push(x);
+                stats.container = stats.container + 1;
+                if (wordTest > -1) {
+                    word();
+                }
+                if (vart.len > -1) {
+                    vart.count[vart.len] = vart.count[vart.len] + 1;
+                }
+                if (token[lengtha - 2] === "function") {
+                    lword.push(["function", lengtha]);
+                } else {
+                    lword.push([ltoke, lengtha]);
+                }
+                ltoke = x;
+                ltype = "start";
+                if (x === "(" || x === "x(") {
+                    asifix();
+                } else if (x === "{") {
+                    if (paren > -1) {
+                        if (begin[paren - 1] === begin[begin[lengtha - 1] - 1] || token[begin[lengtha - 1]] === "x(") {
+                            paren = -1;
+                            end("x)");
+                            asifix();
+                            ltoke = "{";
+                            ltype = "start";
+                        }
+                    } else if (ltoke === ")") {
+                        asifix();
+                    }
+                    if ((ltype === "comment" || ltype === "comment-inline") && token[lengtha - 2] === ")") {
+                        ltoke              = token[lengtha - 1];
+                        token[lengtha - 1] = "{";
+                        ltype              = types[lengtha - 1];
+                        types[lengtha - 1] = "start";
+                    }
+                }
+                if (options.braceline === true && x === "{") {
+                    tokenpush(false, 2);
+                } else {
+                    tokenpush(false, 0);
+                }
+                if (classy.length > 0) {
+                    classy[classy.length - 1] = classy[classy.length - 1] + 1;
+                }
+                depthlist.push([
+                    depth[depth.length - 1],
+                    begin[begin.length - 1]
+                ]);
+            };
+            for (a = 0; a < b; a = a + 1) {
+                if ((/\s/).test(c[a])) {
+                    if (wordTest > -1) {
+                        word();
+                    }
+                    space();
+                } else if (c[a] === "<" && c[a + 1] === "?" && c[a + 2] === "p" && c[a + 3] === "h" && c[a + 4] === "p") {
+                    //php
+                    ltoke              = generic("<?php", "?>");
+                    ltype              = "template";
+                    stats.server.token = stats.server.token + 1;
+                    stats.server.chars = stats.server.chars + ltoke.length;
+                    tokenpush(false, 0);
+                } else if (c[a] === "<" && c[a + 1] === "%") {
+                    //asp
+                    ltoke              = generic("<%", "%>");
+                    ltype              = "template";
+                    stats.server.token = stats.server.token + 1;
+                    stats.server.chars = stats.server.chars + ltoke.length;
+                    tokenpush(false, 0);
+                } else if (c[a] === "{" && c[a + 1] === "%") {
+                    //twig
+                    ltoke              = generic("{%", "%}");
+                    ltype              = tname(ltoke);
+                    stats.server.token = stats.server.token + 1;
+                    stats.server.chars = stats.server.chars + ltoke.length;
+                    tokenpush(false, 0);
+                } else if (c[a] === "{" && c[a + 1] === "{" && c[a + 2] === "{") {
+                    //mustache
+                    ltoke              = generic("{{{", "}}}");
+                    ltype              = "template";
+                    stats.server.token = stats.server.token + 1;
+                    stats.server.chars = stats.server.chars + ltoke.length;
+                    tokenpush(false, 0);
+                } else if (c[a] === "{" && c[a + 1] === "{") {
+                    //handlebars
+                    ltoke              = generic("{{", "}}");
+                    ltype              = tname(ltoke);
+                    stats.server.token = stats.server.token + 1;
+                    stats.server.chars = stats.server.chars + ltoke.length;
+                    tokenpush(false, 0);
+                } else if (c[a] === "<" && c[a + 1] === "!" && c[a + 2] === "-" && c[a + 3] === "-" && c[a + 4] === "#") {
+                    //ssi
+                    ltoke              = generic("<!--#", "-->");
+                    ltype              = "template";
+                    stats.server.token = stats.server.token + 1;
+                    stats.server.chars = stats.server.chars + ltoke.length;
+                    tokenpush(false, 0);
+                } else if (c[a] === "<" && c[a + 1] === "!" && c[a + 2] === "-" && c[a + 3] === "-") {
+                    //markup comment
+                    ltoke                    = generic("<!--", "-->");
+                    ltype                    = "comment";
+                    stats.commentBlock.token = stats.commentBlock.token + 1;
+                    stats.commentBlock.chars = stats.commentBlock.chars + ltoke.length;
+                    tokenpush(false, 0);
+                } else if (c[a] === "<") {
+                    //markup
+                    ltoke              = markup();
+                    stats.server.token = stats.server.token + 1;
+                    stats.server.chars = stats.server.chars + ltoke.length;
+                    tokenpush(false, 0);
+                } else if (c[a] === "/" && (a === b - 1 || c[a + 1] === "*")) {
+                    //comment block
+                    ltoke                    = generic("/*", "*\/");
+                    stats.commentBlock.token = stats.commentBlock.token + 1;
+                    stats.commentBlock.chars = stats.commentBlock.chars + ltoke.length;
+                    if (ltoke.indexOf("# sourceMappingURL=") === 2) {
+                        sourcemap[0] = token.length;
+                        sourcemap[1] = ltoke;
+                    }
+                    if (options.comments !== "nocomment") {
+                        ltype = "comment";
+                        if (token[lengtha - 1] === "var" || token[lengtha - 1] === "let" || token[lengtha - 1] === "const") {
+                            tokenpop();
+                            commentwrap(ltoke, false);
+                            temppush();
+                            if (lines[lengtha - 3] === 0) {
+                                lines[lengtha - 3] = lines[lengtha - 1];
+                            }
+                            lines[lengtha - 1] = 0;
+                        } else {
+                            commentwrap(ltoke, false);
+                        }
+                    }
+                } else if ((lines.length === 0 || lines[lines.length - 1] > 0) && c[a] === "#" && c[a + 1] === "!" && (c[a + 2] === "/" || c[a + 2] === "[")) {
+                    //shebang
+                    ltoke              = generic("#!" + c[a + 2], "\n");
+                    ltoke              = ltoke.slice(0, ltoke.length - 1);
+                    ltype              = "literal";
+                    stats.server.token = stats.server.token + 1;
+                    stats.server.chars = stats.server.chars + ltoke.length;
+                    tokenpush(false, 2);
+                } else if (c[a] === "/" && (a === b - 1 || c[a + 1] === "/")) {
+                    //comment line
+                    asi(false);
+                    ltoke                   = generic("//", "\n");
+                    stats.commentLine.token = stats.commentLine.token + 1;
+                    stats.commentLine.chars = stats.commentLine.chars + ltoke.length;
+                    if (ltoke.indexOf("# sourceMappingURL=") === 2) {
+                        sourcemap[0] = token.length;
+                        sourcemap[1] = ltoke;
+                    }
+                    if (options.comments !== "nocomment") {
+                        commentwrap(ltoke, true);
+                    }
+                } else if (c[a] === "#" && c[a + 1] === "r" && c[a + 2] === "e" && c[a + 3] === "g" && c[a + 4] === "i" && c[a + 5] === "o" && c[a + 6] === "n" && (/\s/).test(c[a + 7]) === true) {
+                    //comment line
+                    asi(false);
+                    ltoke                   = generic("#region", "\n");
+                    ltype                   = "comment";
+                    stats.commentLine.token = stats.commentLine.token + 1;
+                    stats.commentLine.chars = stats.commentLine.chars + ltoke.length;
+                    tokenpush(false, 0);
+                } else if (c[a] === "#" && c[a + 1] === "e" && c[a + 2] === "n" && c[a + 3] === "d" && c[a + 4] === "r" && c[a + 5] === "e" && c[a + 6] === "g" && c[a + 7] === "i" && c[a + 8] === "o" && c[a + 9] === "n") {
+                    //comment line
+                    asi(false);
+                    ltoke                   = generic("#endregion", "\n");
+                    ltype                   = "comment";
+                    stats.commentLine.token = stats.commentLine.token + 1;
+                    stats.commentLine.chars = stats.commentLine.chars + ltoke.length;
+                    tokenpush(false, 0);
+                } else if (c[a] === "`" || (c[a] === "}" && templateString[templateString.length - 1] === true)) {
+                    //template string
+                    if (wordTest > -1) {
+                        word();
+                    }
+                    if (c[a] === "`") {
+                        templateString.push(false);
+                    } else {
+                        templateString[templateString.length - 1] = false;
+                    }
+                    ltoke              = tempstring();
+                    ltype              = "literal";
+                    stats.string.token = stats.string.token + 1;
+                    if (ltoke.charAt(ltoke.length - 1) === "{") {
+                        stats.string.quote = stats.string.quote + 3;
+                        stats.string.chars = stats.string.chars + ltoke.length - 3;
+                    } else {
+                        stats.string.quote = stats.string.quote + 2;
+                        stats.string.chars = ltoke.length - 2;
+                    }
+                    tokenpush(false, 0);
+                } else if (c[a] === "\"" || c[a] === "'") {
+                    //string
+                    ltoke = generic(c[a], c[a]);
+                    ltype = "literal";
+                    if ((ltoke.charAt(0) === "\"" && options.quoteConvert === "single") || (ltoke.charAt(0) === "'" && options.quoteConvert === "double")) {
+                        ltoke = quoteConvert(ltoke);
+                    }
+                    stats.string.token = stats.string.token + 1;
+                    if (ltoke.length > 1) {
+                        stats.string.chars = stats.string.chars + ltoke.length - 2;
+                    }
+                    stats.string.quote = stats.string.quote + 2;
+                    if (options.wrap !== 0 && token[lengtha - 1] === "+" && (token[lengtha - 2].charAt(0) === "\"" || token[lengtha - 2].charAt(0) === "'")) {
+                        strmerge();
+                    } else if (options.wrap > 0 && (types[lengtha] !== "operator" || token[lengtha] === "=" || token[lengtha] === ":" || (token[lengtha] === "+" && types[lengtha - 1] === "literal"))) {
+                        if ((token[0] === "[" && (/(\]\s*)$/).test(options.source) === true) || (token[0] === "{" && (/(\}\s*)$/).test(options.source) === true)) {
+                            tokenpush(false, 0);
+                        } else if (types[lengtha - 2] === "literal" && token[lengtha - 1] === "+" && (token[lengtha - 2].charAt(0) === "\"" || token[lengtha - 2].charAt(0) === "'") && token[lengtha - 2].length < options.wrap + 2) {
+                            strmerge();
+                        } else {
+                            tokenpush(false, 0);
+                        }
+                    } else {
+                        tokenpush(false, 0);
+                    }
+                } else if (c[a] === "-" && (a < b - 1 && c[a + 1] !== "=" && c[a + 1] !== "-") && (ltype === "literal" || ltype === "word") && ltoke !== "return" && (ltoke === ")" || ltoke === "]" || ltype === "word" || ltype === "literal")) {
+                    //subtraction
+                    if (wordTest > -1) {
+                        word();
+                    }
+                    stats.operator.token = stats.operator.token + 1;
+                    stats.operator.chars = stats.operator.chars + 1;
+                    ltoke                = "-";
+                    ltype                = "operator";
+                    tokenpush(false, 0);
+                } else if (wordTest === -1 && (c[a] !== "0" || (c[a] === "0" && c[a + 1] !== "b")) && ((/\d/).test(c[a]) || (a !== b - 2 && c[a] === "-" && c[a + 1] === "." && (/\d/).test(c[a + 2])) || (a !== b - 1 && (c[a] === "-" || c[a] === ".") && (/\d/).test(c[a + 1])))) {
+                    //number
+                    if (wordTest > -1) {
+                        word();
+                    }
+                    if (ltype === "end" && c[a] === "-") {
+                        ltoke                = "-";
+                        ltype                = "operator";
+                        stats.operator.token = stats.operator.token + 1;
+                        stats.operator.chars = stats.operator.chars + 1;
+                    } else {
+                        ltoke              = numb();
+                        ltype              = "literal";
+                        stats.number.token = stats.number.token + 1;
+                        stats.number.chars = stats.number.chars + ltoke.length;
+                    }
+                    tokenpush(false, 0);
+                } else if (c[a] === ":" && c[a + 1] === ":") {
+                    if (wordTest > -1) {
+                        word();
+                    }
+                    plusplus();
+                    asifix();
+                    a                    = a + 1;
+                    stats.operator.token = stats.operator.token + 1;
+                    stats.operator.chars = stats.operator.chars + 2;
+                    ltoke                = "::";
+                    ltype                = "separator";
+                    tokenpush(false, 0);
+                } else if (c[a] === ",") {
+                    //comma
+                    if (wordTest > -1) {
+                        word();
+                    }
+                    plusplus();
+                    stats.comma = stats.comma + 1;
+                    if (ltype === "comment" || ltype === "comment-inline") {
+                        commaComment();
+                    } else if (vart.len > -1 && vart.count[vart.len] === 0 && options.varword === "each") {
+                        asifix();
+                        ltoke = ";";
+                        ltype = "separator";
+                        tokenpush(false, 0);
+                        ltoke = vart.word[vart.len];
+                        ltype = "word";
+                        tokenpush(false, 0);
+                        vart.index[vart.len] = token.length - 1;
+                    } else {
+                        ltoke = ",";
+                        ltype = "separator";
+                        asifix();
+                        tokenpush(false, 0);
+                    }
+                } else if (c[a] === ".") {
+                    //period
+                    if (wordTest > -1) {
+                        word();
+                    }
+                    stats.operator.token = stats.operator.token + 1;
+                    if (c[a + 1] === "." && c[a + 2] === ".") {
+                        ltoke                = "...";
+                        ltype                = "operator";
+                        stats.operator.chars = stats.operator.chars + 3;
+                        a                    = a + 2;
+                    } else {
+                        asifix();
+                        ltoke                = ".";
+                        ltype                = "separator";
+                        stats.operator.chars = stats.operator.chars + 1;
+                    }
+                    if ((/\s/).test(c[a - 1]) === true) {
+                        tokenpush(false, 1);
+                    } else {
+                        tokenpush(false, 0);
+                    }
+                } else if (c[a] === ";") {
+                    //semicolon
+                    if (wordTest > -1) {
+                        word();
+                    }
+                    if (options.qml === true) {
+                        ltoke = "x;";
+                        ltype = "separator";
+                        tokenpush(false, 0);
+                    } else {
+                        if (classy[classy.length - 1] === 0) {
+                            classy.pop();
+                        }
+                        if (vart.len > -1 && vart.count[vart.len] === 0) {
+                            if (options.varword === "each") {
+                                vartpop();
+                            } else {
+                                vart.index[vart.len] = token.length;
+                            }
+                        }
+                        stats.semicolon = stats.semicolon + 1;
+                        plusplus();
+                        ltoke = ";";
+                        ltype = "separator";
+                        if (token[token.length - 1] === "x}") {
+                            asibrace();
+                        } else {
+                            tokenpush(false, 0);
+                        }
+                    }
+                    if (brace[brace.length - 1] === "x{" && nextchar(1, false) !== "}") {
+                        blockinsert();
+                    }
+                } else if (c[a] === "(" || c[a] === "[" || c[a] === "{") {
+                    start(c[a]);
+                } else if (c[a] === ")" || c[a] === "]" || c[a] === "}") {
+                    end(c[a]);
+                } else if (c[a] === "*" && depth[lengtha - 1] === "object" && wordTest < 0 && (/\s/).test(c[a + 1]) === false && c[a + 1] !== "=" && (/\d/).test(c[a + 1]) === false) {
+                    wordTest = a;
+                } else if (c[a] === "=" || c[a] === "&" || c[a] === "<" || c[a] === ">" || c[a] === "+" || c[a] === "-" || c[a] === "*" || c[a] === "/" || c[a] === "!" || c[a] === "?" || c[a] === "|" || c[a] === "^" || c[a] === ":" || c[a] === "%" || c[a] === "~") {
+                    //operator
+                    ltoke = operator();
+                    if (ltoke === "regex") {
+                        ltoke = token[lengtha - 1];
+                    } else {
+                        ltype                = "operator";
+                        stats.operator.token = stats.operator.token + 1;
+                        stats.operator.chars = stats.operator.chars + ltoke.length;
+                        if (ltoke !== "!" && ltoke !== "++" && ltoke !== "--") {
+                            asifix();
+                        }
+                        tokenpush(false, 0);
+                    }
+                } else if (wordTest < 0 && c[a] !== "") {
+                    wordTest = a;
+                }
+                if (vart.len > -1 && token.length === vart.index[vart.len] + 2 && token[vart.index[vart.len]] === ";" && ltoke !== vart.word[vart.len] && ltype !== "comment" && ltype !== "comment-inline" && options.varword === "list") {
+                    vartpop();
+                }
+            }
+            if (options.jsx === false && ((token[token.length - 1] !== "}" && token[0] === "{") || token[0] !== "{") && ((token[token.length - 1] !== "]" && token[0] === "[") || token[0] !== "[")) {
+                asi(false);
+            }
+            if (sourcemap[0] === token.length - 1) {
+                ltoke = "\n" + sourcemap[1];
+                ltype = "literal";
+                tokenpush(false, 0);
+            }
+            if (token[token.length - 1] === "x;" && (token[token.length - 2] === "}" || token[token.length - 2] === "]") && begin[begin.length - 2] === 0) {
+                tokenpop();
+            }
+        }());
+
+        if (options.correct === true) {
+            (function jspretty__correct() {
+                var a = 0,
+                    b = token.length;
+                for (a = 0; a < b; a = a + 1) {
+                    if (token[a] === "x;") {
+                        token[a] = ";";
+                        scolon   = scolon + 1;
+                    } else if (token[a] === "x{") {
+                        token[a] = "{";
+                    } else if (token[a] === "x}") {
+                        token[a] = "}";
+                    } else if (token[a] === "x(") {
+                        token[a] = "(";
+                    } else if (token[a] === "x)") {
+                        token[a] = ")";
+                    }
+                }
+            }());
+        }
+        if (options.nodeasync === false) {
+            if (global.prettydiff.meta === undefined) {
+                global.prettydiff.meta       = {};
+                global.prettydiff.meta.error = "";
+            }
+            if (global.prettydiff.meta.error === "") {
+                global.prettydiff.meta.error = globalerror;
+            }
+        }
+        if (options.mode === "parse") {
+            return (function jspretty__parse() {
+                var a      = 0,
+                    c      = token.length,
+                    record = [],
+                    def    = {
+                        begin: "number - The index where the current container starts",
+                        depth: "string - The name of the current container",
+                        lines: "number - Whether the token is preceeded any space and/or line breaks in the or" +
+                                "iginal code source",
+                        token: "string - The parsed code tokens",
+                        types: "string - Data types of the tokens: comment, comment-inline, end, literal, mark" +
+                                "up, operator, regex, separator, start, template, template_else, template_end, " +
+                                "template_start, word"
+                    };
+                for (a = 0; a < c; a = a + 1) {
+                    if (options.correct === false && (token[a] === "x;" || token[a] === "x{" || token[a] === "x}" || token[a] === "x(" || token[a] === "x)")) {
+                        c = c - 1;
+                        begin.splice(a, 1);
+                        depth.splice(a, 1);
+                        lines.splice(a, 1);
+                        token.splice(a, 1);
+                        types.splice(a, 1);
+                    }
+                    if (options.parseFormat !== "htmltable" && types[a] === "markup" && global.prettydiff.markuppretty !== undefined) {
+                        options.source = token[a];
+                        options.jsx    = true;
+                        token[a]       = global
+                            .prettydiff
+                            .markuppretty(options)
+                            .data;
+                    }
+                }
+                if (options.parseFormat === "sequential") {
+                    for (a = 0; a < c; a = a + 1) {
+                        record.push([
+                            token[a], types[a], depth[a], begin[a], lines[a]
+                        ]);
+                    }
+                    if (options.nodeasync === true) {
+                        return [
+                            {
+                                data      : record,
+                                definition: def
+                            },
+                            globalerror
+                        ];
+                    }
+                    return {data: record, definition: def};
+                }
+                if (options.parseFormat === "htmltable") {
+                    return (function jspretty__parse_html() {
+                        var output = [],
+                            header = "<tr class=\"header\"><th>index</th><th>token</th><th>types</th><th>depth</th><" +
+                                    "th>begin</th><th>lines</th></tr>",
+                            aa     = 0,
+                            len    = 0;
+                        output.push("<table summary='CSS parse table'><thead>");
+                        output.push(header);
+                        output.push("</thead><tbody>");
+                        len = token.length;
+                        for (aa = 0; aa < len; aa = aa + 1) {
+                            if (types[aa] === "markup" && global.prettydiff.markuppretty !== undefined) {
+                                options.source = token[aa];
+                                options.jsx    = true;
+                                output.push("<tr><td colspan=\"6\" class=\"nested\">");
+                                output.push(global.prettydiff.markuppretty(options).data.replace(
+                                    "<thead>",
+                                    "<thead><tr><th colspan=\"10\" class=\"nested\">markup tokens</th></tr>"
+                                ));
+                                output.push("</td></tr>");
+                                output.push(
+                                    "<tr><th colspan=\"6\" class=\"nested\">JavaScript tokens</th></tr>"
+                                );
+                                output.push(header);
+                            } else {
+                                output.push("<tr><td>");
+                                output.push(aa);
+                                output.push("</td><td>");
+                                output.push(
+                                    token[aa].replace(/&/g, "&amp;").replace(/>/g, "&gt;").replace(/</g, "&lt;")
+                                );
+                                output.push("</td><td>");
+                                output.push(types[aa]);
+                                output.push("</td><td>");
+                                output.push(depth[aa]);
+                                output.push("</td><td>");
+                                output.push(begin[aa]);
+                                output.push("</td><td>");
+                                output.push(lines[aa]);
+                                output.push("</td></tr>");
+                            }
+                        }
+                        output.push("</tbody></table>");
+                        if (options.nodeasync === true) {
+                            return [
+                                {
+                                    data      : output.join(""),
+                                    definition: def
+                                },
+                                globalerror
+                            ];
+                        }
+                        return {data: output.join(""), definition: def};
+                    }());
+                }
+                if (options.nodeasync === true) {
+                    return [
+                        {
+                            data      : {
+                                begin: begin,
+                                depth: depth,
+                                lines: lines,
+                                token: token,
+                                types: types
+                            },
+                            definition: def
+                        },
+                        globalerror
+                    ];
+                }
+                return {
+                    data      : {
+                        begin: begin,
+                        depth: depth,
+                        lines: lines,
+                        token: token,
+                        types: types
+                    },
+                    definition: def
+                };
+            }());
+        }
+
+        if (options.jsx === true && options.jsscope !== "none" && token[0] === "{") {
+            options.jsscope = "none";
+            (function jspretty__jsxScope() {
+                var a   = 0,
+                    len = token.length;
+                for (a = 0; a < len; a = a + 1) {
+                    if (types[a] === "word" && token[a - 1] !== ".") {
+                        token[a] = "[pdjsxscope]" + token[a] + "[/pdjsxscope]";
+                    }
+                }
+            }());
+        }
+        if (options.mode === "beautify" || options.mode === "diff") {
+            //this function is the pretty-print algorithm
+            (function jspretty__beautify() {
+                var a             = 0,
+                    b             = token.length,
+                    indent        = options.inlevel, //will store the current level of indentation
+                    list          = [], //stores comma status of current block
+                    wordlist      = [], //if the current list is word types preceeded by a word (Java type invocations)
+                    lastlist      = false, //remembers the list status of the most recently closed block
+                    ternary       = [], //used to identify ternary statments
+                    varline       = [], //determines if a current list of the given block is a list of variables following the "var" keyword
+                    ctype         = "", //ctype stands for "current type"
+                    ctoke         = "", //ctoke standa for "current token"
+                    ltype         = types[0], //ltype stands for "last type"
+                    ltoke         = token[0], //ltype stands for "last token"
+                    lettest       = -1,
+                    varlen        = [
+                        []
+                    ], //stores lists of variables, assignments, and object properties for white space padding
+                    extraindent   = [
+                        []
+                    ], //stores token indexes where extra indentation occurs from ternaries and broken method chains
+                    arrbreak      = [], //array where a method break has occurred
+                    destruct      = [], //attempt to identify object destructuring
+                    itemcount     = [], //counts items in destructured lists
+                    assignlist    = [false], //are you in a list right now?
+                    destructfix   = function jspretty__beautify_destructFix(listFix, override) {
+                        // listfix  - at the end of a list correct the containing list override - to
+                        // break arrays with more than 4 items into a vertical list
+                        var c          = 0,
+                            d          = (listFix === true)
+                                ? 0
+                                : 1,
+                            ei         = (extraindent[extraindent.length - 1] === undefined)
+                                ? []
+                                : extraindent[extraindent.length - 1],
+                            arrayCheck = (
+                                override === false && depth[a] === "array" && listFix === true && ctoke !== "["
+                            );
+                        if (destruct[destruct.length - 1] === false || (depth[a] === "array" && options.formatArray === "inline") || (depth[a] === "object" && options.formatObject === "inline")) {
+                            return;
+                        }
+                        destruct[destruct.length - 1] = false;
+                        for (c = a - 1; c > -1; c = c - 1) {
+                            if (types[c] === "end") {
+                                d = d + 1;
+                            } else if (types[c] === "start") {
+                                d = d - 1;
+                            }
+                            if (depth[c] === "global") {
+                                return;
+                            }
+                            if (d === 0) {
+                                if (depth[a] === "class" || depth[a] === "map" || (arrayCheck === false && ((listFix === false && token[c] !== "(" && token[c] !== "x(") || (listFix === true && token[c] === ",")))) {
+                                    if (types[c + 1] === "template_start") {
+                                        if (lines[c] < 1) {
+                                            level[c] = -20;
+                                        } else {
+                                            level[c] = indent - 1;
+                                        }
+                                    } else if (ei.length > 0 && ei[ei.length - 1] > -1) {
+                                        level[c] = indent - 1;
+                                    } else {
+                                        level[c] = indent;
+                                    }
+                                }
+                                if (listFix === false) {
+                                    return;
+                                }
+                            }
+                            if (d < 0) {
+                                if (types[c + 1] === "template_start") {
+                                    if (lines[c] < 1) {
+                                        level[c] = -20;
+                                    } else {
+                                        level[c] = indent - 1;
+                                    }
+                                } else if (ei.length > 0 && ei[ei.length - 1] > -1) {
+                                    level[c] = indent - 1;
+                                } else {
+                                    level[c] = indent;
+                                }
+                                return;
+                            }
+                        }
+                    },
+                    strwrap       = function jspretty__beautify_strwrap(offset) {
+                        var aa        = 0,
+                            bb        = 0,
+                            cc        = 0,
+                            dd        = 0,
+                            ee        = 0,
+                            ff        = 0,
+                            x         = 0,
+                            str       = "",
+                            off       = false,
+                            ei        = (extraindent[extraindent.length - 1] === undefined)
+                                ? []
+                                : extraindent[extraindent.length - 1],
+                            ind       = (token[begin[a]] === "(" && (list[list.length - 1] === true || ei.length > 0))
+                                ? indent + 3
+                                : indent + 2,
+                            bgn       = begin[a],
+                            dep       = depth[a],
+                            lin       = lines[a],
+                            wrap      = options.wrap - 2,
+                            paren     = token[a + 1] === ".",
+                            uchar     = (/u[0-9a-fA-F]{4}/),
+                            xchar     = (/x[0-9a-fA-F]{2}/),
+                            item      = token[a],
+                            qchar     = item.charAt(0),
+                            slash     = function jspretty__beautify_strwrap_slash(trim, entity) {
+                                var dist = 0;
+                                if (entity === true) {
+                                    ff = trim;
+                                }
+                                do {
+                                    dist = dist + 1;
+                                } while (item.charAt(cc - (trim + dist)) === "\\" && dist < cc);
+                                if (entity === false) {
+                                    cc = cc - dist;
+                                    ff = ff + dist;
+                                } else if (dist % 2 === 1) {
+                                    cc = cc - ff;
+                                } else {
+                                    ff = 0;
+                                }
+                            },
+                            parenpush = function jspretty_beautify_strwrap_parenpush() {
+                                token.splice(a, 0, "(");
+                                types.splice(a, 0, "start");
+                                lines.splice(a, 0, lin);
+                                depth.splice(a, 0, "paren");
+                                begin.splice(a, 0, a);
+                                level.push(indent + 1);
+                                bgn = a;
+                                dep = "paren";
+                                a   = a + 1;
+                                b   = b + 1;
+                                x   = x + 1;
+                            },
+                            tokenpush = function jspretty_beautify_strwrap_tokenpush(toke, type) {
+                                token.splice(a, 0, toke);
+                                types.splice(a, 0, type);
+                                lines.splice(a, 0, lin);
+                                depth.splice(a, 0, dep);
+                                begin.splice(a, 0, bgn);
+                                if (toke === "+") {
+                                    level.push(ind);
+                                } else if (toke === ")") {
+                                    level.push(indent);
+                                    level[a - 1] = indent;
+                                } else {
+                                    level.push(-10);
+                                }
+                                a = a + 1;
+                                b = b + 1;
+                                x = x + 1;
+                            };
+                        aa = a;
+                        do {
+                            aa = aa - 1;
+                            if (aa === begin[a] && token[aa] === "(") {
+                                break;
+                            }
+                        } while (aa > 0 && level[aa - 1] < -9);
+                        if (ltoke === "(") {
+                            level[a - 1] = indent + 1;
+                        }
+                        if (token[aa] === "." && token[begin[a]] !== "(") {
+                            ind = ind + 1;
+                        }
+                        if (token[begin[a]] === "(" && list[list.length - 1] === false && token[aa] !== "?" && token[aa] !== ":") {
+                            ind = indent + 1;
+                        }
+                        if (paren === true && token[aa] !== "?" && token[aa] !== ":") {
+                            ind = indent + 1;
+                        }
+                        if (offset > 1 && item.length > offset) {
+                            off = true;
+                            if (paren === true) {
+                                tokenpush("(");
+                            }
+                            if (item.charAt(offset - 5) === "\\" && uchar.test(item.slice(offset - 4, offset + 1)) === true) {
+                                str  = item.slice(0, offset - 5) + item.charAt(0);
+                                item = item.charAt(0) + item.slice(offset - 5);
+                            } else if (item.charAt(offset - 4) === "\\" && uchar.test(item.slice(offset - 3, offset + 2)) === true) {
+                                str  = item.slice(0, offset - 4) + item.charAt(0);
+                                item = item.charAt(0) + item.slice(offset - 4);
+                            } else if (item.charAt(offset - 3) === "\\" && (uchar.test(item.slice(offset - 2, offset + 3)) === true || xchar.test(item.slice(offset - 2, offset + 1)) === true)) {
+                                str  = item.slice(0, offset - 3) + item.charAt(0);
+                                item = item.charAt(0) + item.slice(offset - 3);
+                            } else if (item.charAt(offset - 2) === "\\" && (uchar.test(item.slice(offset - 1, offset + 4)) === true || xchar.test(item.slice(offset - 1, offset + 2)) === true)) {
+                                str  = item.slice(0, offset - 2) + item.charAt(0);
+                                item = item.charAt(0) + item.slice(offset - 2);
+                            } else if (item.charAt(offset - 1) === "\\") {
+                                str  = item.slice(0, offset - 1) + item.charAt(0);
+                                item = item.charAt(0) + item.slice(offset - 1);
+                            } else {
+                                str  = item.slice(0, offset) + item.charAt(0);
+                                item = item.charAt(0) + item.slice(offset);
+                            }
+                            if (str.charAt(str.length - 2) === "\\") {
+                                str = str + str.charAt(0);
+                            }
+                            tokenpush(str, "literal");
+                            tokenpush("+", "operator");
+                        }
+                        if (item.length > wrap) {
+                            if (depth[a] === "object" || depth[a] === "array") {
+                                destructfix(true, false);
+                            }
+                            if (off === false && paren === true) {
+                                parenpush();
+                            }
+                            token.splice(a, 1);
+                            types.splice(a, 1);
+                            lines.splice(a, 1);
+                            depth.splice(a, 1);
+                            begin.splice(a, 1);
+                            b    = b - 1;
+                            item = item.slice(1, item.length - 1);
+                            bb   = Math.floor(item.length / wrap) * wrap;
+                            for (aa = 0; aa < bb; aa = aa + wrap) {
+                                cc = aa + wrap + dd;
+                                if (item.charAt(cc - 5) === "\\" && uchar.test(item.slice(cc - 4, cc + 1)) === true) {
+                                    slash(5, true);
+                                } else if (item.charAt(cc - 4) === "\\" && uchar.test(item.slice(cc - 3, cc + 2)) === true) {
+                                    slash(4, true);
+                                } else if (item.charAt(cc - 3) === "\\" && (uchar.test(item.slice(cc - 2, cc + 3)) === true || xchar.test(item.slice(cc - 2, cc + 1)) === true)) {
+                                    slash(3, true);
+                                } else if (item.charAt(cc - 2) === "\\" && (uchar.test(item.slice(cc - 1, cc + 4)) === true || xchar.test(item.slice(cc - 1, cc + 2)) === true)) {
+                                    slash(2, true);
+                                } else if (item.charAt(cc - 1) === "\\") {
+                                    slash(1, true);
+                                } else {
+                                    ff = 0;
+                                }
+                                if (item.charAt(cc - 1) === "\\") {
+                                    slash(1, false);
+                                }
+                                if (aa > 0 && dd < 0) {
+                                    aa = aa - 1;
+                                    dd = 0;
+                                }
+                                if (item.charAt(cc - 1) === "\\") {
+                                    str = qchar + item.slice(ee, cc - 1) + qchar;
+                                    ee  = cc - 1;
+                                    aa  = aa - 1;
+                                } else {
+                                    str = qchar + item.slice(ee, cc) + qchar;
+                                    ee  = cc;
+                                }
+                                if (item.charAt(cc) === "\\") {
+                                    aa = aa - ff;
+                                }
+                                tokenpush(str, "literal");
+                                if (aa < item.length - wrap) {
+                                    tokenpush("+", "operator");
+                                }
+                            }
+                            if (aa < item.length) {
+                                tokenpush(qchar + item.slice(aa, aa + wrap) + qchar, "literal");
+                            }
+                            if (paren === true) {
+                                tokenpush(")", "end");
+                            }
+                            a  = a - 1;
+                            x  = x - 1;
+                            aa = a + 1;
+                            do {
+                                aa = aa + 1;
+                                if (types[aa - 1] === "start") {
+                                    begin[aa - 1] = (aa - 1);
+                                } else if (begin[aa - 1] > bgn) {
+                                    begin[aa - 1] = begin[aa - 1] + x;
+                                }
+                            } while (aa < b);
+                            ctoke = token[a];
+                            ctype = types[a];
+                            ltoke = token[a - 1];
+                            ltype = types[a - 1];
+                        } else {
+                            if (off === true) {
+                                aa = a;
+                                do {
+                                    aa = aa + 1;
+                                    if (types[aa - 1] === "start") {
+                                        begin[aa - 1] = (aa - 1);
+                                    } else if (begin[aa - 1] > bgn) {
+                                        begin[aa - 1] = begin[aa - 1] + x;
+                                    }
+                                } while (aa < b);
+                            }
+                            token[a] = item;
+                            level.push(-10);
+                        }
+                        ctoke = token[a];
+                        ctype = "string";
+                    },
+                    literal       = function jspretty__beautify_literal() {
+                        if (ctoke.indexOf("#!/") === 0) {
+                            level.push(indent);
+                        } else {
+                            if (ctoke.charAt(0) === "}") {
+                                level[a - 1] = -20;
+                            }
+                            if (options.bracepadding === true && ctoke.charAt(0) === "}" && ctoke.charAt(ctoke.length - 1) === "`") {
+                                level[a - 1] = -10;
+                            }
+                            if (options.wrap > 0 && ctoke.length > options.wrap && (ctoke.charAt(0) === "\"" || ctoke.charAt(0) === "'")) {
+                                strwrap(0);
+                            } else {
+                                level.push(-10);
+                            }
+                        }
+                        if ((ltoke === "," || ltype === "start") && (depth[a] === "object" || depth[a] === "array") && destruct[destruct.length - 1] === false && a > 0) {
+                            level[a - 1] = indent;
+                        }
+                    },
+                    endExtraInd   = function jspretty__beautify_endExtraInd() {
+                        var ei = extraindent[extraindent.length - 1],
+                            c  = 0;
+                        if (ei === undefined) {
+                            return;
+                        }
+                        c = ei.length - 1;
+                        if (c < 1 && ei[c] < 0 && (ctoke === ";" || ctoke === "x;" || ctoke === ")" || ctoke === "x)" || ctoke === "}" || ctoke === "x}")) {
+                            return ei.pop();
+                        }
+                        if (c < 0 || ei[c] < 0) {
+                            return;
+                        }
+                        if (ctoke === ":") {
+                            if (token[ei[c]] !== "?") {
+                                do {
+                                    ei.pop();
+                                    c      = c - 1;
+                                    indent = indent - 1;
+                                } while (c > -1 && ei[c] > -1 && token[ei[c]] !== "?");
+                            }
+                            ei[c]        = a;
+                            level[a - 1] = indent;
+                        } else {
+                            do {
+                                ei.pop();
+                                c      = c - 1;
+                                indent = indent - 1;
+                            } while (c > -1 && ei[c] > -1);
+                        }
+                        if ((depth[a] === "array" || ctoke === ",") && ei.length < 1) {
+                            ei.push(-1);
+                        }
+                    },
+                    comment       = function jspretty__beautify_comment() {
+                        destructfix(false, false);
+                        if (token[a - 1] === ",") {
+                            level[a - 1] = indent;
+                        } else if (lines[a - 1] === 0 && types[a - 1] !== "comment" && types[a - 1] !== "comment-inline") {
+                            level[a - 1] = -20;
+                        } else if (ltoke === "=" && (/^(\/\*\*\s*@[a-z_]+\s)/).test(ctoke) === true) {
+                            level[a - 1] = -10;
+                        } else {
+                            level[a - 1] = indent;
+                        }
+                        level.push(indent);
+                    },
+                    commentInline = function jspretty__beautify_commentInline() {
+                        destructfix(false, false);
+                        if (a < b - 1 && depth[a + 1] !== "block" && (token[a + 1] === "{" || token[a + 1] === "x{")) {
+                            token[a]     = token[a + 1];
+                            types[a]     = "start";
+                            depth[a]     = depth[a + 1];
+                            begin[a]     = begin[a + 1];
+                            lines[a]     = lines[a + 1];
+                            token[a + 1] = ctoke;
+                            types[a + 1] = ctype;
+                            a            = a - 1;
+                        } else {
+                            level[a - 1] = -10;
+                            if (depth[a] === "paren" || depth[a] === "method") {
+                                level.push(indent + 2);
+                            } else {
+                                level.push(indent);
+                            }
+                        }
+                    },
+                    template      = function jspretty__beautify_template() {
+                        if (ctype === "template_else") {
+                            level[a - 1] = indent - 1;
+                            level.push(indent);
+                        } else if (ctype === "template_start") {
+                            indent = indent + 1;
+                            if (lines[a - 1] < 1) {
+                                level[a - 1] = -20;
+                            }
+                            if (lines[a] > 0) {
+                                level.push(indent);
+                            } else {
+                                level.push(-20);
+                            }
+                        } else if (ctype === "template_end") {
+                            indent = indent - 1;
+                            if (ltype === "template_start" || lines[a - 1] < 1) {
+                                level[a - 1] = -20;
+                            } else {
+                                level[a - 1] = indent;
+                            }
+                            if (lines[a] > 0) {
+                                level.push(indent);
+                            } else {
+                                level.push(-20);
+                            }
+                        } else if (ctype === "template") {
+                            if (lines[a] > 0) {
+                                level.push(indent);
+                            } else {
+                                level.push(-20);
+                            }
+                        }
+                    },
+                    markup        = function jspretty__beautify_markup() {
+                        if ((token[a + 1] !== "," && ctoke.indexOf("/>") !== ctoke.length - 2) || (token[a + 1] === "," && token[begin[a] - 3] !== "React")) {
+                            destructfix(false, false);
+                        }
+                        if (ltoke === "return" || ltoke === "?" || ltoke === ":") {
+                            level[a - 1] = -10;
+                            level.push(-20);
+                        } else if (ltype === "start" || (token[a - 2] === "return" && depth[a - 1] === "method")) {
+                            level.push(indent);
+                        } else {
+                            level.push(-20);
+                        }
+                        if (varline[varline.length - 1] === true) {
+                            markupvar.push(a);
+                        }
+                    },
+                    separator     = function jspretty__beautify_separator() {
+                        var methtest      = false,
+                            ei            = (extraindent[extraindent.length - 1] === undefined)
+                                ? []
+                                : extraindent[extraindent.length - 1],
+                            propertybreak = function jspretty__beautify_separator_propertybreak() {
+                                var c = 0,
+                                    d = begin[a],
+                                    e = 1;
+                                if (ctoke === "." && ltype !== "end" && types[a + 2] !== "start") {
+                                    level[a - 1] = -20;
+                                    return;
+                                }
+                                for (c = a - 2; c > d; c = c - 1) {
+                                    if (begin[c] === d) {
+                                        if (token[c] === ".") {
+                                            e = e + 1;
+                                        }
+                                        if (token[c] === ";" || token[c] === "," || types[c] === "operator" || token[c] === "return" || token[c] === "break" || token[c] === "continue" || types[c] === "comment" || types[c] === "comment-inline") {
+                                            break;
+                                        }
+                                        if (types[c - 1] === "end") {
+                                            if (types[c] !== "start" && types[c] !== "operator" && token[c] !== ".") {
+                                                break;
+                                            }
+                                            c = begin[c - 1];
+                                        }
+                                    }
+                                }
+                                if (e < 2) {
+                                    level[a - 1] = -20;
+                                    return;
+                                }
+                                indent = indent + 1;
+                                if (token[c] !== ".") {
+                                    do {
+                                        c = c + 1;
+                                    } while (c < a && (token[c] !== "." || begin[c] !== d));
+                                }
+                                for (e = c; e < a; e = e + 1) {
+                                    if (token[e] === "." && begin[e] === d) {
+                                        level[e - 1] = indent;
+                                    } else if (level[e] > -9) {
+                                        level[e] = level[e] + 1;
+                                    }
+                                }
+                                level[a - 1] = indent;
+                                ei.push(a);
+                            };
+                        if (ctoke === "::") {
+                            level[a - 1] = -20;
+                            return level.push(-20);
+                        }
+                        if ((options.methodchain === "chain" || (options.methodchain === "none" && lines[a] < 1)) && types[a - 1] === "comment-inline" && a > 1) {
+                            return (function jspretty__beautify_separator_commentfix() {
+                                var c    = 0,
+                                    d    = b,
+                                    last = token[a - 1];
+                                level[a - 2] = -20;
+                                level[a - 1] = -20;
+                                for (c = a; c < d; c = c + 1) {
+                                    token[c - 1] = token[c];
+                                    types[c - 1] = types[c];
+                                    if (token[c] === ";" || token[c] === "x;" || token[c] === "{" || token[c] === "x{" || lines[c] > 0) {
+                                        token[c] = last;
+                                        types[c] = "comment-inline";
+                                        a        = a - 1;
+                                        return;
+                                    }
+                                }
+                                token[c - 1] = last;
+                                types[c - 1] = "comment-inline";
+                                a            = a - 1;
+                            }());
+                        }
+                        if (ctoke === ".") {
+                            if (token[begin[a]] !== "(" && token[begin[a]] !== "x(" && ei.length > 0) {
+                                if (depth[a] === "object" || depth[a] === "array") {
+                                    destructfix(true, false);
+                                } else {
+                                    destructfix(false, false);
+                                }
+                            }
+                            if ((options.methodchain === "chain" || (options.methodchain === "none" && lines[a] < 1)) && ltype !== "comment" && ltype !== "comment-inline") {
+                                level[a - 1] = -20;
+                            } else {
+                                if (token[begin[a]] !== "(" && token[begin[a]] !== "x(" && (types[a + 2] === "start" || ltoke === ")" || (token[ei[ei.length - 1]] !== "."))) {
+                                    if (token[ei[ei.length - 1]] !== "." && options.nochainindent === false) {
+                                        propertybreak();
+                                    } else {
+                                        level[a - 1] = indent;
+                                    }
+                                } else if (token[ei[ei.length - 1]] === ".") {
+                                    level[a - 1] = indent;
+                                } else {
+                                    level[a - 1] = -20;
+                                }
+                            }
+                            if (types[a - 1] === "comment" || types[a - 1] === "comment-inline") {
+                                if (ei > 0) {
+                                    level[a - 1] = indent;
+                                } else {
+                                    level[a - 1] = indent + 1;
+                                }
+                            }
+                            return level.push(-20);
+                        }
+                        if (ctoke === ",") {
+                            if (list[list.length - 1] === false && (depth[a] === "object" || depth[a] === "array" || depth[a] === "paren" || depth[a] === "expression" || depth[a] === "method")) {
+                                list[list.length - 1] = true;
+                                if (token[begin[a]] === "(") {
+                                    (function jspretty__beautify_separator_plusfix() {
+                                        var aa = a;
+                                        do {
+                                            aa = aa - 1;
+                                            if (begin[aa] === begin[a] && token[aa] === "+" && level[aa] > -9) {
+                                                level[aa] = level[aa] + 2;
+                                            }
+                                        } while (aa > begin[a]);
+                                    }());
+                                }
+                            }
+                            if (ei.length > 0) {
+                                if (ei[ei.length - 1] > -1) {
+                                    endExtraInd();
+                                }
+                                level[a - 1] = -20;
+                                return level.push(indent);
+                            }
+                            if (token[a - 2] === ":" && token[a - 4] === "where") {
+                                level[a - 1] = -20;
+                                return level.push(-10);
+                            }
+                            level[a - 1]                    = -20;
+                            itemcount[itemcount.length - 1] = itemcount[itemcount.length - 1] + 1;
+                            if ((token[begin[a]] === "(" || token[begin[a]] === "x(") && options.jsx === false && depth[a] !== "global" && (types[a - 1] !== "literal" || token[a - 2] !== "+" || (types[a - 1] === "literal" && token[a - 2] === "+" && types[a - 3] !== "literal"))) {
+                                return level.push(-10);
+                            }
+                            if (ltype === "word" && types[a - 2] === "word" && "var-let-const-from".indexOf(token[a - 2]) < 0 && (types[a - 3] === "end" || token[a - 3] === ";")) {
+                                wordlist[wordlist.length - 1] = true;
+                                return level.push(-10);
+                            }
+                            if (wordlist[wordlist.length - 1] === true || depth[a] === "notation") {
+                                return level.push(-10);
+                            }
+                            if (destruct[destruct.length - 1] === true && itemcount[itemcount.length - 1] > 4 && (depth[a] === "array" || depth[a] === "object")) {
+                                destructfix(true, true);
+                            }
+                            if (depth[a] === "object") {
+                                if (destruct[destruct.length - 1] === true && types[begin[a] - 1] !== "word" && token[begin[a] - 1] !== "(" && token[begin[a] - 1] !== "x(") {
+                                    (function jspretty__beautify_separator_objDestruct() {
+                                        var aa = 0,
+                                            bb = 0;
+                                        for (aa = a - 1; aa > -1; aa = aa - 1) {
+                                            if (types[aa] === "end") {
+                                                bb = bb + 1;
+                                            } else if (types[aa] === "start") {
+                                                bb = bb - 1;
+                                            }
+                                            if (bb < 0 || (bb === 0 && token[aa] === ",")) {
+                                                return;
+                                            }
+                                            if (bb === 0 && token[aa] === ":") {
+                                                return destructfix(true, false);
+                                            }
+                                        }
+                                    }());
+                                }
+                            }
+                            if (types[a - 1] === "word" && token[a - 2] === "for") {
+                                //This is for Volt templates
+                                return level.push(-10);
+                            }
+                            if (destruct[destruct.length - 1] === false || (token[a - 2] === "+" && ltype === "literal" && level[a - 2] > 0 && (ltoke.charAt(0) === "\"" || ltoke.charAt(0) === "'"))) {
+                                if (depth[a] === "method") {
+                                    if (token[a - 2] === "+" && (ltoke.charAt(0) === "\"" || ltoke.charAt(0) === "'") && (token[a - 3].charAt(0) === "\"" || token[a - 3].charAt(0) === "'")) {
+                                        return level.push(indent + 2);
+                                    }
+                                    if (token[a - 2] !== "+") {
+                                        return level.push(-10);
+                                    }
+                                }
+                                return level.push(indent);
+                            }
+                            if (list[list.length - 1] === true) {
+                                if (assignlist[assignlist.length - 1] === true && varline[varline.length - 1] === false) {
+                                    assignlist[assignlist.length - 1] = false;
+                                    varlen[varlen.length - 1]         = [];
+                                }
+                                return (function jspretty__beautify_separator_inList() {
+                                    var c = 0,
+                                        d = 0;
+                                    for (c = a - 1; c > -1; c = c - 1) {
+                                        if (types[c] === "end") {
+                                            d = d + 1;
+                                        }
+                                        if (types[c] === "start") {
+                                            d = d - 1;
+                                        }
+                                        if (d === -1) {
+                                            if (token[c] === "[" && token[c + 1] !== "]" && token[c + 2] !== "]") {
+                                                if (destruct[destruct.length - 1] === false || arrbreak[arrbreak.length - 1] === true) {
+                                                    level[c] = indent;
+                                                } else if (methtest === false && destruct[destruct.length - 1] === true) {
+                                                    level[c] = -20;
+                                                }
+                                                if (token[a - 2] === "+" && ltype === "literal" && level[a - 2] > 0 && (ltoke.charAt(0) === "\"" || ltoke.charAt(0) === "'")) {
+                                                    for (d = a - 2; d > c; d = d - 2) {
+                                                        if (token[d] !== "+") {
+                                                            return;
+                                                        }
+                                                        if (token[d - 1].charAt(0) !== "\"" && token[d - 1].charAt(0) !== "'") {
+                                                            level[d] = -10;
+                                                        }
+                                                    }
+                                                    return;
+                                                }
+                                            }
+                                            if (arrbreak[arrbreak.length - 1] === true) {
+                                                return level.push(indent);
+                                            }
+                                            return level.push(-10);
+                                        }
+                                    }
+                                    if (arrbreak[arrbreak.length - 1] === true) {
+                                        return level.push(indent);
+                                    }
+                                    return level.push(-10);
+                                }());
+                            }
+                            if (varline[varline.length - 1] === true && token[begin[a] - 1] !== "for") {
+                                if (ltoke !== "]") {
+                                    (function jspretty__beautify_separator_varline() {
+                                        var c     = 0,
+                                            brace = false;
+                                        for (c = a - 1; c > -1; c = c - 1) {
+                                            if (token[c] === "]") {
+                                                brace = true;
+                                            }
+                                            if (types[c] === "start") {
+                                                if (token[c] === "[" && token[c + 1] !== "]" && brace === false) {
+                                                    level[c] = indent;
+                                                }
+                                                return;
+                                            }
+                                        }
+                                    }());
+                                }
+                                if (ltype === "literal" && token[a - 2] === "+" && (ltoke.charAt(0) === "\"" || ltoke.charAt(0) === "'")) {
+                                    return level.push(indent);
+                                }
+                                return level.push(indent);
+                            }
+                            if (destruct[destruct.length - 1] === true && depth[a] !== "object") {
+                                return level.push(-10);
+                            }
+                            return level.push(indent);
+                        }
+                        if (ctoke === ";" || ctoke === "x;") {
+                            endExtraInd();
+                            if (token[begin[a] - 1] !== "for") {
+                                destructfix(false, false);
+                            }
+                            wordlist[wordlist.length - 1] = false;
+                            if (ctoke === "x;") {
+                                scolon = scolon + 1;
+                            }
+                            level[a - 1] = -20;
+                            if (varline[varline.length - 1] === true) {
+                                varline[varline.length - 1] = false;
+                                if (depth[a] !== "method" && varlen.length > 0 && varlen[varlen.length - 1].length > 1) {
+                                    varlist.push(varlen[varlen.length - 1]);
+                                }
+                                varlen[varlen.length - 1] = [];
+                                (function jspretty__beautify_separator_varlinefix() {
+                                    var c = 0,
+                                        d = 0;
+                                    for (c = a - 1; c > -1; c = c - 1) {
+                                        if (types[c] === "start") {
+                                            d = d + 1;
+                                        }
+                                        if (types[c] === "end") {
+                                            d = d - 1;
+                                        }
+                                        if (d > 0) {
+                                            return;
+                                        }
+                                        if (d === 0) {
+                                            if (token[c] === "var" || token[c] === "let" || token[c] === "const") {
+                                                return;
+                                            }
+                                            if (token[c] === ",") {
+                                                indent = indent - 1;
+                                                return;
+                                            }
+                                        }
+                                    }
+                                }());
+                            }
+                            if (begin[a] > 0 && token[begin[a] - 1] === "for" && depth[a] !== "for") {
+                                return level.push(-10);
+                            }
+                            return level.push(indent);
+                        }
+                    },
+                    start         = function jspretty__beautify_start() {
+                        var deep   = depth[a],
+                            deeper = (a === 0)
+                                ? depth[a]
+                                : depth[a - 1];
+                        if (ltoke === ")" || ((deeper === "object" || deeper === "array") && ltoke !== "]")) {
+                            if (deep !== "method" || (deep === "method" && token[a + 1] !== ")" && token[a + 2] !== ")")) {
+                                if (ltoke === ")" && (deep !== "function" || token[begin[begin[a - 1] - 1]] === "(" || token[begin[begin[a - 1] - 1]] === "x(")) {
+                                    destructfix(false, false);
+                                } else if (types[a + 1] !== "end" && types[a + 2] !== "end") {
+                                    destructfix(true, false);
+                                }
+                            }
+                        }
+                        list.push(false);
+                        extraindent.push([]);
+                        assignlist.push(false);
+                        arrbreak.push(false);
+                        wordlist.push(false);
+                        itemcount.push(0);
+                        varlen.push([]);
+                        if (options.neverflatten === true || options.qml === true || deep === "attribute" || ltype === "generic" || (deep === "class" && ltoke !== "(" && ltoke !== "x(") || (ctoke === "[" && token[a + 1] === "function")) {
+                            destruct.push(false);
+                        } else {
+                            if (deep === "expression" || deep === "method") {
+                                destruct.push(true);
+                            } else if ((deep === "object" || deep === "class") && (ltoke === "(" || ltoke === "x(" || ltype === "word")) {
+                                //array or object literal following `return` or `(`
+                                destruct.push(true);
+                            } else if (deep === "array" || ctoke === "(" || ctoke === "x(") {
+                                //array, method, paren
+                                destruct.push(true);
+                            } else if (ctoke === "{" && deep === "object" && ltype !== "operator" && ltype !== "start" && ltype !== "literal" && deeper !== "object" && deeper !== "array" && a > 0) {
+                                //curly brace not in a list and not assigned
+                                destruct.push(true);
+                            } else {
+                                //not destructured (multiline)
+                                destruct.push(false);
+                            }
+                        }
+                        if (ctoke !== "(" && ctoke !== "x(" && depth[a] !== "attribute") {
+                            //if (ctoke !== "[" || (ctoke === "[" && token[a + 1] !== "(")) {
+                                indent = indent + 1;
+                            //}
+                        }
+                        if (ctoke === "{" || ctoke === "x{") {
+                            if (ctoke === "{") {
+                                varline.push(false);
+                            }
+                            if (types[a - 1] !== "comment" && types[a - 1] !== "comment-inline") {
+                                if (ltype === "markup") {
+                                    level[a - 1] = indent;
+                                } else if (options.braces === true && ltype !== "operator" && ltoke !== "return") {
+                                    level[a - 1] = indent - 1;
+                                } else if (deep === "function" || ltoke === ")" || ltoke === "x)" || ltoke === "," || ltoke === "}" || ltype === "markup") {
+                                    level[a - 1] = -10;
+                                } else if (ltoke === "{" || ltoke === "x{" || ltoke === "[" || ltoke === "}" || ltoke === "x}") {
+                                    level[a - 1] = indent - 1;
+                                }
+                            }
+                            if (deep === "object") {
+                                if (options.formatObject === "indent") {
+                                    destruct[destruct.length - 1] = false;
+                                    return level.push(indent);
+                                }
+                                if (options.formatObject === "inline") {
+                                    destruct[destruct.length - 1] = true;
+                                    return level.push(-20);
+                                }
+                            }
+                            if (deep === "switch") {
+                                if (options.nocaseindent === true) {
+                                    return level.push(indent - 1);
+                                }
+                                indent = indent + 1;
+                                return level.push(indent);
+                            }
+                            if (destruct[destruct.length - 1] === true) {
+                                if (ltype !== "word") {
+                                    return level.push(-20);
+                                }
+                            }
+                            return level.push(indent);
+                        }
+                        if (ctoke === "(" || ctoke === "x(") {
+                            if (ltoke === "-" && (token[a - 2] === "(" || token[a - 2] === "x(")) {
+                                level[a - 2] = -20;
+                            }
+                            // the start of scope, at least for counting, is pushed back from the opening of
+                            // the block to the paranthesis containing arguments so that the arguments can
+                            // be tagged as variables of the coming scope
+                            if (options.jsscope !== "none" || options.mode === "minify") {
+                                // a 0 is pushed into the start of scope, but this number is updated in the
+                                // "end" function to indicate the index where the scope ends
+                                if (ltoke === "function" || token[a - 2] === "function") {
+                                    meta[meta.length - 1] = 0;
+                                }
+                            }
+                            if (ltype === "end" && deeper !== "if" && deeper !== "for" && deeper !== "catch" && deeper !== "else" && deeper !== "do" && deeper !== "try" && deeper !== "finally" && deeper !== "catch") {
+                                if (types[a - 1] === "comment" || types[a - 1] === "comment-inline") {
+                                    level[a - 1] = indent;
+                                } else {
+                                    level[a - 1] = -20;
+                                }
+                            }
+                            if (ltoke === "async") {
+                                level[a - 1] = -10;
+                            } else if (deep === "method" || (token[a - 2] === "function" && ltype === "word")) {
+                                if (ltoke === "import" || ltoke === "in" || options.functionname === true) {
+                                    level[a - 1] = -10;
+                                } else if ((ltoke === "}" && depth[a - 1] === "function") || ltype === "word") {
+                                    level[a - 1] = -20;
+                                } else if (deeper !== "method" && deep !== "method") {
+                                    level[a - 1] = indent;
+                                }
+                            }
+                            if (ltoke === "+" && (token[a - 2].charAt(0) === "\"" || token[a - 2].charAt(0) === "'")) {
+                                return level.push(indent);
+                            }
+                            if (ltoke === "}" || ltoke === "x}") {
+                                return level.push(-20);
+                            }
+                            if ((ltoke === "-" && (a < 2 || (token[a - 2] !== ")" && token[a - 2] !== "x)" && token[a - 2] !== "]" && types[a - 2] !== "word" && types[a - 2] !== "literal"))) || (options.space === false && ltoke === "function")) {
+                                level[a - 1] = -20;
+                            }
+                            return level.push(-20);
+                        }
+                        if (ctoke === "[") {
+                            if (ltoke === "[") {
+                                list[list.length - 2] = true;
+                            }
+                            if (ltoke === "return" || ltoke === "var" || ltoke === "let" || ltoke === "const") {
+                                level[a - 1] = -10;
+                            } else if (types[a - 1] !== "comment" && types[a - 1] !== "comment-inline" && depth[a - 1] !== "attribute" && (ltype === "end" || ltype === "word")) {
+                                level[a - 1] = -20;
+                            } else if (ltoke !== "{" && (ltoke === "[" || ltoke === "{" || ltoke === "x{")) {
+                                level[a - 1] = indent - 1;
+                            }
+                            if (depth[a] === "attribute") {
+                                return level.push(-20);
+                            }
+                            if (options.formatArray === "indent") {
+                                destruct[destruct.length - 1] = false;
+                                return level.push(indent);
+                            }
+                            if (options.formatArray === "inline") {
+                                destruct[destruct.length - 1] = true;
+                                return level.push(-20);
+                            }
+                            if (deep === "method" || destruct[destruct.length - 1] === true) {
+                                return level.push(-20);
+                            }
+                            return (function jspretty__beautify_start_squareBrace() {
+                                var c = 0;
+                                for (c = a + 1; c < b; c = c + 1) {
+                                    if (token[c] === "]") {
+                                        return level.push(-20);
+                                    }
+                                    if (token[c] === ",") {
+                                        return level.push(indent);
+                                    }
+                                }
+                                return level.push(-20);
+                            }());
+                        }
+                    },
+                    end           = function jspretty__beautify_end() {
+                        var ei = (extraindent[extraindent.length - 1] === undefined)
+                            ? []
+                            : extraindent[extraindent.length - 1];
+                        if (ctoke === ")" && token[a + 1] === "." && ei[ei.length - 1] > -1 && token[ei[0]] !== ":") {
+                            (function jspretty__beautify_end_brokenParen() {
+                                var c = begin[a],
+                                    d = false,
+                                    e = false;
+                                do {
+                                    c = c - 1;
+                                } while (c > 0 && level[c] < -9);
+                                d = (level[c] === indent);
+                                c = a + 1;
+                                do {
+                                    c = c + 1;
+                                    if (token[c] === "{") {
+                                        e = true;
+                                        break;
+                                    }
+                                    if (begin[c] === begin[a + 1] && (types[c] === "separator" || types[c] === "end")) {
+                                        break;
+                                    }
+                                } while (c < b);
+                                if (d === false && e === true && extraindent.length > 1) {
+                                    extraindent[extraindent.length - 2].push(begin[a]);
+                                    indent = indent + 1;
+                                }
+                            }());
+                        }
+                        if (token[a + 1] === "," && (depth[a] === "object" || depth[a] === "array")) {
+                            destructfix(true, false);
+                        }
+                        if ((token[a + 1] === "}" || token[a + 1] === "]") && (depth[a] === "object" || depth[a] === "array") && token[begin[a] - 1] === ",") {
+                            destructfix(true, false);
+                        }
+                        if (depth[a] !== "attribute") {
+                            if (ctoke !== ")" && ctoke !== "x)" && (ltype !== "markup" || (ltype === "markup" && token[a - 2] !== "return"))) {
+                                indent = indent - 1;
+                            }
+                            if (ctoke === "}" && depth[a] === "switch" && options.nocaseindent === false) {
+                                indent = indent - 1;
+                            }
+                        }
+                        if (ctoke === "}" || ctoke === "x}") {
+                            if (types[a - 1] !== "comment" && types[a - 1] !== "comment-inline" && ltoke !== "{" && ltoke !== "x{" && ltype !== "end" && ltype !== "literal" && ltype !== "separator" && ltoke !== "++" && ltoke !== "--" && varline[varline.length - 1] === false && (a < 2 || token[a - 2] !== ";" || token[a - 2] !== "x;" || ltoke === "break" || ltoke === "return")) {
+                                (function jspretty__beautify_end_curlyBrace() {
+                                    var c       = 0,
+                                        d       = 1,
+                                        assign  = false,
+                                        listlen = list.length;
+                                    for (c = a - 1; c > -1; c = c - 1) {
+                                        if (types[c] === "end") {
+                                            d = d + 1;
+                                        }
+                                        if (types[c] === "start") {
+                                            d = d - 1;
+                                        }
+                                        if (d === 1) {
+                                            if (token[c] === "=" || token[c] === ";" || token[c] === "x;") {
+                                                assign = true;
+                                            }
+                                            if (c > 0 && token[c] === "return" && (token[c - 1] === ")" || token[c - 1] === "x)" || token[c - 1] === "{" || token[c - 1] === "x{" || token[c - 1] === "}" || token[c - 1] === "x}" || token[c - 1] === ";" || token[c - 1] === "x;")) {
+                                                indent       = indent - 1;
+                                                level[a - 1] = indent;
+                                                return;
+                                            }
+                                            if ((token[c] === ":" && ternary.length === 0) || (token[c] === "," && assign === false && varline[varline.length - 1] === false)) {
+                                                return;
+                                            }
+                                            if ((c === 0 || token[c - 1] === "{" || token[c - 1] === "x{") || token[c] === "for" || token[c] === "if" || token[c] === "do" || token[c] === "function" || token[c] === "while" || token[c] === "var" || token[c] === "let" || token[c] === "const" || token[c] === "with") {
+                                                if (list[listlen - 1] === false && listlen > 1 && (a === b - 1 || (token[a + 1] !== ")" && token[a + 1] !== "x)")) && depth[a] !== "object") {
+                                                    indent = indent - 1;
+                                                }
+                                                if (varline[varline.length - 1] === true) {
+                                                    indent = indent - 1;
+                                                }
+                                                return;
+                                            }
+                                        }
+                                    }
+                                }());
+                            }
+                            //this is the bulk of logic identifying scope start and end
+                            if (depth[a] === "function" && (options.jsscope !== "none" || options.mode === "minify")) {
+                                (function jspretty__beautify_end_jsscope() {
+                                    var c     = 0,
+                                        d     = 1,
+                                        build = [],
+                                        paren = false;
+                                    for (c = a - 1; c > -1; c = c - 1) {
+                                        if (types[c] === "end") {
+                                            d = d + 1;
+                                        } else if (types[c] === "start") {
+                                            d = d - 1;
+                                        }
+                                        if (d < 0) {
+                                            return;
+                                        }
+                                        if (meta[c] === "v" && token[c] !== build[build.length - 1]) {
+                                            build.push(token[c]);
+                                        } else if (d === 1 && token[c] === ")") {
+                                            paren = true;
+                                        } else if (d === 1 && paren === true && types[c] === "word" && token[c] !== build[build.length - 1]) {
+                                            build.push(token[c]);
+                                        }
+                                        if (c === lettest) {
+                                            meta[c] = a - 1;
+                                            if (token[c] === "let" || token[c] === "const") {
+                                                meta[meta.length - 2] = [build, true];
+                                            }
+                                            build   = [];
+                                            lettest = -1;
+                                        }
+                                        if (c > 0 && token[c - 1] === "function" && types[c] === "word" && token[c] !== build[build.length - 1]) {
+                                            build.push(token[c]);
+                                        }
+                                        if (d === 0) {
+                                            if (token[c] === "function") {
+                                                if (types[c + 1] === "word") {
+                                                    meta[c + 2] = a;
+                                                } else {
+                                                    meta[c + 1] = a;
+                                                }
+                                                meta[meta.length - 1] = [build, false];
+                                                return;
+                                            }
+                                        }
+                                    }
+                                }());
+                            }
+                        }
+                        if (options.bracepadding === false && ctoke !== "}" && ltype !== "markup") {
+                            level[a - 1] = -20;
+                        }
+                        if (options.bracepadding === true && ltype !== "start" && ltoke !== ";" && (level[begin[a]] < -9 || destruct[destruct.length - 1] === true)) {
+                            level[begin[a]] = -10;
+                            level[a - 1]    = -10;
+                            level.push(-20);
+                        } else if (options.qml === true) {
+                            if (ltype === "start" || ctoke === ")" || ctoke === "x)") {
+                                level[a - 1] = -20;
+                            } else {
+                                level[a - 1] = indent;
+                            }
+                            level.push(indent);
+                        } else if (depth[a] === "attribute") {
+                            level[a - 1] = -20;
+                            level.push(indent);
+                        } else if (depth[a] === "array" && (ei.length > 0 || arrbreak[arrbreak.length - 1] === true)) {
+                            endExtraInd();
+                            destruct[destruct.length - 1] = false;
+                            level[begin[a]]               = indent + 1;
+                            level[a - 1]                  = indent;
+                            level.push(-20);
+                        } else if ((depth[a] === "object" || (begin[a] === 0 && ctoke === "}")) && ei.length > 0) {
+                            endExtraInd();
+                            destruct[destruct.length - 1] = false;
+                            level[begin[a]]               = indent + 1;
+                            level[a - 1]                  = indent;
+                            level.push(-20);
+                        } else if (ctoke === ")" || ctoke === "x)") {
+                            if (options.wrap > 0 && ctoke === ")") {
+                                (function jspretty__beautify_end_parenWrap() {
+                                    var len   = 0,
+                                        aa    = 0,
+                                        short = 0,
+                                        first = 0,
+                                        inc   = 0,
+                                        comma = false,
+                                        array = false,
+                                        wrap  = options.wrap,
+                                        open  = begin[a],
+                                        ind   = (indent + 1),
+                                        exl   = ei.length,
+                                        ready = false,
+                                        mark  = false,
+                                        tern  = false;
+                                    if (level[open] < -9) {
+                                        aa = open;
+                                        do {
+                                            aa = aa + 1;
+                                        } while (aa < a && level[aa] < -9);
+                                        first = aa;
+                                        do {
+                                            len = len + token[aa].length;
+                                            if (level[aa] === -10) {
+                                                len = len + 1;
+                                            }
+                                            if (token[aa] === "(" && short > 0 && short < wrap - 1 && first === a) {
+                                                short = -1;
+                                            }
+                                            if (token[aa] === ")") {
+                                                inc = inc - 1;
+                                            } else if (token[aa] === "(") {
+                                                inc = inc + 1;
+                                            }
+                                            if (aa === open && inc > 0) {
+                                                short = len;
+                                            }
+                                            aa = aa - 1;
+                                        } while (aa > 0 && level[aa] < -9);
+                                        if (token[aa + 1] === ".") {
+                                            ind = level[aa] + 1;
+                                        }
+                                        if (len > wrap - 1 && ltoke !== "(" && short !== -1 && destruct[destruct.length - 2] === false) {
+                                            if ((token[open - 1] === "if" && list[list.length - 1] === true) || token[open - 1] !== "if") {
+                                                level[open] = ind;
+                                                if (token[open - 1] === "for") {
+                                                    aa = open;
+                                                    do {
+                                                        aa = aa + 1;
+                                                        if (token[aa] === ";" && begin[aa] === open) {
+                                                            level[aa] = ind;
+                                                        }
+                                                    } while (aa < a);
+                                                }
+                                            }
+                                        }
+                                    }
+                                    aa  = a;
+                                    len = 0;
+                                    do {
+                                        aa = aa - 1;
+                                        if (depth[aa] === "function") {
+                                            aa = begin[aa];
+                                        } else if (begin[aa] === open) {
+                                            if (token[aa] === "?") {
+                                                tern = true;
+                                            } else if (token[aa] === "," && comma === false) {
+                                                comma = true;
+                                                if (len >= wrap) {
+                                                    ready = true;
+                                                }
+                                            } else if (types[aa] === "markup" && mark === false) {
+                                                mark = true;
+                                            }
+                                            if (level[aa] > -9 && token[aa] !== "," && types[aa] !== "markup") {
+                                                len = 0;
+                                            } else {
+                                                if (level[aa] === -10) {
+                                                    len = len + 1;
+                                                }
+                                                len = len + token[aa].length;
+                                                if (len >= wrap && (comma === true || mark === true)) {
+                                                    ready = true;
+                                                }
+                                            }
+                                        } else {
+                                            if (level[aa] > -9) {
+                                                len = 0;
+                                            } else {
+                                                len = len + token[aa].length;
+                                                if (len >= wrap && (comma === true || mark === true)) {
+                                                    ready = true;
+                                                }
+                                            }
+                                        }
+                                    } while (aa > open && ready === false);
+                                    if (((comma === true || mark === true) && len >= wrap) || level[open] > -9) {
+                                        if (tern === true) {
+                                            ind = level[open];
+                                            if (token[open - 1] === "[") {
+                                                aa = a;
+                                                do {
+                                                    aa = aa + 1;
+                                                    if (types[aa] === "end" || token[aa] === "," || token[aa] === ";") {
+                                                        break;
+                                                    }
+                                                } while (aa < b);
+                                                if (token[aa] === "]") {
+                                                    ind = ind - 1;
+                                                    array = true;
+                                                }
+                                            }
+                                        } else if (exl > 0 && ei[exl - 1] > aa) {
+                                            ind = ind - exl;
+                                        }
+                                        destruct[destruct.length - 1] = false;
+                                        aa = a;
+                                        do {
+                                            aa = aa - 1;
+                                            if (begin[aa] === open) {
+                                                if (token[aa].indexOf("=") > -1 && types[aa] === "operator" && token[aa].indexOf("!") < 0 && token[aa].indexOf("==") < 0 && token[aa] !== "<=" && token[aa].indexOf(">") < 0) {
+                                                    len = aa;
+                                                    do {
+                                                        len = len - 1;
+                                                        if (begin[len] === open && (token[len] === ";" || token[len] === "," || len === open)) {
+                                                            break;
+                                                        }
+                                                    } while (len > open);
+                                                    if (token[len] !== ";" && varlen.length > 0) {
+                                                        varlen[varlen.length - 1].push(aa - 1);
+                                                    }
+                                                } else if (token[aa] === ",") {
+                                                    level[aa] = ind;
+                                                } else if (level[aa] > -9 && array === false && (token[open - 1] !== "for" || token[aa + 1] === "?" || token[aa + 1] === ":") && (token[begin[a]] !== "(" || token[aa] !== "+")) {
+                                                    level[aa] = level[aa] + 1;
+                                                }
+                                            } else if (level[aa] > -9 && array === false) {
+                                                level[aa] = level[aa] + 1;
+                                            }
+                                        } while (aa > open);
+                                        level[open]  = ind;
+                                        level[a - 1] = ind - 1;
+                                    } else {
+                                        level[a - 1] = -20;
+                                    }
+                                }());
+                                if (token[begin[a] - 1] === "+" && level[begin[a]] > -9) {
+                                    level[begin[a] - 1] = -10;
+                                }
+                            } else {
+                                level[a - 1] = -20;
+                            }
+                            level.push(-20);
+                        } else if (destruct[destruct.length - 1] === true) {
+                            if (ctoke === "]" && begin[a] - 1 > 0 && token[begin[begin[a] - 1]] === "[") {
+                                destruct[destruct.length - 2] = false;
+                            }
+                            if (begin[a] < level.length) {
+                                level[begin[a]] = -20;
+                            }
+                            level[a - 1] = -20;
+                            level.push(-20);
+                        } else if ((types[a - 1] === "comment" && token[a - 1].substr(0, 2) === "//") || types[a - 1] === "comment-inline") {
+                            if (token[a - 2] === "x}") {
+                                level[a - 3] = indent + 1;
+                            }
+                            level[a - 1] = indent;
+                            level.push(-20);
+                        } else if (types[a - 1] !== "comment" && types[a - 1] !== "comment-inline" && ((ltoke === "{" && ctoke === "}") || (ltoke === "[" && ctoke === "]"))) {
+                            level[a - 1] = -20;
+                            if (ctoke === "}" && options.titanium === true) {
+                                level.push(indent);
+                            } else {
+                                level.push(-20);
+                            }
+                        } else if (ctoke === "]") {
+                            if ((list[list.length - 1] === true && destruct[destruct.length - 1] === false) || (ltoke === "]" && level[a - 2] === indent + 1)) {
+                                level[a - 1]    = indent;
+                                level[begin[a]] = indent + 1;
+                            } else if (level[a - 1] === -10) {
+                                level[a - 1] = -20;
+                            }
+                            if (token[begin[a] + 1] === "function") {
+                                level[a - 1] = indent;
+                            } else if (list[list.length - 1] === false) {
+                                if (ltoke === "}" || ltoke === "x}") {
+                                    level[a - 1] = indent;
+                                }
+                                (function jspretty__beautify_end_squareBrace() {
+                                    var c = 0,
+                                        d = 1;
+                                    for (c = a - 1; c > -1; c = c - 1) {
+                                        if (token[c] === "]") {
+                                            d = d + 1;
+                                        }
+                                        if (token[c] === "[") {
+                                            d = d - 1;
+                                            if (d === 0) {
+                                                if (c > 0 && (token[c + 1] === "{" || token[c + 1] === "x{" || token[c + 1] === "[")) {
+                                                    level[c] = indent + 1;
+                                                    return;
+                                                }
+                                                if (token[c + 1] !== "[" || lastlist === false) {
+                                                    level[c] = -20;
+                                                    return;
+                                                }
+                                                return;
+                                            }
+                                        }
+                                        if (d === 1 && token[c] === "+" && level[c] > 1) {
+                                            level[c] = level[c] - 1;
+                                        }
+                                    }
+                                }());
+                            }
+                            level.push(-20);
+                        } else if (ctoke === "}" || ctoke === "x}" || list[list.length - 1] === true) {
+                            if (ctoke === "}" && ltoke === "x}" && token[a + 1] === "else") {
+                                level[a - 2] = indent + 2;
+                                level.push(-20);
+                            } else {
+                                level.push(indent);
+                            }
+                            level[a - 1] = indent;
+                        } else {
+                            level.push(-20);
+                        }
+                        endExtraInd();
+                        lastlist = list[list.length - 1];
+                        list.pop();
+                        extraindent.pop();
+                        arrbreak.pop();
+                        itemcount.pop();
+                        if (ctoke === "}" || (ctoke === ")" && level[a - 1] > -9)) {
+                            if (varline[varline.length - 1] === true || ltoke !== "{" || token[begin[a] - 2] === "interface") {
+                                if (varlen.length > 0 && varlen[varlen.length - 1].length > 1 && destruct[destruct.length - 1] === false) {
+                                    varlist.push(varlen[varlen.length - 1]);
+                                }
+                            }
+                            if (ctoke === "}") {
+                                varline.pop();
+                            }
+                        }
+                        wordlist.pop();
+                        varlen.pop();
+                        destruct.pop();
+                        assignlist.pop();
+                    },
+                    operator      = function jspretty__beautify_operator() {
+                        var ei = (extraindent[extraindent.length - 1] === undefined)
+                            ? []
+                            : extraindent[extraindent.length - 1];
+                        if (ei.length > 0 && ei[ei.length - 1] > -1 && depth[a] === "array") {
+                            arrbreak[arrbreak.length - 1] = true;
+                        }
+                        if (ctoke !== ":") {
+                            if (token[begin[a]] !== "(" && token[begin[a]] !== "x(" && destruct.length > 0) {
+                                destructfix(true, false);
+                            }
+                            if (ctoke !== "?" && token[ei[ei.length - 1]] === ".") {
+                                (function jspretty__beautify_operator_question() {
+                                    var c = a,
+                                        d = begin[c],
+                                        e = 0;
+                                    do {
+                                        if (begin[c] === d) {
+                                            if (token[c + 1] === "{" || token[c + 1] === "[" || token[c] === "function") {
+                                                return;
+                                            }
+                                            if (token[c] === "," || token[c] === ";" || types[c] === "end" || token[c] === ":") {
+                                                ei.pop();
+                                                indent = indent - 1;
+                                                return;
+                                            }
+                                            if (token[c] === "?" || token[c] === ":") {
+                                                if (token[ei[ei.length - 1]] === "." && e < 2) {
+                                                    ei[ei.length - 1] = d + 1;
+                                                }
+                                                return;
+                                            }
+                                            if (token[c] === ".") {
+                                                e = e + 1;
+                                            }
+                                        }
+                                        c = c + 1;
+                                    } while (c < b);
+                                }());
+                            }
+                        }
+                        if (ctoke === "!" || ctoke === "...") {
+                            if (ltoke === "}" || ltoke === "x}") {
+                                level[a - 1] = indent;
+                            }
+                            return level.push(-20);
+                        }
+                        if (ltoke === ";" || ltoke === "x;") {
+                            if (token[begin[a] - 1] !== "for") {
+                                level[a - 1] = indent;
+                            }
+                            return level.push(-20);
+                        }
+                        if (ctoke === "*") {
+                            if (ltoke === "function" || ltoke === "yield") {
+                                level[a - 1] = -20;
+                            } else {
+                                level[a - 1] = -10;
+                            }
+                            return level.push(-10);
+                        }
+                        if (ctoke === "?") {
+                            if (lines[a] === 0 && types[a - 2] === "word" && token[a - 2] !== "return" && token[a - 2] !== "in" && token[a - 2] !== "instanceof" && token[a - 2] !== "typeof" && ltype === "word") {
+                                if (types[a + 1] === "word" || ((token[a + 1] === "(" || token[a + 1] === "x(") && token[a - 2] === "new")) {
+                                    level[a - 1] = -20;
+                                    if (types[a + 1] === "word") {
+                                        return level.push(-10);
+                                    }
+                                    return level.push(-20);
+                                }
+                            }
+                            if (token[a + 1] === ":") {
+                                level[a - 1] = -20;
+                                return level.push(-20);
+                            }
+                            if (options.ternaryline === true) {
+                                level[a - 1] = -10;
+                            } else {
+                                (function jspretty__beautify_operator_ternObj() {
+                                    var c = a - 1;
+                                    do {
+                                        c = c - 1;
+                                    } while (c > -1 && level[c] < -9);
+                                    ei.push(a);
+                                    ternary.push(a);
+                                    indent = indent + 1;
+                                    if (level[c] === indent && token[c + 1] !== ":") {
+                                        indent = indent + 1;
+                                        ei.push(a);
+                                    }
+                                    level[a - 1] = indent;
+                                    if (token[begin[a]] === "(" && (ei.length < 2 || ei[0] === ei[1])) {
+                                        destruct[destruct.length - 1] = false;
+                                        if (a - 2 === begin[a]) {
+                                            level[begin[a]] = indent - 1;
+                                        } else {
+                                            level[begin[a]] = indent;
+                                        }
+                                        c = a - 2;
+                                        do {
+                                            if (types[c] === "end" && level[c - 1] > -1) {
+                                                break;
+                                            }
+                                            if (level[c] > -1) {
+                                                level[c] = level[c] + 1;
+                                            }
+                                            c = c - 1;
+                                        } while (c > begin[a]);
+                                    }
+                                }());
+                            }
+                        }
+                        if (ctoke === ":") {
+                            if (token[a - 2] === "where" && depth[a - 2] === depth[a]) {
+                                level[a - 1] = -10;
+                                return level.push(-10);
+                            }
+                            if ((token[a - 2] === "var" || token[a - 2] === "let" || token[a - 2] === "const" || token[a - 2] === "," || (depth[a] === "global" && options.jsx === true && ternary.length < 1)) && ltype === "word" && token[begin[a]] !== "(" && token[begin[a]] !== "x(") {
+                                level[a - 1] = -20;
+                                if (depth[a] === "object" || (varline[varline.length - 1] === true && token[begin[a]] !== "(" && token[begin[a]] !== "x(")) {
+                                    if (varlen.length > 0 && varlen[varlen.length - 1].length > 0 && token[varlen[varlen.length - 1][varlen[varlen.length - 1].length - 1] + 1] !== ctoke) {
+                                        if (varlen[varlen.length - 1].length > 1) {
+                                            varlist.push(varlen[varlen.length - 1]);
+                                        }
+                                        varlen[varlen.length - 1] = [];
+                                    }
+                                    varlen[varlen.length - 1].push(a - 1);
+                                }
+                                return level.push(-10);
+                            }
+                            if ((ltoke === ")" || ltoke === "x)") && token[begin[a - 1] - 2] === "function") {
+                                level[a - 1] = -20;
+                                return level.push(-10);
+                            }
+                            if (depth[a] === "attribute") {
+                                level[a - 1] = -20;
+                                return level.push(-10);
+                            }
+                            if (token[begin[a]] !== "(" && token[begin[a]] !== "x(" && (ltype === "word" || ltoke === ")" || ltoke === "]" || ltoke === "?") && (depth[a] === "map" || depth[a] === "class" || types[a + 1] === "word") && (ternary.length === 0 || ternary[ternary.length - 1] < begin[a]) && ("mapclassexpressionmethodglobalparen".indexOf(depth[a]) > -1 || (types[a - 2] === "word" && depth[a] !== "switch"))) {
+                                level[a - 1] = -20;
+                                varlen[varlen.length - 1].push(a - 1);
+                                return level.push(-10);
+                            }
+                            if (depth[a] === "switch" && (ternary.length < 1 || ternary[ternary.length - 1] < begin[a])) {
+                                level[a - 1] = -20;
+                                return level.push(indent);
+                            }
+                            if (ternary.length > 0 && ternary[ternary.length - 1] > begin[a]) {
+                                (function jspretty_beautify_operator_colon() {
+                                    var c = a,
+                                        d = begin[a];
+                                    do {
+                                        c = c - 1;
+                                        if (begin[c] === d) {
+                                            if (token[c] === "," || token[c] === ";") {
+                                                level[a - 1] = -20;
+                                                return;
+                                            }
+                                            if (token[c] === "?") {
+                                                ternary.pop();
+                                                return endExtraInd();
+                                            }
+                                        }
+                                    } while (c > d);
+                                }());
+                            } else if (depth[a] === "object") {
+                                level[a - 1] = -20;
+                                varlen[varlen.length - 1].push(a - 1);
+                            } else if (ternary.length > 0) {
+                                level[a - 1] = indent;
+                            } else {
+                                level[a - 1] = -10;
+                            }
+                            return level.push(-10);
+                        }
+                        if (ctoke === "++" || ctoke === "--") {
+                            if (ltype === "literal" || ltype === "word") {
+                                level[a - 1] = -20;
+                                level.push(-10);
+                            } else if (a < b - 1 && (types[a + 1] === "literal" || types[a + 1] === "word")) {
+                                level.push(-20);
+                            } else {
+                                level.push(-10);
+                            }
+                            return;
+                        }
+                        if (ctoke === "+") {
+                            if (ltype === "start") {
+                                level[a - 1] = -20;
+                            } else {
+                                level[a - 1] = -10;
+                            }
+                            if (options.wrap < 1 || token[begin[a]] === "x(") {
+                                return level.push(-10);
+                            }
+                            return (function jspretty__beautify_operator_plus() {
+                                var line = 0,
+                                    next = 0,
+                                    c    = a,
+                                    ind  = indent + 2,
+                                    aa   = token[a + 1],
+                                    meth = 0;
+                                if (aa === undefined) {
+                                    return level.push(-10);
+                                }
+                                if (types[a - 1] === "operator" || types[a - 1] === "start") {
+                                    if (types[a + 1] === "word" || aa === "(" || aa === "[") {
+                                        return level.push(-20);
+                                    }
+                                    if (isNaN(aa.slice(1, -1)) === false && ((/\d/).test(aa.charAt(1)) === true || aa.charAt(1) === "." || aa.charAt(1) === "-" || aa.charAt(1) === "+")) {
+                                        return level.push(-20);
+                                    }
+                                }
+                                do {
+                                    c = c - 1;
+                                    if (token[begin[a]] === "(") {
+                                        if (c === begin[a]) {
+                                            meth = line;
+                                        }
+                                        if (token[c] === "," && begin[c] === begin[a] && list[list.length - 1] === true) {
+                                            break;
+                                        }
+                                    }
+                                    if (line > options.wrap - 1) {
+                                        break;
+                                    }
+                                    if (level[c] > -9) {
+                                        break;
+                                    }
+                                    if (types[c] === "operator" && token[c] !== "=" && token[c] !== "+" && begin[c] === begin[a]) {
+                                        break;
+                                    }
+                                    line = line + token[c].length;
+                                    if (c === begin[a] && token[c] === "[" && line < options.wrap - 1) {
+                                        break;
+                                    }
+                                    if (token[c] === "." && level[c] > -9) {
+                                        break;
+                                    }
+                                    if (level[c] === -10) {
+                                        line = line + 1;
+                                    }
+                                } while (c > 0);
+                                if (meth > 0) {
+                                    meth = meth + aa.length;
+                                }
+                                line = line + aa.length;
+                                next = c;
+                                if (line > options.wrap - 1 && level[c] < -9) {
+                                    do {
+                                        next = next - 1;
+                                    } while (next > 0 && level[next] < -9);
+                                }
+                                if (token[next + 1] === "." && begin[a] <= begin[next]) {
+                                    ind = ind + 1;
+                                } else if (token[next] === "+") {
+                                    ind = level[next];
+                                }
+                                next = aa.length;
+                                if (line + next < options.wrap) {
+                                    level.push(-10);
+                                } else {
+                                    if (token[begin[a]] === "(" && (token[ei[0]] === ":" || token[ei[0]] === "?")) {
+                                        ind = indent + 3;
+                                    } else if (depth[a] === "method") {
+                                        level[begin[a]] = indent;
+                                        if (list[list.length - 1] === true) {
+                                            ind = indent + 3;
+                                        } else {
+                                            ind = indent + 1;
+                                        }
+                                    } else if (depth[a] === "object" || depth[a] === "array") {
+                                        destructfix(true, false);
+                                    }
+                                    if (token[c] === "var" || token[c] === "let" || token[c] === "const") {
+                                        line = line - (options.insize * options.inchar.length * 2);
+                                    }
+                                    if (meth > 0) {
+                                        c = options.wrap - meth;
+                                    } else {
+                                        c = options.wrap - line;
+                                    }
+                                    if (c > 0 && c < 5) {
+                                        level.push(ind);
+                                        if (token[a].charAt(0) === "\"" || token[a].charAt(0) === "'") {
+                                            a = a + 1;
+                                            if (token[a].length > options.wrap) {
+                                                strwrap(0);
+                                            } else {
+                                                level.push(-10);
+                                            }
+                                        }
+                                    } else if (token[begin[a]] !== "(" || meth > options.wrap - 1 || meth === 0) {
+                                        if (meth > 0) {
+                                            line = meth;
+                                        }
+                                        if (line - aa.length < options.wrap - 1 && (aa.charAt(0) === "\"" || aa.charAt(0) === "'")) {
+                                            a = a + 1;
+                                            if (line - aa.length > options.wrap - 4) {
+                                                level.push(ind);
+                                            } else {
+                                                level.push(-10);
+                                            }
+                                            if (varline[varline.length - 1] === true && token[c] === "=") {
+                                                line = line + (options.inchar.length * options.insize) - 1;
+                                            } else {
+                                                line = line + 3;
+                                            }
+                                            strwrap(options.wrap - (line - aa.length));
+                                        } else {
+                                            level.push(ind);
+                                        }
+                                    } else {
+                                        level.push(-10);
+                                    }
+                                }
+                            }());
+                        }
+                        if (types[a - 1] !== "comment" && types[a - 1] !== "comment-inline") {
+                            if (ltoke === "(") {
+                                level[a - 1] = -20;
+                            } else if (ctoke === "*" && depth[a] === "object" && types[a + 1] === "word" && (ltoke === "{" || ltoke === ",")) {
+                                level[a - 1] = indent;
+                            } else if (ctoke !== "?" || ternary.length === 0) {
+                                level[a - 1] = -10;
+                            }
+                        }
+                        if (ctoke.indexOf("=") > -1 && ctoke !== "==" && ctoke !== "===" && ctoke !== "!=" && ctoke !== "!==" && ctoke !== ">=" && ctoke !== "<=" && ctoke !== "=>" && depth[a] !== "method" && depth[a] !== "object") {
+                            if (assignlist[assignlist.length - 1] === true && token[begin[a] - 1] !== "for") {
+                                (function jspretty__beautify_operator_assignTest() {
+                                    var c = 0,
+                                        d = "",
+                                        e = begin[a];
+                                    if (depth[a] === "class") {
+                                        varlen[varlen.length - 1].push(a - 1);
+                                    } else {
+                                        for (c = a - 1; c > e; c = c - 1) {
+                                            d = token[c];
+                                            if (d === ";" || d === "x;" || d === "," || d === "?" || d === ":" || c === e + 1) {
+                                                return varlen[varlen.length - 1].push(a - 1);
+                                            }
+                                            if (d.indexOf("=") > -1 && d !== "==" && d !== "===" && d !== "!=" && d !== "!==" && d !== ">=" && d !== "<=") {
+                                                return;
+                                            }
+                                        }
+                                    }
+                                }());
+                            }
+                            (function jspretty__beautify_operator_assignSpaces() {
+                                var c = 0,
+                                    d = 0,
+                                    e = false,
+                                    f = "";
+                                if ((token[begin[a]] === "(" || token[begin[a]] === "x(") && token[a + 1] !== "function") {
+                                    return;
+                                }
+                                for (c = a + 1; c < b; c = c + 1) {
+                                    if (types[c] === "start") {
+                                        if (e === true && token[c] !== "[") {
+                                            if (assignlist[assignlist.length - 1] === true) {
+                                                assignlist[assignlist.length - 1] = false;
+                                                if (varlen[varlen.length - 1].length > 1) {
+                                                    varlist.push(varlen[varlen.length - 1]);
+                                                }
+                                                varlen[varlen.length - 1] = [];
+                                            }
+                                            break;
+                                        }
+                                        d = d + 1;
+                                    }
+                                    if (types[c] === "end") {
+                                        d = d - 1;
+                                    }
+                                    if (d < 0) {
+                                        if (assignlist[assignlist.length - 1] === true) {
+                                            assignlist[assignlist.length - 1] = false;
+                                            if (varlen[varlen.length - 1].length > 1) {
+                                                varlist.push(varlen[varlen.length - 1]);
+                                            }
+                                            varlen[varlen.length - 1] = [];
+                                        }
+                                        break;
+                                    }
+                                    if (d === 0) {
+                                        f = token[c];
+                                        if (e === true) {
+                                            if (types[c] === "operator" || token[c] === ";" || token[c] === "x;" || token[c] === "?" || token[c] === "var" || token[c] === "let" || token[c] === "const") {
+                                                if (f !== undefined && (f === "?" || (f.indexOf("=") > -1 && f !== "==" && f !== "===" && f !== "!=" && f !== "!==" && f !== ">=" && f !== "<="))) {
+                                                    if (assignlist[assignlist.length - 1] === false && (varlen[varlen.length - 1].length === 0 || token[varlen[varlen.length - 1][varlen[varlen.length - 1].length - 1] + 1] === ctoke)) {
+                                                        varlen[varlen.length - 1].push(a - 1);
+                                                        assignlist[assignlist.length - 1] = true;
+                                                    }
+                                                }
+                                                if ((f === ";" || f === "x;" || f === "var" || f === "let" || f === "const") && assignlist[assignlist.length - 1] === true) {
+                                                    assignlist[assignlist.length - 1] = false;
+                                                    if (varlen[varlen.length - 1].length > 1) {
+                                                        varlist.push(varlen[varlen.length - 1]);
+                                                    }
+                                                    varlen[varlen.length - 1] = [];
+                                                }
+                                                break;
+                                            }
+                                            if (assignlist[assignlist.length - 1] === true && (f === "return" || f === "break" || f === "continue" || f === "throw")) {
+                                                assignlist[assignlist.length - 1] = false;
+                                                if (varlen[varlen.length - 1].length > 1) {
+                                                    varlist.push(varlen[varlen.length - 1]);
+                                                }
+                                                varlen[varlen.length - 1] = [];
+                                            }
+                                        }
+                                        if (f === ";" || f === "x;" || f === ",") {
+                                            e = true;
+                                        }
+                                    }
+                                }
+                            }());
+                        }
+                        if ((ctoke === "-" && ltoke === "return") || ltoke === "=") {
+                            return level.push(-20);
+                        }
+                        if (ltype === "operator" && types[a + 1] === "word" && ltoke !== "--" && ltoke !== "++" && ctoke !== "&&" && ctoke !== "||") {
+                            return level.push(-20);
+                        }
+                        level.push(-10);
+                    },
+                    word          = function jspretty__beautify_word() {
+                        var next    = token[a + 1],
+                            compare = (
+                                next !== undefined && next !== "==" && next !== "===" && next !== "!=" && next !== "!==" && next === ">=" && next !== "<=" && next.indexOf("=") > -1
+                            );
+                        if (varline[varline.length - 1] === true && (ltoke === "," || ltoke === "var" || ltoke === "let" || ltoke === "const")) {
+                            if (token[begin[a] - 1] !== "for" && depth[a] !== "method" && token[begin[a]] !== "(" && token[begin[a]] !== "x(") {
+                                if (types[a + 1] === "operator" && compare === true && token[varlen[varlen.length - 1][varlen[varlen.length - 1].length - 1] + 1] !== ":") {
+                                    varlen[varlen.length - 1].push(a);
+                                }
+                            }
+                            if (options.jsscope !== "none" || options.mode === "minify") {
+                                meta[meta.length - 1] = "v";
+                            }
+                        } else if ((options.jsscope !== "none" || options.mode === "minify") && ltoke === "function") {
+                            meta[meta.length - 1] = "v";
+                        }
+                        if ((ltoke === ")" || ltoke === "x)") && depth[a] === "class" && (token[begin[a - 1] - 1] === "static" || token[begin[a - 1] - 1] === "final" || token[begin[a - 1] - 1] === "void")) {
+                            level[a - 1]            = -10;
+                            level[begin[a - 1] - 1] = -10;
+                        }
+                        if (ltoke === "]") {
+                            level[a - 1] = -10;
+                        }
+                        if (ltoke === "}" || ltoke === "x}") {
+                            level[a - 1] = indent;
+                        }
+                        if (ctoke === "else" && ltoke === "}" && token[a - 2] === "x}") {
+                            level[a - 3] = level[a - 3] - 1;
+                        }
+                        if (varline.length === 1 && varline[0] === true && (ltoke === "var" || ltoke === "let" || ltoke === "const" || ltoke === "," || (ltoke === "function" && depth[a + 1] === "method"))) {
+                            globals.push(ctoke);
+                        }
+                        if ((ctoke === "let" || ctoke === "const") && lettest < 0) {
+                            lettest = a;
+                        }
+                        if (ctoke === "new") {
+                            (function jspretty__beautify_word_new() {
+                                var c       = 0,
+                                    nextish = (typeof next === "string")
+                                        ? next
+                                        : "",
+                                    apiword = (nextish === "")
+                                        ? []
+                                        : [
+                                            "ActiveXObject",
+                                            "ArrayBuffer",
+                                            "AudioContext",
+                                            "Canvas",
+                                            "CustomAnimation",
+                                            "DOMParser",
+                                            "DataView",
+                                            "Date",
+                                            "Error",
+                                            "EvalError",
+                                            "FadeAnimation",
+                                            "FileReader",
+                                            "Flash",
+                                            "Float32Array",
+                                            "Float64Array",
+                                            "FormField",
+                                            "Frame",
+                                            "Generator",
+                                            "HotKey",
+                                            "Image",
+                                            "Iterator",
+                                            "Intl",
+                                            "Int16Array",
+                                            "Int32Array",
+                                            "Int8Array",
+                                            "InternalError",
+                                            "Loader",
+                                            "Map",
+                                            "MenuItem",
+                                            "MoveAnimation",
+                                            "Notification",
+                                            "ParallelArray",
+                                            "Point",
+                                            "Promise",
+                                            "Proxy",
+                                            "RangeError",
+                                            "Rectangle",
+                                            "ReferenceError",
+                                            "Reflect",
+                                            "RegExp",
+                                            "ResizeAnimation",
+                                            "RotateAnimation",
+                                            "Set",
+                                            "SQLite",
+                                            "ScrollBar",
+                                            "Set",
+                                            "Shadow",
+                                            "StopIteration",
+                                            "Symbol",
+                                            "SyntaxError",
+                                            "Text",
+                                            "TextArea",
+                                            "Timer",
+                                            "TypeError",
+                                            "URL",
+                                            "Uint16Array",
+                                            "Uint32Array",
+                                            "Uint8Array",
+                                            "Uint8ClampedArray",
+                                            "URIError",
+                                            "WeakMap",
+                                            "WeakSet",
+                                            "Web",
+                                            "Window",
+                                            "XMLHttpRequest"
+                                        ],
+                                    apilen  = apiword.length;
+                                for (c = 0; c < apilen; c = c + 1) {
+                                    if (nextish === apiword[c]) {
+                                        return;
+                                    }
+                                }
+                                news = news + 1;
+                                if (options.jsscope !== "none") {
+                                    token[a] = "<strong class='new'>new</strong>";
+                                }
+                            }());
+                        }
+                        if (ctoke === "from" && ltype === "end" && a > 0 && (token[begin[a - 1] - 1] === "import" || token[begin[a - 1] - 1] === ",")) {
+                            level[a - 1] = -10;
+                        }
+                        if (ctoke === "this" && options.jsscope !== "none") {
+                            token[a] = "<strong class='new'>this</strong>";
+                        }
+                        if (ctoke === "function") {
+                            if (options.space === false && a < b - 1 && (token[a + 1] === "(" || token[a + 1] === "x(")) {
+                                return level.push(-20);
+                            }
+                            return level.push(-10);
+                        }
+                        if (ltype === "literal" && ltoke.charAt(ltoke.length - 1) === "{" && options.bracepadding === false) {
+                            level[a - 1] = -20;
+                        } else if (ltoke === "-" && a > 1) {
+                            if (types[a - 2] === "operator" || token[a - 2] === ",") {
+                                level[a - 1] = -20;
+                            } else if (types[a - 2] === "start") {
+                                level[a - 2] = -20;
+                                level[a - 1] = -20;
+                            }
+                        } else if (ctoke === "while" && (ltoke === "}" || ltoke === "x}")) {
+                            //verify if this is a do/while block
+                            (function jspretty__beautify_word_curlyBrace() {
+                                var c = 0,
+                                    d = 0;
+                                for (c = a - 1; c > -1; c = c - 1) {
+                                    if (token[c] === "}" || token[c] === "x}") {
+                                        d = d + 1;
+                                    }
+                                    if (token[c] === "{" || token[c] === "x{") {
+                                        d = d - 1;
+                                    }
+                                    if (d === 0) {
+                                        if (token[c - 1] === "do") {
+                                            level[a - 1] = -10;
+                                            return;
+                                        }
+                                        level[a - 1] = indent;
+                                        return;
+                                    }
+                                }
+                            }());
+                        } else if (ctoke === "in" || (((ctoke === "else" && options.elseline === false) || ctoke === "catch") && (ltoke === "}" || ltoke === "x}"))) {
+                            level[a - 1] = -10;
+                        } else if (ctoke === "var" || ctoke === "let" || ctoke === "const") {
+                            if (assignlist[assignlist.length - 1] === true && varlen.length > 0 && varlen[varlen.length - 1].length > 1) {
+                                assignlist[assignlist.length - 1] = false;
+                                varlist.push(varlen[varlen.length - 1]);
+                                varlen[varlen.length - 1] = [];
+                            } else if (depth[a] !== "method") {
+                                varlen[varlen.length - 1] = [];
+                            }
+                            if (ltype === "end") {
+                                level[a - 1] = indent;
+                            }
+                            if (token[begin[a] - 1] !== "for") {
+                                if (varline.length === 0) {
+                                    varline.push(true);
+                                } else {
+                                    varline[varline.length - 1] = true;
+                                }
+                                (function jspretty__beautify_word_varlisttest() {
+                                    var c = 0,
+                                        d = 0;
+                                    for (c = a + 1; c < b; c = c + 1) {
+                                        if (types[c] === "end") {
+                                            d = d - 1;
+                                        }
+                                        if (types[c] === "start") {
+                                            d = d + 1;
+                                        }
+                                        if (d < 0 || (d === 0 && (token[c] === ";" || token[c] === ","))) {
+                                            break;
+                                        }
+                                    }
+                                    if (token[c] === ",") {
+                                        indent = indent + 1;
+                                    }
+                                }());
+                            }
+                        } else if ((ctoke === "default" || ctoke === "case") && ltype !== "word" && depth[a] === "switch") {
+                            level[a - 1] = indent - 1;
+                            return level.push(-10);
+                        }
+                        if (ctoke === "catch" && ltoke === ".") {
+                            level[a - 1] = -20;
+                            return level.push(-20);
+                        }
+                        if (ctoke === "catch" || ctoke === "finally") {
+                            level[a - 1] = -10;
+                            return level.push(-10);
+                        }
+                        if (options.bracepadding === false && a < b - 1 && token[a + 1].charAt(0) === "}") {
+                            return level.push(-20);
+                        }
+                        if (depth[a] === "object" && (ltoke === "{" || ltoke === ",") && (token[a + 1] === "(" || token[a + 1] === "x(")) {
+                            return level.push(-20);
+                        }
+                        level.push(-10);
+                    };
+                if (options.titanium === true) {
+                    indent = indent - 1;
+                }
+                for (a = 0; a < b; a = a + 1) {
+                    if (options.jsscope !== "none" || options.mode === "minify") {
+                        meta.push("");
+                    }
+                    ctype = types[a];
+                    ctoke = token[a];
+                    if (ctype === "comment") {
+                        comment();
+                    } else if (ctype === "comment-inline") {
+                        commentInline();
+                    } else if (ctype === "regex") {
+                        level.push(-20);
+                    } else if (ctype === "literal") {
+                        literal();
+                    } else if (ctype === "separator") {
+                        separator();
+                    } else if (ctype === "start") {
+                        start();
+                    } else if (ctype === "end") {
+                        end();
+                    } else if (ctype === "operator") {
+                        operator();
+                    } else if (ctype === "word") {
+                        word();
+                    } else if (ctype === "markup") {
+                        markup();
+                    } else if (ctype.indexOf("template") === 0) {
+                        template();
+                    } else if (ctype === "generic") {
+                        if (ltoke !== "return" && ltoke.charAt(0) !== "#" && ltype !== "operator" && ltoke !== "public" && ltoke !== "private" && ltoke !== "static" && ltoke !== "final" && ltoke !== "implements" && ltoke !== "class" && ltoke !== "void") {
+                            level[a - 1] = -20;
+                        }
+                        if (token[a + 1] === "(" || token[a + 1] === "x(") {
+                            level.push(-20);
+                        } else {
+                            level.push(-10);
+                        }
+                    }
+                    if (ctype !== "comment" && ctype !== "comment-inline") {
+                        ltype = ctype;
+                        ltoke = ctoke;
+                    }
+                }
+                if (assignlist[assignlist.length - 1] === true && varlen[varlen.length - 1].length > 1 && ltoke === ";") {
+                    varlist.push(varlen[varlen.length - 1]);
+                }
+            }());
+        }
+        if (options.titanium === true) {
+            token[0] = "";
+            types[0] = "";
+            lines[0] = 0;
+        }
+        if (options.mode === "minify") {
+            result = (function jspretty__minify() {
+                var a        = 0,
+                    linelen  = 0,
+                    length   = token.length,
+                    comtest  = (options.topcoms === false),
+                    build    = [],
+                    lastsemi = function jspretty__minify_lastsemi() {
+                        var aa = 0,
+                            bb = 0;
+                        for (aa = a; aa > -1; aa = aa - 1) {
+                            if (types[aa] === "end") {
+                                bb = bb + 1;
+                            } else if (types[aa] === "start") {
+                                bb = bb - 1;
+                            }
+                            if (bb < 0) {
+                                if (token[aa - 1] === "for") {
+                                    build.push(";");
+                                }
+                                return;
+                            }
+                        }
+                    };
+                for (a = 0; a < length; a = a + 1) {
+                    if (types[a] !== "comment") {
+                        comtest = true;
+                    }
+                    if (types[a - 1] === "operator" && types[a] === "operator" && token[a] !== "!") {
+                        build.push(" ");
+                    }
+                    if (types[a] === "markup" && typeof global.prettydiff.markuppretty === "function") {
+                        build.push(extlib({jsx: true, mode: "minify", source: token[a]}));
+                    } else if (types[a] === "word" && (types[a + 1] === "word" || types[a + 1] === "literal" || token[a + 1] === "x{" || types[a + 1] === "comment" || types[a + 1] === "comment-inline")) {
+                        if (types[a - 1] === "literal" && token[a - 1].charAt(0) !== "\"" && token[a - 1].charAt(0) !== "'") {
+                            build.push(" ");
+                        }
+                        build.push(token[a]);
+                        build.push(" ");
+                    } else if (types[a] === "comment" && comtest === false) {
+                        build.push(token[a]);
+                        build.push(lf);
+                    } else if (token[a] === "x;" && token[a + 1] !== "}") {
+                        build.push(";");
+                    } else if (token[a] === ";" && token[a + 1] === "}") {
+                        lastsemi();
+                    } else if (token[a] !== "x;" && token[a] !== "x{" && token[a] !== "x}" && token[a] !== "x)" && token[a] !== "x(" && types[a] !== "comment" && types[a] !== "comment-inline") {
+                        build.push(token[a]);
+                    }
+                    if (options.wrap > 0) {
+                        if (types[a] !== "comment" && types[a] !== "comment-inline") {
+                            linelen = linelen + token[a].length;
+                        }
+                        if ((types[a] === "operator" || types[a] === "separator" || types[a] === "start") && a < length - 1 && linelen + token[a + 1].length > options.wrap) {
+                            build.push(lf);
+                            linelen = 0;
+                        }
+                    }
+                }
+                if (options.newline === true) {
+                    if (options.crlf === true) {
+                        build.push("\r\n");
+                    } else {
+                        build.push("\n");
+                    }
+                }
+                if (options.nodeasync === true) {
+                    return [build.join(""), globalerror];
+                }
+                return build.join("");
+            }());
+        } else {
+            //the result function generates the out
+            (function jspretty__result() {
+                var tab      = (function jspretty__result_tab() {
+                        var aa = options.inchar,
+                            bb = options.insize,
+                            cc = [];
+                        for (bb = bb; bb > 0; bb = bb - 1) {
+                            cc.push(aa);
+                        }
+                        return cc.join("");
+                    }()),
+                    vertical = function jspretty__result_vertical() {
+                        var aa          = 0,
+                            lastListLen = 0,
+                            cc          = 0,
+                            dd          = 0,
+                            longest     = 0,
+                            longTest    = 0,
+                            strlongest  = 0,
+                            isvar       = false,
+                            isvartoken  = 0,
+                            strspace    = "",
+                            tokenInList = "",
+                            longList    = [],
+                            joins       = function jspretty__result_vertical_joins(x) {
+                                var xlen = token[x].length,
+                                    y    = x;
+                                if (level[x] === 0) {
+                                    return xlen;
+                                }
+                                if (level[x] < -9) {
+                                    do {
+                                        y = y - 1;
+                                        if (level[y] > -9) {
+                                            break;
+                                        }
+                                        if (level[y] === -10) {
+                                            xlen = xlen + 1;
+                                        }
+                                        xlen = xlen + token[y].length;
+                                    } while (y > 0);
+                                    if (level[y] > 0) {
+                                        xlen = xlen + (options.inchar.length * options.insize * level[y]);
+                                    }
+                                } else {
+                                    xlen = xlen + (options.inchar.length * options.insize * level[x]);
+                                }
+                                if (depth[x] === "global" && varlist[0][0] === x && options.lang !== "javascript") {
+                                    y = x;
+                                    do {
+                                        y = y - 1;
+                                    } while (y > -1 && level[y] < -9);
+                                    if (y < 0) {
+                                        xlen = xlen + (options.inchar.length * options.insize * options.inlevel);
+                                    }
+                                }
+                                return xlen;
+                            };
+                        for (aa = varlist.length - 1; aa > -1; aa = aa - 1) {
+                            if (varlist[aa] !== undefined) {
+                                lastListLen = varlist[aa].length;
+                                longest     = 0;
+                                longList    = [];
+                                isvartoken  = token[varlist[aa][0] - 1];
+                                isvar       = (
+                                    isvartoken === "var" || isvartoken === "let" || isvartoken === "const"
+                                );
+                                for (cc = 0; cc < lastListLen; cc = cc + 1) {
+                                    longTest = joins(varlist[aa][cc], isvar);
+                                    if (longTest > longest) {
+                                        longest = longTest;
+                                    }
+                                    longList.push(longTest);
+                                }
+                                strspace = "";
+                                if (longest > options.insize) {
+                                    strlongest = longest - options.insize;
+                                } else if (longest < options.insize) {
+                                    strlongest = options.insize - longest;
+                                }
+                                if (token[varlist[aa][0] - 1] === "var" || token[varlist[aa][0] - 1] === "let" || token[varlist[aa][0] - 1] === "const") {
+                                    strlongest = strlongest - options.insize;
+                                } else if (token[varlist[aa][0] + 1] === "=") {
+                                    strlongest = strlongest + 1;
+                                }
+                                if (longest !== options.insize && strlongest > 0) {
+                                    do {
+                                        strspace   = strspace + " ";
+                                        strlongest = strlongest - 1;
+                                    } while (strlongest > -1);
+                                }
+                                for (cc = 0; cc < lastListLen; cc = cc + 1) {
+                                    tokenInList = token[varlist[aa][cc]];
+                                    if (longList[cc] < longest) {
+                                        do {
+                                            tokenInList  = tokenInList + " ";
+                                            longList[cc] = longList[cc] + 1;
+                                        } while (longList[cc] < longest);
+                                    }
+                                    token[varlist[aa][cc]] = tokenInList;
+                                    if (token[varlist[aa][cc] + 2] !== undefined && token[varlist[aa][cc] + 2].length === options.wrap + 2 && token[varlist[aa][cc] + 3] === "+" && token[varlist[aa][cc] + 4] !== undefined && options.styleguide !== "crockford" && options.styleguide !== "jslint" && (token[varlist[aa][cc] + 4].charAt(0) === "\"" || token[varlist[aa][cc] + 4].charAt(0) === "'")) {
+                                        if (longest <= options.insize) {
+                                            strspace = "";
+                                            dd       = 0;
+                                            do {
+                                                dd       = dd + 1;
+                                                strspace = strspace + " ";
+                                            } while (dd < longest + 1);
+                                            dd = varlist[aa][cc] + 4;
+                                            do {
+                                                token[dd]     = strspace + tab + tab + token[dd];
+                                                level[dd - 1] = level[dd - 1] - 1;
+                                                dd            = dd + 2;
+                                            } while (types[dd] === "literal" && types[dd - 1] !== "separator");
+                                        } else {
+                                            dd = varlist[aa][cc] + 4;
+                                            do {
+                                                token[dd]     = strspace + tab + tab + token[dd];
+                                                level[dd - 1] = 0;
+                                                dd            = dd + 2;
+                                            } while (types[dd] === "literal" && types[dd - 1] !== "separator");
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    };
+                if (options.jsscope !== "none") {
+                    result = (function jspretty__result_scope() {
+                        var a                  = 0,
+                            b                  = token.length,
+                            build              = [],
+                            linecount          = 2,
+                            last               = "",
+                            scope              = 1,
+                            buildlen           = 0,
+                            commentfix         = (function jspretty__result_scope_commentfix() {
+                                var aa = 1,
+                                    bb = 1;
+                                if (types[0] !== "comment" || (token[0].indexOf("//") === 0 && lines[0] > 0) || types[1] !== "comment") {
+                                    return 1;
+                                }
+                                do {
+                                    if (token[aa].indexOf("/*") === 0) {
+                                        bb = bb + 1;
+                                    }
+                                    aa = aa + 1;
+                                } while (types[aa] === "comment" && aa < b);
+                                return bb + 1;
+                            }()),
+                            folderItem         = [],
+                            comfold            = -1,
+                            //if current folding is for comment
+                            data               = [
+                                "<div class='beautify' data-prettydiff-ignore='true'><ol class='count'>", "<li>", 1, "</li>"
+                            ],
+                            //applies folding to comments and functions
+                            //
+                            // Folder uses the i variable to determine how far back into the data array to
+                            // look.  i must be multiplied by 3 because each line number is three indexes in
+                            // the data array: <li>, line #, </li>.
+                            //
+                            //i is incremented for:
+                            // * block comments following one or more line  comments that follow one or more
+                            // block comments
+                            //* if last comment in a series is a block comment  and not the first token
+                            // * block comments with a new line that are either  the first token or not
+                            // followed by another block
+                            //* if a block comment is followed by another block  comment
+                            //
+                            //i is decremented for:
+                            //* line comment following a block comment
+                            //* block comment if "i" is greater than 1 and  inside a function fold
+                            // * if a line comment is not preceeded by another  comment and is followed by a
+                            // block comment
+                            //
+                            // If closing a fold and token is a comment and not token 0 then decrement by
+                            // commentfix.
+                            folder             = function jspretty__result_scope_folder() {
+                                var datalen = (data.length - (commentfix * 3) > 0)
+                                        ? data.length - (commentfix * 3)
+                                        : 1,
+                                    index   = a,
+                                    start   = data[datalen + 1] || 1,
+                                    assign  = true,
+                                    kk      = index;
+                                if (types[a] === "comment" && comfold === -1) {
+                                    comfold = a;
+                                } else if (types[a] !== "comment") {
+                                    index = meta[a];
+                                    do {
+                                        kk = kk - 1;
+                                    } while (token[kk] !== "function" && kk > -1);
+                                    kk = kk - 1;
+                                    if (token[kk] === "(" || token[kk] === "x(") {
+                                        do {
+                                            kk = kk - 1;
+                                        } while (kk > -1 && (token[kk] === "(" || token[kk] === "x("));
+                                    }
+                                    if (token[kk] === "=" || token[kk] === ":" || token[kk] === "," || token[kk + 1] === "(" || token[kk + 1] === "x(") {
+                                        assign = false;
+                                    }
+                                }
+                                if (types[a] === "comment" && lines[a] > 1) {
+                                    datalen = datalen - 3;
+                                    start   = start - 1;
+                                }
+                                data[datalen]     = "<li class='fold' title='folds from line " + start + " to line " +
+                                        "xxx'>";
+                                data[datalen + 1] = "- " + start;
+                                folderItem.push([datalen, index, assign]);
+                            },
+                            // determines where folding ends function assignments require one more line for
+                            // closing than everything else
+                            foldclose          = function jspretty__result_scope_foldclose() {
+                                var end  = (function jspretty__result_scope_foldclose_end() {
+                                        if (comfold > -1 || folderItem[folderItem.length - 1][2] === true) {
+                                            return linecount - commentfix - 1;
+                                        }
+                                        return linecount - commentfix;
+                                    }()),
+                                    semi = (/(>;<\/em>)$/).test(token[a]),
+                                    gg   = 0,
+                                    lets = false;
+                                if (semi === true) {
+                                    end = end - 1;
+                                    for (gg = build.length - 1; gg > 0; gg = gg - 1) {
+                                        if (build[gg] === "let" || build[gg] === "const") {
+                                            lets = true;
+                                        }
+                                        if (build[gg].indexOf("><li") > 0) {
+                                            build[gg] = build[gg].replace(/class\='l\d+'/, "class='l" + (
+                                                scope + 1
+                                            ) + "'");
+                                            if (lets === true) {
+                                                break;
+                                            }
+                                        }
+                                        if (build[gg].indexOf("<em class='l" + scope + "'>" + tab) > -1) {
+                                            build[gg] = build[gg].replace(
+                                                "<em class='l" + scope + "'>" + tab,
+                                                "<em class='l" + (
+                                                    scope + 1
+                                                ) + "'>" + tab
+                                            );
+                                        }
+                                    }
+                                }
+                                if (a > 1 && token[a].indexOf("}</em>") === token[a].length - 6 && token[a - 1].indexOf("{</em>") === token[a - 1].length - 6) {
+                                    for (gg = data.length - 1; gg > 0; gg = gg - 1) {
+                                        if (typeof data[gg] === "string" && data[gg].charAt(0) === "-") {
+                                            data[gg - 1] = "<li>";
+                                            data[gg]     = Number(data[gg].substr(1));
+                                            folderItem.pop();
+                                            return;
+                                        }
+                                    }
+                                }
+                                if (folderItem[folderItem.length - 1][1] === b - 1 && token[a].indexOf("<em ") === 0) {
+                                    end = end + 1;
+                                }
+                                data[folderItem[folderItem.length - 1][0]] = data[folderItem[folderItem.length - 1][0]].replace(
+                                    "xxx",
+                                    end
+                                );
+                                folderItem.pop();
+                            },
+                            // splits block comments, which are single tokens, into multiple lines of output
+                            blockline          = function jspretty__result_scope_blockline(x) {
+                                var commentLines = x.split(lf),
+                                    hh           = 0,
+                                    ii           = commentLines.length - 1;
+                                if (lines[a] > 0) {
+                                    data.push("<li>");
+                                    data.push(linecount);
+                                    data.push("</li>");
+                                    linecount = linecount + 1;
+                                }
+                                for (hh = 0; hh < ii; hh = hh + 1) {
+                                    data.push("<li>");
+                                    data.push(linecount);
+                                    data.push("</li>");
+                                    linecount        = linecount + 1;
+                                    commentLines[hh] = commentLines[hh] + "<em>&#xA;</em></li><li class='c0'>";
+                                }
+                                return commentLines.join("");
+                            },
+                            //finds the variables if the jsscope option is true
+                            findvars           = function jspretty__result_scope_findvars(x) {
+                                var metax         = meta[x],
+                                    metameta      = meta[metax][0],
+                                    lettest       = false,
+                                    ee            = 0,
+                                    ff            = 0,
+                                    hh            = 0,
+                                    adjustment    = 1,
+                                    functionBlock = true,
+                                    varbuild      = [],
+                                    varbuildlen   = 0,
+                                    letcomma      = function jspretty__result_scope_findvars_letcomma() {
+                                        var aa = 0,
+                                            bb = 0;
+                                        for (aa = a; aa > -1; aa = aa - 1) {
+                                            if (types[aa] === "end") {
+                                                bb = bb - 1;
+                                            }
+                                            if (types[aa] === "start") {
+                                                bb = bb + 1;
+                                            }
+                                            if (bb > 0) {
+                                                return;
+                                            }
+                                            if (bb === 0) {
+                                                if (token[aa] === "var" || token[aa] === ";" || token[aa] === "x;") {
+                                                    return;
+                                                }
+                                                if (token[aa] === "let" || token[aa] === "const") {
+                                                    token[ee] = "<em class='s" + scope + "'>" + varbuild[0] + "</em>";
+                                                }
+                                            }
+                                        }
+                                    };
+                                if (metameta === undefined) {
+                                    return;
+                                }
+                                lettest = meta[metax][1];
+                                hh      = metameta.length;
+                                if (types[a - 1] === "word" && token[a - 1] !== "function" && lettest === false) {
+                                    varbuild     = token[a - 1].split(" ");
+                                    token[a - 1] = "<em class='s" + scope + "'>" + varbuild[0] + "</em>";
+                                    varbuildlen  = varbuild.length;
+                                    if (varbuildlen > 1) {
+                                        do {
+                                            token[ee]   = token[ee] + " ";
+                                            varbuildlen = varbuildlen - 1;
+                                        } while (varbuildlen > 1);
+                                    }
+                                }
+                                if (hh > 0) {
+                                    ee = metax - 1;
+                                    if (lettest === true) {
+                                        ee = ee - 1;
+                                    }
+                                    for (ee = ee; ee > a; ee = ee - 1) {
+                                        if (types[ee] === "word") {
+                                            varbuild = token[ee].split(" ");
+                                            for (ff = 0; ff < hh; ff = ff + 1) {
+                                                if (varbuild[0] === metameta[ff] && token[ee - 1] !== ".") {
+                                                    if (token[ee - 1] === "function" && token[ee + 1] === "(") {
+                                                        token[ee]   = "<em class='s" + (
+                                                            scope + 1
+                                                        ) + "'>" + varbuild[0] + "</em>";
+                                                        varbuildlen = varbuild.length;
+                                                        if (varbuildlen > 1) {
+                                                            do {
+                                                                token[ee]   = token[ee] + " ";
+                                                                varbuildlen = varbuildlen - 1;
+                                                            } while (varbuildlen > 1);
+                                                        }
+                                                    } else if (token[ee - 1] === "case" || token[ee + 1] !== ":" || (token[ee + 1] === ":" && level[ee] > -20)) {
+                                                        if (lettest === true) {
+                                                            if (token[ee - 1] === "let" || token[ee - 1] === "const") {
+                                                                token[ee] = "<em class='s" + scope + "'>" + varbuild[0] + "</em>";
+                                                            } else if (token[ee - 1] === ",") {
+                                                                letcomma();
+                                                            } else {
+                                                                token[ee] = "<em class='s" + scope + "'>" + varbuild[0] + "</em>";
+                                                            }
+                                                        } else {
+                                                            token[ee] = "<em class='s" + scope + "'>" + varbuild[0] + "</em>";
+                                                        }
+                                                        varbuildlen = varbuild.length;
+                                                        if (varbuildlen > 1) {
+                                                            do {
+                                                                token[ee]   = token[ee] + " ";
+                                                                varbuildlen = varbuildlen - 1;
+                                                            } while (varbuildlen > 1);
+                                                        }
+                                                    }
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        if (functionBlock === true) {
+                                            if (types[ee] === "end") {
+                                                adjustment = adjustment + 1;
+                                            } else if (types[ee] === "start") {
+                                                adjustment = adjustment - 1;
+                                            }
+                                            if (adjustment === 0 && token[ee] === "{") {
+                                                token[ee]     = "<em class='s" + scope + "'>{</em>";
+                                                functionBlock = false;
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    ee = a + 1;
+                                    if (lettest === true) {
+                                        ee = ee - 1;
+                                    }
+                                    for (ee = ee; ee < metax; ee = ee + 1) {
+                                        if (types[ee] === "end") {
+                                            adjustment = adjustment - 1;
+                                        } else if (types[ee] === "start") {
+                                            adjustment = adjustment + 1;
+                                        }
+                                        if (adjustment === 1 && token[ee] === "{") {
+                                            token[ee] = "<em class='s" + scope + "'>{</em>";
+                                            return;
+                                        }
+                                    }
+                                }
+                            },
+                            indent             = options.inlevel,
+                            //some prebuilt color coded tabs
+                            lscope             = [
+                                "<em class='l0'>" + tab + "</em>",
+                                "<em class='l0'>" + tab + "</em><em class='l1'>" + tab + "</em>",
+                                "<em class='l0'>" + tab + "</em><em class='l1'>" + tab +
+                                        "</em><em class='l2'>" + tab + "</em>",
+                                "<em class='l0'>" + tab + "</em><em class='l1'>" + tab +
+                                        "</em><em class='l2'>" + tab + "</em><em class='l3'>" + tab + "</em>",
+                                "<em class='l0'>" + tab + "</em><em class='l1'>" + tab +
+                                        "</em><em class='l2'>" + tab + "</em><em class='l3'>" + tab + "</em><em class='" +
+                                        "l4'>" + tab + "</em>",
+                                "<em class='l0'>" + tab + "</em><em class='l1'>" + tab +
+                                        "</em><em class='l2'>" + tab + "</em><em class='l3'>" + tab + "</em><em class='" +
+                                        "l4'>" + tab + "</em><em class='l5'>" + tab + "</em>",
+                                "<em class='l0'>" + tab + "</em><em class='l1'>" + tab +
+                                        "</em><em class='l2'>" + tab + "</em><em class='l3'>" + tab + "</em><em class='" +
+                                        "l4'>" + tab + "</em><em class='l5'>" + tab + "</em><em class='l6'>" + tab + "<" +
+                                        "/em>",
+                                "<em class='l0'>" + tab + "</em><em class='l1'>" + tab +
+                                        "</em><em class='l2'>" + tab + "</em><em class='l3'>" + tab + "</em><em class='" +
+                                        "l4'>" + tab + "</em><em class='l5'>" + tab + "</em><em class='l6'>" + tab + "<" +
+                                        "/em><em class='l7'>" + tab + "</em>",
+                                "<em class='l0'>" + tab + "</em><em class='l1'>" + tab +
+                                        "</em><em class='l2'>" + tab + "</em><em class='l3'>" + tab + "</em><em class='" +
+                                        "l4'>" + tab + "</em><em class='l5'>" + tab + "</em><em class='l6'>" + tab + "<" +
+                                        "/em><em class='l7'>" + tab + "</em><em class='l8'>" + tab + "</em>",
+                                "<em class='l0'>" + tab + "</em><em class='l1'>" + tab +
+                                        "</em><em class='l2'>" + tab + "</em><em class='l3'>" + tab + "</em><em class='" +
+                                        "l4'>" + tab + "</em><em class='l5'>" + tab + "</em><em class='l6'>" + tab + "<" +
+                                        "/em><em class='l7'>" + tab + "</em><em class='l8'>" + tab + "</em><em class='l" +
+                                        "9'>" + tab + "</em>",
+                                "<em class='l0'>" + tab + "</em><em class='l1'>" + tab +
+                                        "</em><em class='l2'>" + tab + "</em><em class='l3'>" + tab + "</em><em class='" +
+                                        "l4'>" + tab + "</em><em class='l5'>" + tab + "</em><em class='l6'>" + tab + "<" +
+                                        "/em><em class='l7'>" + tab + "</em><em class='l8'>" + tab + "</em><em class='l" +
+                                        "9'>" + tab + "</em><em class='l10'>" + tab + "</em>",
+                                "<em class='l0'>" + tab + "</em><em class='l1'>" + tab +
+                                        "</em><em class='l2'>" + tab + "</em><em class='l3'>" + tab + "</em><em class='" +
+                                        "l4'>" + tab + "</em><em class='l5'>" + tab + "</em><em class='l6'>" + tab + "<" +
+                                        "/em><em class='l7'>" + tab + "</em><em class='l8'>" + tab + "</em><em class='l" +
+                                        "9'>" + tab + "</em><em class='l10'>" + tab + "</em><em class='l11'>" + tab + "</em>",
+                                "<em class='l0'>" + tab + "</em><em class='l1'>" + tab +
+                                        "</em><em class='l2'>" + tab + "</em><em class='l3'>" + tab + "</em><em class='" +
+                                        "l4'>" + tab + "</em><em class='l5'>" + tab + "</em><em class='l6'>" + tab + "<" +
+                                        "/em><em class='l7'>" + tab + "</em><em class='l8'>" + tab + "</em><em class='l" +
+                                        "9'>" + tab + "</em><em class='l10'>" + tab + "</em><em class='l11'>" + tab + "</em><em class='l12'>" +
+                                        tab + "</em>",
+                                "<em class='l0'>" + tab + "</em><em class='l1'>" + tab +
+                                        "</em><em class='l2'>" + tab + "</em><em class='l3'>" + tab + "</em><em class='" +
+                                        "l4'>" + tab + "</em><em class='l5'>" + tab + "</em><em class='l6'>" + tab + "<" +
+                                        "/em><em class='l7'>" + tab + "</em><em class='l8'>" + tab + "</em><em class='l" +
+                                        "9'>" + tab + "</em><em class='l10'>" + tab + "</em><em class='l11'>" + tab + "</em><em class='l12'>" +
+                                        tab + "</em><em class='l13'>" + tab + "</em>",
+                                "<em class='l0'>" + tab + "</em><em class='l1'>" + tab +
+                                        "</em><em class='l2'>" + tab + "</em><em class='l3'>" + tab + "</em><em class='" +
+                                        "l4'>" + tab + "</em><em class='l5'>" + tab + "</em><em class='l6'>" + tab + "<" +
+                                        "/em><em class='l7'>" + tab + "</em><em class='l8'>" + tab + "</em><em class='l" +
+                                        "9'>" + tab + "</em><em class='l10'>" + tab + "</em><em class='l11'>" + tab + "</em><em class='l12'>" +
+                                        tab + "</em><em class='l13'>" + tab + "</em><em class='l14'>" + tab + "</em>",
+                                "<em class='l0'>" + tab + "</em><em class='l1'>" + tab +
+                                        "</em><em class='l2'>" + tab + "</em><em class='l3'>" + tab + "</em><em class='" +
+                                        "l4'>" + tab + "</em><em class='l5'>" + tab + "</em><em class='l6'>" + tab + "<" +
+                                        "/em><em class='l7'>" + tab + "</em><em class='l8'>" + tab + "</em><em class='l" +
+                                        "9'>" + tab + "</em><em class='l10'>" + tab + "</em><em class='l11'>" + tab + "</em><em class='l12'>" +
+                                        tab + "</em><em class='l13'>" + tab + "</em><em class='l14'>" + tab + "</em><em" +
+                                        " class='l15'>" + tab + "</em>",
+                                "<em class='l0'>" + tab + "</em><em class='l1'>" + tab +
+                                        "</em><em class='l2'>" + tab + "</em><em class='l3'>" + tab + "</em><em class='" +
+                                        "l4'>" + tab + "</em><em class='l5'>" + tab + "</em><em class='l6'>" + tab + "<" +
+                                        "/em><em class='l7'>" + tab + "</em><em class='l8'>" + tab + "</em><em class='l" +
+                                        "9'>" + tab + "</em><em class='l10'>" + tab + "</em><em class='l11'>" + tab + "</em><em class='l12'>" +
+                                        tab + "</em><em class='l13'>" + tab + "</em><em class='l14'>" + tab + "</em><em" +
+                                        " class='l15'>" + tab + "</em><em class='l16'>" + tab + "</em>"
+                            ],
+                            //a function for calculating indentation after each new line
+                            nl                 = function jspretty__result_scope_nl(x, linetest) {
+                                var dd = 0;
+                                if (token[a] !== "x}" || (token[a] === "x}" && token[a + 1] !== "}")) {
+                                    data.push("<li>");
+                                    data.push(linecount);
+                                    data.push("</li>");
+                                    linecount = linecount + 1;
+                                    if (a < b - 1 && token[a + 1].indexOf("/*") === 0) {
+                                        build.push("<em>&#xA;</em></li><li class='c0'>");
+                                    } else {
+                                        build.push("<em>&#xA;</em></li><li class='l" + scope + "'>");
+                                        if (x > 0) {
+                                            dd = scope;
+                                            if (scope > 0) {
+                                                if (scope === x + 1 && x > 0 && linetest !== true) {
+                                                    dd = dd - 1;
+                                                }
+                                                build.push(lscope[dd - 1]);
+                                            }
+                                        } else if (linetest === true) {
+                                            build.push(lscope[0]);
+                                        }
+                                    }
+                                } else {
+                                    if (x > 0) {
+                                        dd = scope;
+                                        if (scope > 0) {
+                                            if (scope === x + 1 && x > 0 && linetest !== true) {
+                                                dd = dd - 1;
+                                            }
+                                            build.push(lscope[dd - 1]);
+                                        }
+                                    }
+                                }
+                                for (dd = dd; dd < x; dd = dd + 1) {
+                                    build.push(tab);
+                                }
+                            },
+                            rl                 = function jspretty__result_scope_rl(x) {
+                                var bb = token.length,
+                                    cc = 2,
+                                    dd = 0;
+                                for (dd = a + 2; dd < bb; dd = dd + 1) {
+                                    if (token[dd] === "x}") {
+                                        cc = cc + 1;
+                                    } else {
+                                        break;
+                                    }
+                                }
+                                nl(x - cc);
+                                a = a + 1;
+                            },
+                            markupBuild        = function jspretty__result_scope_markupBuild() {
+                                var mindent  = (function jspretty__result_scope_markupBuild_offset() {
+                                        var d = 0;
+                                        if (a === markupvar[0]) {
+                                            markupvar.splice(0, 1);
+                                            return 1;
+                                        }
+                                        if (token[d] === "return" || token[0] === "{") {
+                                            return 1;
+                                        }
+                                        if (level[a] < -9) {
+                                            return 0;
+                                        }
+                                        for (d = a - 1; d > -1; d = d - 1) {
+                                            if (token[d] !== "(" && token[d] !== "x(") {
+                                                if (token[d] === "=") {
+                                                    return 1;
+                                                }
+                                                return 0;
+                                            }
+                                        }
+                                        return 0;
+                                    }()),
+                                    markup   = (function jspretty__result_scope_markupBuild_varscope() {
+                                        var item    = "",
+                                            emscope = function jsscope__result_scope_markupBuild_varscope_emscope(x) {
+                                                return "<em class='s" + x
+                                                    .replace("[pdjsxem", "")
+                                                    .replace("]", "") + "'>";
+                                            },
+                                            word    = "",
+                                            newword = "",
+                                            inca    = 0,
+                                            incb    = 0,
+                                            lena    = meta.length,
+                                            lenb    = 0,
+                                            vars    = [],
+                                            mode    = options.mode,
+                                            inle    = options.inlevel,
+                                            jsx     = options.jsx;
+                                        options.source  = token[a];
+                                        options.mode    = "beautify";
+                                        options.inlevel = mindent;
+                                        options.jsx     = true;
+                                        item            = extlib().replace(/return\s+</g, "return <");
+                                        options.mode    = mode;
+                                        options.inlevel = inle;
+                                        options.jsx     = jsx;
+                                        if (item.indexOf("[pdjsxscope]") < 0) {
+                                            return item
+                                                .replace(/&/g, "&amp;")
+                                                .replace(/</g, "&lt;")
+                                                .replace(/>/g, "&gt;")
+                                                .split(lf);
+                                        }
+                                        do {
+                                            newword = "";
+                                            vars    = [];
+                                            word    = item.substring(
+                                                item.indexOf("[pdjsxscope]") + 12,
+                                                item.indexOf("[/pdjsxscope]")
+                                            );
+                                            for (inca = 0; inca < lena; inca = inca + 1) {
+                                                if (typeof meta[inca] === "number" && inca < a && a < meta[inca]) {
+                                                    vars.push(meta[inca]);
+                                                    lenb = meta[meta[inca]].length;
+                                                    for (incb = 0; incb < lenb; incb = incb + 1) {
+                                                        if (meta[meta[inca]][incb] === word) {
+                                                            newword = "[pdjsxem" + (
+                                                                vars.length + 1
+                                                            ) + "]" + word + "[/pdjsxem]";
+                                                        }
+                                                    }
+                                                    if (incb < lenb) {
+                                                        break;
+                                                    }
+                                                    vars.pop();
+                                                }
+                                            }
+                                            if (newword === "") {
+                                                lenb = globals.length;
+                                                for (incb = 0; incb < lenb; incb = incb + 1) {
+                                                    if (word === globals[incb]) {
+                                                        newword = "[pdjsxem0]" + word + "[/pdjsxem]";
+                                                    }
+                                                }
+                                                if (newword === "") {
+                                                    newword = word;
+                                                }
+                                            }
+                                            item = item.replace("[pdjsxscope]" + word + "[/pdjsxscope]", newword);
+                                        } while (item.indexOf("[pdjsxscope]") > -1);
+                                        return item
+                                            .replace(/&/g, "&amp;")
+                                            .replace(/</g, "&lt;")
+                                            .replace(/>/g, "&gt;")
+                                            .replace(/\[pdjsxem\d+\]/g, emscope)
+                                            .replace(/\[\/pdjsxem\]/g, "</em>")
+                                            .split(lf);
+                                    }()),
+                                    len      = 0,
+                                    c        = 0,
+                                    spaces   = 0,
+                                    synthtab = "\\" + tab.charAt(0),
+                                    tabreg   = {};
+                                len = tab.length;
+                                for (c = 1; c < len; c = c + 1) {
+                                    synthtab = synthtab + "\\" + tab.charAt(c);
+                                }
+                                tabreg  = new RegExp("^(" + synthtab + "+)");
+                                mindent = indent + 2;
+                                if (level[a] < -9) {
+                                    markup[0] = markup[0].replace(tabreg, "");
+                                    mindent   = mindent - 1;
+                                }
+                                len = markup.length;
+                                for (c = 0; c < len - 1; c = c + 1) {
+                                    if (markup[c].indexOf(tab) !== 0 && c > 0) {
+                                        spaces = markup[c - 1]
+                                            .split(tab)
+                                            .length - 1;
+                                        do {
+                                            spaces    = spaces - 1;
+                                            markup[c] = tab + markup[c];
+                                        } while (spaces > 0);
+                                    }
+                                    build.push(markup[c]);
+                                    nl(mindent - 1);
+                                }
+                                build.push(markup[markup.length - 1]);
+                            },
+                            multiline          = function jspretty__result_scope_multiline(x) {
+                                var temparray = x.split(lf),
+                                    c         = 0,
+                                    d         = temparray.length;
+                                build.push(temparray[0]);
+                                for (c = 1; c < d; c = c + 1) {
+                                    nl(indent);
+                                    build.push(temparray[c]);
+                                }
+                            },
+                            endcomma_multiline = function jspretty__result_scope_endcommaMultiline() {
+                                var c = a;
+                                if (types[c] === "comment" || types[c] === "comment-inline") {
+                                    do {
+                                        c = c - 1;
+                                    } while (c > 0 && (types[c] === "comment" || types[c] === "comment-inline"));
+                                }
+                                token[c] = token[c] + ",";
+                            };
+                        if (verticalop === true) {
+                            vertical();
+                        }
+                        if (types[a] === "comment" && token[a].indexOf("/*") === 0) {
+                            build.push("<ol class='data'><li class='c0'>");
+                        } else {
+                            build.push("<ol class='data'><li>");
+                        }
+                        for (a = 0; a < indent; a = a + 1) {
+                            build.push(tab);
+                        }
+                        // its important to find the variables separately from building the output so
+                        // that recursive flows in the loop incrementation do not present simple
+                        // counting collisions as to what gets modified versus what gets included
+                        for (a = b - 1; a > -1; a = a - 1) {
+                            if (typeof meta[a] === "number") {
+                                scope = scope - 1;
+                                findvars(a);
+                            } else if (meta[a] !== undefined && typeof meta[a] !== "string" && typeof meta[a] !== "number" && a > 0 && token[a] !== "x;" && token[a] !== "x}" && token[a] !== "x{" && token[a] !== "x(" && token[a] !== "x)") {
+                                token[a] = "<em class='s" + scope + "'>" + token[a] + "</em>";
+                                scope    = scope + 1;
+                                if (scope > 16) {
+                                    scope = 16;
+                                }
+                            }
+                        }
+                        (function jspretty__result_scope_globals() {
+                            var aa          = 0,
+                                bb          = token.length,
+                                globalLocal = globals,
+                                dd          = globalLocal.length,
+                                ee          = 0,
+                                word        = [],
+                                wordlen     = 0;
+                            for (aa = bb - 1; aa > 0; aa = aa - 1) {
+                                if (types[aa] === "word" && (token[aa + 1] !== ":" || (token[aa + 1] === ":" && level[aa + 1] === -20)) && token[aa].indexOf("<em ") < 0) {
+                                    word = token[aa].split(" ");
+                                    for (ee = dd - 1; ee > -1; ee = ee - 1) {
+                                        if (word[0] === globalLocal[ee] && token[aa - 1] !== ".") {
+                                            if (token[aa - 1] === "function" && depth[aa + 1] === "method") {
+                                                token[aa] = "<em class='s1'>" + word[0] + "</em>";
+                                                wordlen   = word.length;
+                                                if (wordlen > 1) {
+                                                    do {
+                                                        token[aa] = token[aa] + " ";
+                                                        wordlen   = wordlen - 1;
+                                                    } while (wordlen > 1);
+                                                }
+                                            } else {
+                                                token[aa] = "<em class='s0'>" + word[0] + "</em>";
+                                                wordlen   = word.length;
+                                                if (wordlen > 1) {
+                                                    do {
+                                                        token[aa] = token[aa] + " ";
+                                                        wordlen   = wordlen - 1;
+                                                    } while (wordlen > 1);
+                                                }
+                                            }
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }());
+                        scope = 0;
+                        // this loops combines the white space as determined from the algorithm with the
+                        // tokens to create the output
+                        for (a = 0; a < b; a = a + 1) {
+                            if (typeof meta[a] === "number") {
+                                folder();
+                            }
+                            if (comfold === -1 && types[a] === "comment" && ((token[a].indexOf("/*") === 0 && token[a].indexOf("\n") > 0) || types[a + 1] === "comment" || lines[a] > 1)) {
+                                folder();
+                                comfold = a;
+                            }
+                            if (comfold > -1 && types[a] !== "comment") {
+                                foldclose();
+                                comfold = -1;
+                            }
+                            if (options.endcomma === "multiline" && (token[a + 1] === "]" || token[a + 1] === "}") && level[a] !== -20) {
+                                endcomma_multiline();
+                            }
+                            if (types[a] === "comment" && token[a].indexOf("/*") === 0) {
+                                build.push(blockline(token[a]));
+                            } else if (token[a] !== "x;" && token[a] !== "x{" && token[a] !== "x}" && token[a] !== "x(" && token[a] !== "x)") {
+                                if (typeof meta[a] === "number") {
+                                    scope = scope + 1;
+                                    if (scope > 16) {
+                                        scope = 16;
+                                    }
+                                    build.push(token[a]);
+                                } else if (typeof meta[a] !== "string" && typeof meta[a] !== "number") {
+                                    build.push(token[a]);
+                                    scope    = scope - 1;
+                                    buildlen = build.length - 1;
+                                    do {
+                                        buildlen = buildlen - 1;
+                                    } while (buildlen > 0 && build[buildlen].indexOf("</li><li") < 0);
+                                    build[buildlen] = build[buildlen].replace(
+                                        /class\='l\d+'/,
+                                        "class='l" + scope + "'"
+                                    );
+                                } else if (token[a] !== "x;" && token[a] !== "x{" && token[a] !== "x}" && token[a] !== "x(" && token[a] !== "x)") {
+                                    if (types[a] === "markup") {
+                                        if (level[a] > -9) {
+                                            if (types[a - 1] === "operator") {
+                                                nl(indent);
+                                            } else if (token[a - 1] !== "return") {
+                                                nl(indent + 1);
+                                            }
+                                        }
+                                        if (typeof global.prettydiff.markuppretty === "function") {
+                                            markupBuild();
+                                        } else {
+                                            build.push(token[a].replace(/\r?\n(\s*)/g, " "));
+                                        }
+                                    } else if (types[a] === "comment") {
+                                        if (types[a - 1] !== "comment" && types[a - 1] !== "comment-inline") {
+                                            nl(indent);
+                                        }
+                                        if (a === 0) {
+                                            build[0] = "<ol class='data'><li class='c0'>";
+                                        } else {
+                                            buildlen = build.length - 1;
+                                            if (build[buildlen].indexOf("<li") < 0) {
+                                                do {
+                                                    build[buildlen] = build[buildlen]
+                                                        .replace(/<em\u0020class\='[a-z]\d+'>/g, "")
+                                                        .replace(/<\/em>/g, "");
+                                                    buildlen        = buildlen - 1;
+                                                    if (buildlen > 0 && build[buildlen] === undefined) {
+                                                        buildlen = buildlen - 1;
+                                                    }
+                                                } while (
+                                                    buildlen > 0 && build[buildlen - 1] !== undefined && build[buildlen].indexOf("<li") < 0
+                                                );
+                                            }
+                                            if ((/^(<em>&#xA;<\/em><\/li><li\u0020class='l\d+'>)$/).test(build[buildlen - 1]) === true) {
+                                                build[buildlen - 1] = build[buildlen - 1].replace(
+                                                    /class\='l\d+'/,
+                                                    "class='c0'"
+                                                );
+                                            }
+                                            build[buildlen] = build[buildlen].replace(/class\='l\d+'/, "class='c0'");
+                                        }
+                                        build.push(token[a]);
+                                    } else {
+                                        if (types[a] === "literal" && token[a].indexOf("\n") > 0) {
+                                            multiline(token[a]);
+                                        } else {
+                                            build.push(token[a]);
+                                        }
+                                    }
+                                }
+                            }
+                            // this condition performs additional calculations for options.preserve.
+                            // options.preserve determines whether empty lines should be preserved from the
+                            // code input
+                            if (options.preserve > 0 && lines[a] > 0 && level[a] > -9 && token[a] !== "+") {
+                                //special treatment for math operators
+                                if (token[a] === "+" || token[a] === "-" || token[a] === "*" || token[a] === "/") {
+                                    //comments get special treatment
+                                    if (a < b - 1 && types[a + 1] !== "comment" && types[a + 1] !== "comment-inline") {
+                                        nl(level[a]);
+                                        build.push(tab);
+                                        level[a] = -20;
+                                    } else {
+                                        indent = level[a];
+                                        if (lines[a] > 1) {
+                                            do {
+                                                build.push(lf);
+                                                lines[a] = lines[a] - 1;
+                                            } while (lines[a] > 1);
+                                        }
+                                        nl(indent);
+                                        build.push(tab);
+                                        build.push(token[a + 1]);
+                                        nl(indent);
+                                        build.push(tab);
+                                        level[a + 1] = -20;
+                                        a            = a + 1;
+                                    }
+                                } else if (lines[a] > 1 && token[a].charAt(0) !== "=" && token[a].charAt(0) !== "!" && (types[a] !== "start" || (a < b - 1 && types[a + 1] !== "end"))) {
+                                    if ((token[a] !== "x}" || isNaN(level[a]) === true) && (a < b - 1 && (types[a + 1] === "comment" || types[a + 1] === "comment-inline" || (token[a] !== "." && types[a + 1] !== "separator")))) {
+                                        do {
+                                            nl(0, true);
+                                            lines[a] = lines[a] - 1;
+                                        } while (lines[a] > 1);
+                                        if (types[a] === "comment") {
+                                            build.push("<em>&#xA;</em></li><li class='c0'>");
+                                        } else {
+                                            commentfix = commentfix + 1;
+                                            nl(level[a], true);
+                                        }
+                                    }
+                                }
+                            }
+                            if ((token[a] === ";" || token[a] === "x;") && token[a + 1] === "x}" && ((/<em\u0020class='s\d+'>\}<\/em>/).test(token[a + 2]) === true || token[a + 2] === "x}")) {
+                                rl(indent);
+                            } else if (token[a] === "x{" && level[a] === -10 && level[a - 1] === -10) {
+                                build.push("");
+                            } else if (a < b - 1 && types[a + 1] === "comment" && options.comments === "noindent") {
+                                nl(options.inlevel);
+                            } else if (level[a] === -10 && token[a] !== "x}") {
+                                build.push(" ");
+                            } else if (token[a] !== "" && level[a] !== -20 && (token[a] !== "x}" || (token[a] === "x}" && (token[a - 1] === "x;" || token[a - 1] === ";") && types[a + 1] !== "word") || lines[a] > 1)) {
+                                indent = level[a];
+                                nl(indent);
+                            }
+                            if (folderItem.length > 0) {
+                                if (a === folderItem[folderItem.length - 1][1] && comfold === -1) {
+                                    foldclose();
+                                }
+                            }
+                        }
+                        for (a = build.length - 1; a > -1; a = a - 1) {
+                            if (build[a] === tab) {
+                                build.pop();
+                            } else {
+                                break;
+                            }
+                        }
+                        //this logic is necessary to some line counting corrections to the HTML output
+                        last = build[build.length - 1];
+                        if (last.indexOf("<li") > 0) {
+                            build[build.length - 1] = "<em>&#xA;</em></li>";
+                        } else if (last.indexOf("</li>") < 0) {
+                            build.push("<em>&#xA;</em></li>");
+                        }
+                        build.push("</ol></div>");
+                        last = build.join("");
+                        if (last.match(/<li/g) !== null) {
+                            scope = last
+                                .match(/<li/g)
+                                .length;
+                            if (linecount - 1 > scope) {
+                                linecount = linecount - 1;
+                                do {
+                                    data.pop();
+                                    data.pop();
+                                    data.pop();
+                                    linecount = linecount - 1;
+                                } while (linecount > scope);
+                            }
+                        }
+                        data.push("</ol>");
+                        if (options.jsscope === "html") {
+                            data.push(last);
+                            if (options.newline === true) {
+                                if (options.crlf === true) {
+                                    data.push("\r\n");
+                                } else {
+                                    data.push("\n");
+                                }
+                            }
+                            return data.join("");
+                        }
+                        build = [
+                            "<p>Scope analysis does not provide support for undeclared variables.</p>",
+                            "<p><em>",
+                            scolon,
+                            "</em> instances of <strong>missing semicolons</strong> counted.</p>",
+                            "<p><em>",
+                            news,
+                            "</em> unnecessary instances of the keyword <strong>new</strong> counted.</p>",
+                            data.join(""),
+                            last
+                        ];
+                        if (options.newline === true) {
+                            if (options.crlf === true) {
+                                build.push("\r\n");
+                            } else {
+                                build.push("\n");
+                            }
+                        }
+                        if (options.nodeasync === true) {
+                            return [build.join(""), globalerror];
+                        }
+                        return build.join("");
+                    }())
+                        .replace(/(\s+)$/, "")
+                        .replace(options.functions.binaryCheck, "");
+                } else {
+                    result = (function jspretty__result_standard() {
+                        var a                  = 0,
+                            b                  = token.length,
+                            build              = [],
+                            indent             = options.inlevel,
+                            //a function for calculating indentation after each new line
+                            nl                 = function jspretty__result_standard_nl(x) {
+                                var dd = 0;
+                                build.push(lf);
+                                for (dd = 0; dd < x; dd = dd + 1) {
+                                    build.push(tab);
+                                }
+                            },
+                            rl                 = function jspretty__result_standard_rl(x) {
+                                var bb = token.length,
+                                    cc = 2,
+                                    dd = 0;
+                                for (dd = a + 2; dd < bb; dd = dd + 1) {
+                                    if (token[dd] === "x}") {
+                                        cc = cc + 1;
+                                    } else {
+                                        break;
+                                    }
+                                }
+                                nl(x - cc);
+                                a = a + 1;
+                            },
+                            markupwrapper      = function jspretty__result_standard_markupwrapper() {
+                                var inle = options.inlevel,
+                                    mode = options.mode,
+                                    jsx  = options.jsx;
+                                options.source = token[a];
+                                options.jsx    = true;
+                                options.mode   = "beautify";
+                                if (level[a] < -9 || depth[a] === "array" || token[begin[a]] === "(") {
+                                    options.inlevel = indent;
+                                } else {
+                                    options.inlevel = indent + 1;
+                                }
+                                build.push(extlib(options));
+                                options.jsx     = jsx;
+                                options.mode    = mode;
+                                options.inlevel = inle;
+                            },
+                            endcomma_multiline = function jspretty__result_standard_endcommaMultiline() {
+                                var c = a;
+                                if (types[c] === "comment" || types[c] === "comment-inline") {
+                                    do {
+                                        c = c - 1;
+                                    } while (c > 0 && (types[c] === "comment" || types[c] === "comment-inline"));
+                                }
+                                token[c] = token[c] + ",";
+                            };
+                        if (verticalop === true) {
+                            vertical();
+                        }
+                        for (a = 0; a < indent; a = a + 1) {
+                            build.push(tab);
+                        }
+                        // this loops combines the white space as determined from the algorithm with the
+                        // tokens to create the output
+                        for (a = 0; a < b; a = a + 1) {
+                            if (options.endcomma === "multiline" && (token[a + 1] === "]" || token[a + 1] === "}") && level[a] > -20) {
+                                endcomma_multiline();
+                            }
+                            if (types[a] === "comment" || (token[a] !== "x;" && token[a] !== "x{" && token[a] !== "x}" && token[a] !== "x(" && token[a] !== "x)")) {
+                                if (types[a] === "markup") {
+                                    if (level[a - 1] > -9 && token[a - 1] !== "return" && depth[a] !== "global" && depth[a] !== "array" && types[a] !== "markup") {
+                                        build.push(tab);
+                                    }
+                                    if (typeof global.prettydiff.markuppretty === "function") {
+                                        markupwrapper();
+                                    } else {
+                                        build.push(token[a].replace(/\r?\n(\s*)/g, " "));
+                                    }
+                                } else {
+                                    build.push(token[a]);
+                                }
+                            }
+                            // this condition performs additional calculations if options.preserve === true.
+                            // options.preserve determines whether empty lines should be preserved from the
+                            // code input
+                            if (options.preserve > 0 && ((lines[a] > 0 && level[a] > -9 && token[a] !== "+" && options.qml === false) || (options.qml === true && lines[a] > 1))) {
+                                if (options.qml === true) {
+                                    do {
+                                        build.push(lf);
+                                        lines[a] = lines[a] - 1;
+                                    } while (lines[a] > 1);
+                                    //special treatment for math operators
+                                } else if (token[a] === "+" || token[a] === "-" || token[a] === "*" || token[a] === "/") {
+                                    //comments get special treatment
+                                    if (a < b - 1 && types[a + 1] !== "comment" && types[a + 1] !== "comment-inline") {
+                                        nl(level[a]);
+                                        build.push(tab);
+                                        level[a] = -20;
+                                    } else {
+                                        indent = level[a];
+                                        if (lines[a] > 1) {
+                                            do {
+                                                build.push(lf);
+                                                lines[a] = lines[a] - 1;
+                                            } while (lines[a] > 1);
+                                        }
+                                        nl(indent);
+                                        build.push(tab);
+                                        build.push(token[a + 1]);
+                                        nl(indent);
+                                        build.push(tab);
+                                        level[a + 1] = -20;
+                                        a            = a + 1;
+                                    }
+                                } else if (lines[a] > 1 && token[a].charAt(0) !== "=" && token[a].charAt(0) !== "!" && (types[a] !== "start" || (a < b - 1 && types[a + 1] !== "end"))) {
+                                    if (a < b - 1 && (types[a + 1] === "comment" || types[a + 1] === "comment-inline" || (token[a] !== "." && types[a + 1] !== "separator"))) {
+                                        if (token[a] !== "x}" || isNaN(level[a]) === true || level[a] === -20) {
+                                            do {
+                                                build.push(lf);
+                                                lines[a] = lines[a] - 1;
+                                            } while (lines[a] > 1);
+                                        }
+                                    }
+                                }
+                            }
+                            if ((token[a] === ";" || token[a] === "x;") && token[a + 1] === "x}" && (token[a + 2] === "}" || token[a + 2] === "x}")) {
+                                rl(indent);
+                            } else if (token[a] === "x{" && level[a] === -10 && level[a - 1] === -10) {
+                                build.push("");
+                                //adds a new line and no indentation
+                            } else if (a < b - 1 && types[a + 1] === "comment" && options.comments === "noindent") {
+                                nl(options.inlevel);
+                            } else if (level[a] === -10 && token[a] !== "x}") {
+                                build.push(" ");
+                                //adds a new line and indentation
+                            } else if (token[a] !== "" && level[a] !== -20 && (token[a] !== "x}" || (token[a] === "x}" && (token[a - 1] === "x;" || token[a - 1] === ";") && types[a + 1] !== "word") || lines[a] > 1)) {
+                                indent = level[a];
+                                nl(indent);
+                            }
+                        }
+                        for (a = build.length - 1; a > -1; a = a - 1) {
+                            if (build[a] === tab) {
+                                build.pop();
+                            } else {
+                                break;
+                            }
+                        }
+                        if (options.preserve > 0 && lines[lines.length - 1] > 0) {
+                            if (options.nodeasync === true) {
+                                return [
+                                    build
+                                        .join("")
+                                        .replace(/(\s+)$/, lf),
+                                    globalerror
+                                ];
+                            }
+                            return build
+                                .join("")
+                                .replace(/(\s+)$/, lf);
+                        }
+                        if (options.newline === true) {
+                            if (options.crlf === true) {
+                                build.push("\r\n");
+                            } else {
+                                build.push("\n");
+                            }
+                        }
+                        if (options.nodeasync === true) {
+                            return [
+                                build
+                                    .join("")
+                                    .replace(/(\s+)$/, ""),
+                                globalerror
+                            ];
+                        }
+                        return build
+                            .join("")
+                            .replace(/(\s+)$/, "");
+                    }());
+                }
+            }());
+            //the analysis report is generated in this function
+            if (options.mode === "analysis") {
+                stats.space.space = stats.space.space - 1;
+                return (function jspretty__report() {
+                    var noOfLines = result
+                            .split(lf)
+                            .length,
+                        newlines  = stats.space.newline,
+                        percent   = 0,
+                        total     = {
+                            chars  : 0,
+                            comment: {
+                                chars: stats.commentBlock.chars + stats.commentLine.chars,
+                                token: stats.commentBlock.token + stats.commentLine.token
+                            },
+                            literal: {
+                                chars: stats.number.chars + stats.regex.chars + stats.string.chars,
+                                token: stats.number.token + stats.regex.token + stats.string.token
+                            },
+                            space  : stats.space.newline + stats.space.other + stats.space.space + stats.space.tab,
+                            syntax : {
+                                chars: 0,
+                                token: stats.string.quote + stats.comma + stats.semicolon + stats.container
+                            },
+                            token  : 0
+                        },
+                        output    = [],
+                        zero      = function jspretty__report_zero(x, y) {
+                            var ratio = 0;
+                            if (y === 0) {
+                                return "0.00%";
+                            }
+                            ratio = ((x / y) * 100);
+                            return ratio.toFixed(2) + "%";
+                        };
+                    total.syntax.chars = total.syntax.token + stats.operator.chars;
+                    total.syntax.token = total.syntax.token + stats.operator.token;
+                    total.token        = stats.server.token + stats.word.token + total.comment.token +
+                            total.literal.token + total.space + total.syntax.token;
+                    total.chars        = stats.server.chars + stats.word.chars + total.comment.chars +
+                            total.literal.chars + total.space + total.syntax.chars;
+                    if (newlines === 0) {
+                        newlines = 1;
+                    }
+                    output.push("<div class='report'>");
+                    if (error.length > 0) {
+                        output.push("<p id='jserror'><strong>Error: ");
+                        output.push(
+                            error[0].replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(options.functions.binaryCheck, "")
+                        );
+                        output.push("</strong> <code><span>");
+                        error[1] = error[1]
+                            .replace(/&/g, "&amp;")
+                            .replace(/</g, "&lt;")
+                            .replace(/>/g, "&gt;")
+                            .replace(options.functions.binaryCheck, "")
+                            .replace(/^(\s+)/, "");
+                        if (error.indexOf("\n") > 0) {
+                            output.push(error[1].replace(lf, "</span>"));
+                        } else {
+                            output.push(error[1]);
+                            output.push("</span>");
+                        }
+                        output.push("</code></p>");
+                    }
+                    output.push("<p><em>");
+                    output.push(scolon);
+                    output.push("</em> instance");
+                    if (scolon !== 1) {
+                        output.push("s");
+                    }
+                    output.push(" of <strong>missing semicolons</strong> counted.</p>");
+                    output.push("<p><em>");
+                    output.push(news);
+                    output.push("</em> unnessary instance");
+                    if (news !== 1) {
+                        output.push("s");
+                    }
+                    output.push(" of the keyword <strong>new</strong> counted.</p>");
+                    output.push(
+                        "<table class='analysis' summary='JavaScript character size comparison'><captio" +
+                        "n>JavaScript data report</caption><thead><tr><th>Data Label</th><th>Input</th>" +
+                        "<th>Output</th><th>Literal Increase</th><th>Percentage Increase</th></tr>"
+                    );
+                    output.push("</thead><tbody><tr><th>Total Character Size</th><td>");
+                    output.push(originalSize);
+                    output.push("</td><td>");
+                    output.push(result.length);
+                    output.push("</td><td>");
+                    output.push(result.length - originalSize);
+                    output.push("</td><td>");
+                    percent = (((result.length - originalSize) / originalSize) * 100);
+                    output.push(percent.toFixed(2));
+                    output.push("%</td></tr><tr><th>Total Lines of Code</th><td>");
+                    output.push(newlines);
+                    output.push("</td><td>");
+                    output.push(noOfLines);
+                    output.push("</td><td>");
+                    output.push(noOfLines - newlines);
+                    output.push("</td><td>");
+                    percent = (((noOfLines - newlines) / newlines) * 100);
+                    output.push(percent.toFixed(2));
+                    output.push("%</td></tr></tbody></table>");
+                    output.push(
+                        "<table class='analysis' summary='JavaScript component analysis'><caption>JavaS" +
+                        "cript component analysis</caption><thead><tr><th>JavaScript Component</th><th>" +
+                        "Component Quantity</th><th>Percentage Quantity from Section</th>"
+                    );
+                    output.push(
+                        "<th>Percentage Qauntity from Total</th><th>Character Length</th><th>Percentage" +
+                        " Length from Section</th><th>Percentage Length from Total</th></tr></thead><tb" +
+                        "ody>"
+                    );
+                    output.push("<tr><th>Total Accounted</th><td>");
+                    output.push(total.token);
+                    output.push("</td><td>100.00%</td><td>100.00%</td><td>");
+                    output.push(total.chars);
+                    output.push(
+                        "</td><td>100.00%</td><td>100.00%</td></tr><tr><th colspan='7'>Comments</th></t" +
+                        "r><tr><th>Block Comments</th><td>"
+                    );
+                    output.push(stats.commentBlock.token);
+                    output.push("</td><td>");
+                    output.push(zero(stats.commentBlock.token, total.comment.token));
+                    output.push("</td><td>");
+                    output.push(zero(stats.commentBlock.token, total.token));
+                    output.push("</td><td>");
+                    output.push(stats.commentBlock.chars);
+                    output.push("</td><td>");
+                    output.push(zero(stats.commentBlock.chars, total.comment.chars));
+                    output.push("</td><td>");
+                    output.push(zero(stats.commentBlock.chars, total.chars));
+                    output.push("</td></tr><tr><th>Inline Comments</th><td>");
+                    output.push(stats.commentLine.token);
+                    output.push("</td><td>");
+                    output.push(zero(stats.commentLine.token, total.comment.token));
+                    output.push("</td><td>");
+                    output.push(zero(stats.commentLine.token, total.token));
+                    output.push("</td><td>");
+                    output.push(stats.commentLine.chars);
+                    output.push("</td><td>");
+                    output.push(zero(stats.commentLine.chars, total.comment.chars));
+                    output.push("</td><td>");
+                    output.push(zero(stats.commentLine.chars, total.chars));
+                    output.push("</td></tr><tr><th>Comment Total</th><td>");
+                    output.push(total.comment.token);
+                    output.push("</td><td>100.00%</td><td>");
+                    output.push(zero(total.comment.token, total.token));
+                    output.push("</td><td>");
+                    output.push(total.comment.chars);
+                    output.push("</td><td>100.00%</td><td>");
+                    output.push(zero(total.comment.chars, total.chars));
+                    output.push(
+                        "</td></tr><tr><th colspan='7'>Whitespace Outside of Strings and Comments</th><" +
+                        "/tr><tr><th>New Lines</th><td>"
+                    );
+                    output.push(stats.space.newline);
+                    output.push("</td><td>");
+                    output.push(zero(stats.space.newline, total.space));
+                    output.push("</td><td>");
+                    output.push(zero(stats.space.newline, total.token));
+                    output.push("</td><td>");
+                    output.push(stats.space.newline);
+                    output.push("</td><td>");
+                    output.push(zero(stats.space.newline, total.space));
+                    output.push("</td><td>");
+                    output.push(zero(stats.space.newline, total.chars));
+                    output.push("</td></tr><tr><th>Spaces</th><td>");
+                    output.push(stats.space.space);
+                    output.push("</td><td>");
+                    output.push(zero(stats.space.space, total.space));
+                    output.push("</td><td>");
+                    output.push(zero(stats.space.space, total.token));
+                    output.push("</td><td>");
+                    output.push(stats.space.space);
+                    output.push("</td><td>");
+                    output.push(zero(stats.space.space, total.space));
+                    output.push("</td><td>");
+                    output.push(zero(stats.space.space, total.chars));
+                    output.push("</td></tr><tr><th>Tabs</th><td>");
+                    output.push(stats.space.tab);
+                    output.push("</td><td>");
+                    output.push(zero(stats.space.tab, total.space));
+                    output.push("</td><td>");
+                    output.push(zero(stats.space.tab, total.token));
+                    output.push("</td><td>");
+                    output.push(stats.space.tab);
+                    output.push("</td><td>");
+                    output.push(zero(stats.space.tab, total.space));
+                    output.push("</td><td>");
+                    output.push(zero(stats.space.tab, total.chars));
+                    output.push("</td></tr><tr><th>Other Whitespace</th><td>");
+                    output.push(stats.space.other);
+                    output.push("</td><td>");
+                    output.push(zero(stats.space.other, total.space));
+                    output.push("</td><td>");
+                    output.push(zero(stats.space.other, total.token));
+                    output.push("</td><td>");
+                    output.push(stats.space.other);
+                    output.push("</td><td>");
+                    output.push(zero(stats.space.other, total.space));
+                    output.push("</td><td>");
+                    output.push(zero(stats.space.other, total.chars));
+                    output.push("</td></tr><tr><th>Total Whitespace</th><td>");
+                    output.push(total.space);
+                    output.push("</td><td>100.00%</td><td>");
+                    output.push(zero(total.space, total.token));
+                    output.push("</td><td>");
+                    output.push(total.space);
+                    output.push("</td><td>100.00%</td><td>");
+                    output.push(zero(total.space, total.chars));
+                    output.push(
+                        "</td></tr><tr><th colspan='7'>Literals</th></tr><tr><th>Strings</th><td>"
+                    );
+                    output.push(stats.string.token);
+                    output.push("</td><td>");
+                    output.push(zero(stats.string.token, total.literal.token));
+                    output.push("</td><td>");
+                    output.push(zero(stats.string.token, total.token));
+                    output.push("</td><td>");
+                    output.push(stats.string.chars);
+                    output.push("</td><td>");
+                    output.push(zero(stats.string.chars, total.literal.chars));
+                    output.push("</td><td>");
+                    output.push(zero(stats.string.chars, total.chars));
+                    output.push("</td></tr><tr><th>Numbers</th><td>");
+                    output.push(stats.number.token);
+                    output.push("</td><td>");
+                    output.push(zero(stats.number.token, total.literal.token));
+                    output.push("</td><td>");
+                    output.push(zero(stats.number.token, total.token));
+                    output.push("</td><td>");
+                    output.push(stats.number.chars);
+                    output.push("</td><td>");
+                    output.push(zero(stats.number.chars, total.literal.chars));
+                    output.push("</td><td>");
+                    output.push(zero(stats.number.chars, total.chars));
+                    output.push("</td></tr><tr><th>Regular Expressions</th><td>");
+                    output.push(stats.regex.token);
+                    output.push("</td><td>");
+                    output.push(zero(stats.regex.token, total.literal.token));
+                    output.push("</td><td>");
+                    output.push(zero(stats.regex.token, total.token));
+                    output.push("</td><td>");
+                    output.push(stats.regex.chars);
+                    output.push("</td><td>");
+                    output.push(zero(stats.regex.chars, total.literal.chars));
+                    output.push("</td><td>");
+                    output.push(zero(stats.regex.chars, total.chars));
+                    output.push("</td></tr><tr><th>Total Literals</th><td>");
+                    output.push(total.literal.token);
+                    output.push("</td><td>100.00%</td><td>");
+                    output.push(zero(total.literal.token, total.token));
+                    output.push("</td><td>");
+                    output.push(total.literal.chars);
+                    output.push("</td><td>100.00%</td><td>");
+                    output.push(zero(total.literal.chars, total.chars));
+                    output.push(
+                        "</td></tr><tr><th colspan='7'>Syntax Characters</th></tr><tr><th>Quote Charact" +
+                        "ers</th><td>"
+                    );
+                    output.push(stats.string.quote);
+                    output.push("</td><td>");
+                    output.push(zero(stats.string.quote, total.syntax.token));
+                    output.push("</td><td>");
+                    output.push(zero(stats.string.quote, total.token));
+                    output.push("</td><td>");
+                    output.push(stats.string.quote);
+                    output.push("</td><td>");
+                    output.push(zero(stats.string.quote, total.syntax.chars));
+                    output.push("</td><td>");
+                    output.push(zero(stats.string.quote, total.chars));
+                    output.push("</td></tr><tr><th>Commas</th><td>");
+                    output.push(stats.comma);
+                    output.push("</td><td>");
+                    output.push(zero(stats.comma, total.syntax.token));
+                    output.push("</td><td>");
+                    output.push(zero(stats.comma, total.token));
+                    output.push("</td><td>");
+                    output.push(stats.comma);
+                    output.push("</td><td>");
+                    output.push(zero(stats.comma, total.syntax.chars));
+                    output.push("</td><td>");
+                    output.push(zero(stats.comma, total.chars));
+                    output.push("</td></tr><tr><th>Containment Characters</th><td>");
+                    output.push(stats.container);
+                    output.push("</td><td>");
+                    output.push(zero(stats.container, total.syntax.token));
+                    output.push("</td><td>");
+                    output.push(zero(stats.container, total.token));
+                    output.push("</td><td>");
+                    output.push(stats.container);
+                    output.push("</td><td>");
+                    output.push(zero(stats.container, total.syntax.chars));
+                    output.push("</td><td>");
+                    output.push(zero(stats.container, total.chars));
+                    output.push("</td></tr><tr><th>Semicolons</th><td>");
+                    output.push(stats.semicolon);
+                    output.push("</td><td>");
+                    output.push(zero(stats.semicolon, total.syntax.token));
+                    output.push("</td><td>");
+                    output.push(zero(stats.semicolon, total.token));
+                    output.push("</td><td>");
+                    output.push(stats.semicolon);
+                    output.push("</td><td>");
+                    output.push(zero(stats.semicolon, total.syntax.chars));
+                    output.push("</td><td>");
+                    output.push(zero(stats.semicolon, total.chars));
+                    output.push("</td></tr><tr><th>Operators</th><td>");
+                    output.push(stats.operator.token);
+                    output.push("</td><td>");
+                    output.push(zero(stats.operator.token, total.syntax.token));
+                    output.push("</td><td>");
+                    output.push(zero(stats.operator.token, total.token));
+                    output.push("</td><td>");
+                    output.push(stats.operator.chars);
+                    output.push("</td><td>");
+                    output.push(zero(stats.operator.chars, total.syntax.chars));
+                    output.push("</td><td>");
+                    output.push(zero(stats.operator.chars, total.chars));
+                    output.push("</td></tr><tr><th>Total Syntax Characters</th><td>");
+                    output.push(total.syntax.token);
+                    output.push("</td><td>100.00%</td><td>");
+                    output.push(zero(total.syntax.token, total.token));
+                    output.push("</td><td>");
+                    output.push(total.syntax.chars);
+                    output.push("</td><td>100.00%</td><td>");
+                    output.push(zero(total.syntax.chars, total.chars));
+                    output.push("</td></tr>");
+                    output.push(
+                        "<tr><th colspan='7'>Keywords and Variables</th></tr><tr><th>Words</th><td>"
+                    );
+                    output.push(stats.word.token);
+                    output.push("</td><td>100.00%</td><td>");
+                    output.push(zero(stats.word.token, total.token));
+                    output.push("</td><td>");
+                    output.push(stats.word.chars);
+                    output.push("</td><td>100.00%</td><td>");
+                    output.push(zero(stats.word.chars, total.chars));
+                    output.push("</td></tr>");
+                    output.push(
+                        "<tr><th colspan='7'>Server-side Tags</th></tr><tr><th>Server Tags</th><td>"
+                    );
+                    output.push(stats.server.token);
+                    output.push("</td><td>100.00%</td><td>");
+                    output.push(zero(stats.server.token, total.token));
+                    output.push("</td><td>");
+                    output.push(stats.server.chars);
+                    output.push("</td><td>100.00%</td><td>");
+                    output.push(zero(stats.server.chars, total.chars));
+                    output.push("</td></tr></tbody></table></div>");
+                    if (options.nodeasync === true) {
+                        return [output.join(""), globalerror];
+                    }
+                    return output.join("");
+                }());
+            }
+        }
+        return result;
+    };
+
+    if ((typeof define === "object" || typeof define === "function") && (typeof ace !== "object" || ace.prettydiffid === undefined)) {
+        //requirejs support
+        define(function jspretty_requirejs() {
+            return function jspretty_requirejs_wrapper(x) {
+                return jspretty(x);
+            };
+        });
+    } else if (typeof module === "object" && typeof module.parent === "object") {
+        //commonjs and nodejs support
+        module.exports = jspretty;
+        if (typeof require === "function" && (typeof ace !== "object" || ace.prettydiffid === undefined)) {
+            (function glib_jspretty() {
+                var localPath = (
+                    typeof process === "object" && typeof process.cwd === "function" && (process.cwd() === "/" || (/^([a-z]:\\)$/).test(process.cwd()) === true) && typeof __dirname === "string"
+                )
+                    ? __dirname
+                    : ".";
+                if (global.prettydiff.markuppretty === undefined) {
+                    global.prettydiff.markuppretty = require(
+                        localPath + "/markuppretty.js"
+                    );
+                }
+            }());
+        }
+    } else {
+        global.prettydiff.jspretty = jspretty;
+    }
+}());

--- a/node_modules/prettydiff/lib/language.js
+++ b/node_modules/prettydiff/lib/language.js
@@ -1,0 +1,319 @@
+/*global ace, define, global, module*/
+/*
+ Please see the license.txt file associated with the Pretty Diff
+ application for license information.
+*/
+(function language_init() {
+    "use strict";
+    var language = {};
+    global.prettydiff.language = language;
+    language.setlangmode = function language_setlangmode(input) {
+        var langmap = {
+            c_cpp     : "javascript",
+            coldfusion: "markup",
+            csharp    : "javascript",
+            css       : "css",
+            csv       : "csv",
+            dustjs    : "html",
+            ejs       : "html",
+            go        : "html",
+            handlebars: "html",
+            html      : "html",
+            html_ruby : "html",
+            java      : "javascript",
+            javascript: "javascript",
+            json      : "json",
+            jsp       : "markup",
+            jsx       : "javascript",
+            less      : "css",
+            markup    : "markup",
+            php       : "html",
+            qml       : "qml",
+            scss      : "css",
+            swig      : "html",
+            text      : "text",
+            titanium  : "tss",
+            tss       : "tss",
+            twig      : "html",
+            typescript: "typescript",
+            velocity  : "velocity",
+            xhtml     : "markup",
+            xml       : "markup"
+        };
+        if (typeof input !== "string") {
+            return "javascript";
+        }
+        if (input.indexOf("html") > -1) {
+            return "html";
+        }
+        if (langmap[input] === undefined) {
+            return "javascript";
+        }
+        return langmap[input];
+    };
+    language.nameproper  = function language_nameproper(input) {
+        var langmap = {
+            c_cpp     : "C++ (Not yet supported)",
+            coldfusion: "ColdFusion",
+            csharp    : "C#",
+            dustjs    : "Dust.js",
+            ejs       : "EJS Template",
+            elm       : "Elm Template",
+            go        : "Go Lang Template",
+            handlebars: "Handlebars Template",
+            html_ruby : "ERB (Ruby) Template",
+            java      : "Java",
+            javascript: "JavaScript",
+            jsp       : "JSTL (JSP)",
+            jsx       : "React JSX",
+            liquid    : "Liquid Template",
+            markup    : "markup",
+            scss      : "SCSS",
+            text      : "Plain Text",
+            titanium  : "Titanium Stylesheets",
+            tss       : "Titanium Stylesheets",
+            twig      : "HTML TWIG Template",
+            typescript: "TypeScript",
+            velocity  : "Apache Velocity",
+            volt      : "Volt Template"
+        };
+        if (typeof input !== "string" || langmap[input] === undefined) {
+            return input.toUpperCase();
+        }
+        return langmap[input];
+    };
+    // [0] = language value for ace mode [1] = prettydiff language category from [0]
+    // [2] = pretty formatting for text output to user
+    language.auto = function language_auto(sample, defaultLang) {
+        var b           = [],
+            c           = 0,
+            vartest     = (
+                /(((var)|(let)|(const)|(function)|(import))\s+(\w|\$)+[a-zA-Z0-9]*)/
+            ).test(sample),
+            finalstatic = (/((((final)|(public)|(private))\s+static)|(static\s+void))/).test(
+                sample
+            ),
+            output      = function language_auto_output(langname) {
+                if (langname === "unknown") {
+                    return [defaultLang, language.setlangmode(defaultLang), "unknown"];
+                }
+                if (langname === "xhtml" || langname === "markup") {
+                    return ["xml", "html", "XHTML"];
+                }
+                if (langname === "tss") {
+                    return ["tss", "tss", "Titanium Stylesheets"];
+                }
+                return [langname, language.setlangmode(langname), language.nameproper(langname)];
+            },
+            cssA        = function language_auto_cssA() {
+                if ((/\$[a-zA-Z]/).test(sample) === true || (/\{\s*(\w|\.|\$|#)+\s*\{/).test(sample) === true) {
+                    return output("scss");
+                }
+                if ((/@[a-zA-Z]/).test(sample) === true || (/\{\s*(\w|\.|@|#)+\s*\{/).test(sample) === true) {
+                    return output("less");
+                }
+                return output("css");
+            },
+            notmarkup   = function language_auto_notmarkup() {
+                var d               = 0,
+                    join            = "",
+                    flaga           = false,
+                    flagb           = false,
+                    publicprivate   = (
+                        /((public)|(private))\s+(static\s+)?(((v|V)oid)|(class)|(final))/
+                    ).test(sample),
+                    javascriptA     = function language_auto_notmarkup_javascriptA() {
+                        if (sample.indexOf("(") > -1 || sample.indexOf("=") > -1 || (sample.indexOf(";") > -1 && sample.indexOf("{") > -1)) {
+                            if (vartest === false && ((/\n\s+#region\s/).test(sample) === true || (/\[\w+:/).test(sample) === true)) {
+                                return output("csharp");
+                            }
+                            if (finalstatic === true || (/\w<\w+(,\s+\w+)*>/).test(sample) === true) {
+                                if ((/:\s*((number)|(string))/).test(sample) === false && vartest === false && (finalstatic === true || publicprivate === true)) {
+                                    return output("java");
+                                }
+                                return output("typescript");
+                            }
+                            if ((/final\s+static/).test(sample) === true) {
+                                return output("java");
+                            }
+                            return output("javascript");
+                        }
+                        return output("unknown");
+                    },
+                    cssOrJavaScript = function language_auto_notmarkup_cssOrJavaScript() {
+                        if ((/:\s*((number)|(string))/).test(sample) === true && (/((public)|(private))\s+/).test(sample) === true) {
+                            return output("typescript");
+                        }
+                        if ((/import\s+java(\.|(fx))/).test(sample) === true || (/((public)|(private))\s+static\s+/).test(sample) === true) {
+                            return output("java");
+                        }
+                        if ((/\sclass\s+\w/).test(sample) === false && (/<[a-zA-Z]/).test(sample) === true && (/<\/[a-zA-Z]/).test(sample) === true && ((/\s?\{%/).test(sample) === true || (/\{(\{|#)(?!(\{|#|=))/).test(sample) === true)) {
+                            return output("twig");
+                        }
+                        if ((/^(\s*(\$|@))/).test(sample) === false && (/(\};?\s*)$/).test(sample) === true) {
+                            if ((/export\s+default\s+\{/).test(sample) === true || (/(\?|:)\s*(\{|\[)/).test(sample) === true || (/(\{|\s|;)render\s*\(\)\s*\{/).test(sample) === true || (/^(\s*return;?\s*\{)/).test(sample) === true) {
+                                return output("javascript");
+                            }
+                        }
+                        if ((/\{\{#/).test(sample) === true && (/\{\{\//).test(sample) === true && (/<\w/).test(sample) === true) {
+                            return output("handlebars");
+                        }
+                        if ((/\{\s*(\w|\.|@|#)+\s*\{/).test(sample) === true) {
+                            return output("less");
+                        }
+                        if ((/\$(\w|-)/).test(sample) === true) {
+                            return output("scss");
+                        }
+                        if ((/(;|\{|:)\s*@\w/).test(sample) === true) {
+                            return output("less");
+                        }
+                        if ((/class\s+\w+\s+\{/).test(sample) === true) {
+                            return output("java");
+                        }
+                        return output("css");
+                    };
+                for (d = 1; d < c; d = d + 1) {
+                    if (flaga === false) {
+                        if (b[d] === "*" && b[d - 1] === "/") {
+                            b[d - 1] = "";
+                            flaga    = true;
+                        } else if (flagb === false && b[d] === "f" && d < c - 6 && b[d + 1] === "i" && b[d + 2] === "l" && b[d + 3] === "t" && b[d + 4] === "e" && b[d + 5] === "r" && b[d + 6] === ":") {
+                            flagb = true;
+                        }
+                    } else if (flaga === true && b[d] === "*" && d !== c - 1 && b[d + 1] === "/") {
+                        flaga    = false;
+                        b[d]     = "";
+                        b[d + 1] = "";
+                    } else if (flagb === true && b[d] === ";") {
+                        flagb = false;
+                        b[d]  = "";
+                    }
+                    if (flaga === true || flagb === true) {
+                        b[d] = "";
+                    }
+                }
+                join = b.join("");
+                if ((/\s\/\//).test(sample) === false && (/\/\/\s/).test(sample) === false && (/^(\s*(\{|\[)(?!%))/).test(sample) === true && (/((\]|\})\s*)$/).test(sample) && sample.indexOf(",") !== -1) {
+                    return output("json");
+                }
+                if ((/((\}?(\(\))?\)*;?\s*)|([a-z0-9]("|')?\)*);?(\s*\})*)$/i).test(sample) === true && (vartest === true || publicprivate === true || (/console\.log\(/).test(sample) === true || (/export\s+default\s+class\s+/).test(sample) === true || (/document\.get/).test(sample) === true || (/((\=|(\$\())\s*function)|(\s*function\s+(\w*\s+)?\()/).test(sample) === true || sample.indexOf("{") === -1 || (/^(\s*if\s+\()/).test(sample) === true)) {
+                    return javascriptA();
+                }
+                // * u007b === {
+                // * u0024 === $
+                // * u002e === .
+                if (sample.indexOf("{") > -1 && ((/^(\s*[\u007b\u0024\u002e#@a-z0-9])/i).test(sample) === true || (/^(\s*\/(\*|\/))/).test(sample) === true || (/^(\s*\*\s*\{)/).test(sample) === true) && (/^(\s*if\s*\()/).test(sample) === false && (/\=\s*(\{|\[|\()/).test(join) === false && (((/(\+|-|\=|\?)\=/).test(join) === false || (/\/\/\s*\=+/).test(join) === true) || ((/\=+('|")?\)/).test(sample) === true && (/;\s*base64/).test(sample) === true)) && (/function(\s+\w+)*\s*\(/).test(join) === false) {
+                    if ((/\s*#((include)|(define)|(endif))\s+/).test(sample)) {
+                        return output("c_cpp");
+                    }
+                    return cssOrJavaScript();
+                }
+                if ((/"\s*:\s*\{/).test(sample) === true) {
+                    return output("tss");
+                }
+                if (sample.indexOf("{%") > -1) {
+                    return output("twig");
+                }
+                return output("unknown");
+            },
+            markup      = function language_auto_markup() {
+                var html = function language_auto_markup_html() {
+                    if ((/<%\s*\}/).test(sample) === true) {
+                        return output("ejs");
+                    }
+                    if ((/<%\s*end/).test(sample) === true) {
+                        return output("html_ruby");
+                    }
+                    if ((/\{\{(#|\/|\{)/).test(sample) === true) {
+                        return output("handlebars");
+                    }
+                    if ((/\{\{end\}\}/).test(sample) === true) {
+                        //place holder for Go lang templates
+
+                        return output("html");
+                    }
+                    if ((/\s?\{%/).test(sample) === true && (/\{(\{|#)(?!(\{|#|\=))/).test(sample) === true) {
+                        return output("twig");
+                    }
+                    if ((/<\?/).test(sample) === true) {
+                        return output("php");
+                    }
+                    if ((/<jsp:include\s/).test(sample) === true || (/<c:((set)|(if))\s/).test(sample) === true) {
+                        return output("jsp");
+                    }
+                    if ((/\{(#|\?|\^|@|<|\+|~)/).test(sample) === true && (/\{\//).test(sample) === true) {
+                        return output("dustjs");
+                    }
+                    return output("html");
+                };
+                if ((/^(\s*<!doctype\u0020html>)/i).test(sample) === true || (/^(\s*<html)/i).test(sample) === true || ((/^(\s*<!DOCTYPE\s+((html)|(HTML))\s+PUBLIC\s+)/).test(sample) === true && (/XHTML\s+1\.1/).test(sample) === false && (/XHTML\s+1\.0\s+(S|s)((trict)|(TRICT))/).test(sample) === false)) {
+                    return html();
+                }
+                if ((/<jsp:include\s/).test(sample) === true || (/<c:((set)|(if))\s/).test(sample) === true) {
+                    return output("jsp");
+                }
+                if ((/<%\s*\}/).test(sample) === true) {
+                    return output("ejs");
+                }
+                if ((/<%\s*end/).test(sample) === true) {
+                    return output("html_ruby");
+                }
+                if ((/\{\{(#|\/|\{)/).test(sample) === true) {
+                    return output("handlebars");
+                }
+                if ((/\{\{end\}\}/).test(sample) === true) {
+                    //place holder for Go lang templates
+
+                    return output("xml");
+                }
+                if ((/\s?\{%/).test(sample) === true && (/\{\{(?!(\{|#|\=))/).test(sample) === true) {
+                    return output("twig");
+                }
+                if ((/<\?(?!(xml))/).test(sample) === true) {
+                    return output("php");
+                }
+                if ((/\{(#|\?|\^|@|<|\+|~)/).test(sample) === true && (/\{\//).test(sample) === true) {
+                    return output("dustjs");
+                }
+                if ((/<jsp:include\s/).test(sample) === true || (/<c:((set)|(if))\s/).test(sample) === true) {
+                    return output("jsp");
+                }
+                return output("xml");
+            };
+        if (sample === null) {
+            return;
+        }
+        if ((/^(\s*<\!DOCTYPE\s+html>)/i).test(sample) === true) {
+            return output("html");
+        }
+        if ((/^(\s*((if)|(for)|(function))\s*\()/).test(sample) === false && (/(\s|;|\})((if)|(for)|(function\s*\w*))\s*\(/).test(sample) === false && vartest === false && (/return\s*\w*\s*(;|\})/).test(sample) === false && (sample === undefined || (/^(\s*#(?!(!\/)))/).test(sample) === true || ((/\n\s*(\.|@)\w+(\(?|(\s*:))/).test(sample) === true && (/>\s*<\w/).test(sample) === false))) {
+            return cssA();
+        }
+        b = sample
+            .replace(/\[[a-zA-Z][\w\-]*\=("|')?[a-zA-Z][\w\-]*("|')?\]/g, "")
+            .split("");
+        c = b.length;
+        if ((/^(\s*\{(%|#|\{))/).test(sample) === true) {
+            return markup();
+        }
+        if (((/^([\s\w\-]*<)/).test(sample) === false && (/(>[\s\w\-]*)$/).test(sample) === false) || finalstatic === true) {
+            return notmarkup();
+        }
+        if ((((/(>[\w\s:]*)?<(\/|!|#)?[\w\s:\-\[]+/).test(sample) === true || (/^(\s*<\?xml)/).test(sample) === true) && ((/^([\s\w]*<)/).test(sample) === true || (/(>[\s\w]*)$/).test(sample) === true)) || ((/^(\s*<s((cript)|(tyle)))/i).test(sample) === true && (/(<\/s((cript)|(tyle))>\s*)$/i).test(sample) === true)) {
+            if ((/^([\s\w]*<)/).test(sample) === false || (/(>[\s\w]*)$/).test(sample) === false) {
+                return notmarkup();
+            }
+            return markup();
+        }
+        return output("unknown");
+    };
+    if ((typeof define === "object" || typeof define === "function") && (typeof ace !== "object" || ace.prettydiffid === undefined)) {
+        //requirejs support
+        define(function language_requirejs() {
+            return global.prettydiff.language;
+        });
+    } else if (typeof module === "object" && typeof module.parent === "object") {
+        //commonjs and nodejs support
+        module.exports = global.prettydiff.language;
+    }
+}());

--- a/node_modules/prettydiff/lib/markuppretty.js
+++ b/node_modules/prettydiff/lib/markuppretty.js
@@ -1,0 +1,4472 @@
+/*prettydiff.com api.topcoms:true,api.insize:4,api.inchar:" ",api.vertical:true */
+/*jshint laxbreak: true*/
+/*global __dirname, ace, define, global, module, process, require*/
+/***********************************************************************
+ markuppretty is written by Austin Cheney on 20 Jun 2015.
+
+ Please see the license.txt file associated with the Pretty Diff
+ application for license information.
+ **********************************************************************/
+/* A simple parser for XML, HTML, and a variety of template schemes. It
+ beautifies, minifies, and peforms a series of analysis*/
+(function markuppretty_init() {
+    "use strict";
+    var markuppretty = function markuppretty_(options) {
+        var safeSort    = global.prettydiff.safeSort,
+            output      = "",
+            stats       = {
+                cdata      : [
+                    0, 0
+                ],
+                comment    : [
+                    0, 0
+                ],
+                conditional: [
+                    0, 0
+                ],
+                content    : [
+                    0, 0
+                ],
+                end        : [
+                    0, 0
+                ],
+                ignore     : [
+                    0, 0
+                ],
+                script     : [
+                    0, 0
+                ],
+                sgml       : [
+                    0, 0
+                ],
+                singleton  : [
+                    0, 0
+                ],
+                space      : 0,
+                start      : [
+                    0, 0
+                ],
+                style      : [
+                    0, 0
+                ],
+                template   : [
+                    0, 0
+                ],
+                text       : [
+                    0, 0
+                ],
+                xml        : [0, 0]
+            },
+
+            //parallel arrays
+            // * attrs is a list of arrays, each of which contains (if any) parsed
+            // attributes
+            // * begin stores the index of the current token's parent element
+            // * daddy stores the tag name of the parent element
+            // * jscom stores true/false if the current token is a JS comment from JSX
+            // format
+            // * level describes the indentation of a given token level is only used in
+            // beautify and diff modes
+            // * linen stores the input line number on which the token occurs
+            // * lines describes the preceeding space using: 2, 1, or 0 lines is populated
+            // in markuppretty__tokenize_spacer
+            // * presv whether a given token should be preserved as provided
+            // * token stores parsed tokens
+            // * types segments tokens into named groups
+            // * value attribute value if current type is attribute and
+            // options.attributetoken is true
+            attrs       = [],
+            jscom       = [],
+            level       = [],
+            linen       = [],
+            lines       = [],
+            token       = [],
+            types       = [],
+            presv       = [],
+            daddy       = [],
+            begin       = [],
+            value       = [],
+            reqs        = [],
+            ids         = [],
+            parseError  = [],
+            parent      = [
+                ["none", -1]
+            ],
+            line        = 1,
+            wrap        = options.wrap,
+            objsortop   = false,
+            globalerror = "",
+            lf          = (options.crlf === true || options.crlf === "true")
+                ? "\r\n"
+                : "\n",
+            sourceSize  = options.source.length,
+            extlib      = function markuppretty__extlib(type) {
+                var result = "";
+                if (type === "script" && typeof global.prettydiff.jspretty !== "function") {
+                    return options.source;
+                }
+                if (type === "style" && typeof global.prettydiff.csspretty !== "function") {
+                    return options.source;
+                }
+                result = (type === "script")
+                    ? global
+                        .prettydiff
+                        .jspretty(options)
+                    : global
+                        .prettydiff
+                        .csspretty(options);
+                if (options.nodeasync === true) {
+                    if (globalerror === "") {
+                        globalerror = result[1];
+                    }
+                    if (options.mode === "parse") {
+                        if (options.parseFormat === "htmltable") {
+                            if (type === "script") {
+                                return result[0]
+                                    .data
+                                    .replace(
+                                        "<thead>",
+                                        "<thead><tr><th colspan=\"6\" class=\"nested\">JavaScript tokens</th></tr>"
+                                    );
+                            }
+                            return result[0]
+                                .data
+                                .replace(
+                                    "<thead>",
+                                    "<thead><tr><th colspan=\"4\" class=\"nested\">CSS tokens</th></tr>"
+                                );
+                        }
+                        return result[0].data;
+                    }
+                    return result[0];
+                }
+                if (options.mode === "parse") {
+                    if (options.parseFormat === "htmltable") {
+                        if (type === "script") {
+                            return result
+                                .data
+                                .replace(
+                                    "<thead>",
+                                    "<thead><tr><th colspan=\"6\" class=\"nested\">JavaScript tokens</th></tr>"
+                                );
+                        }
+                        return result
+                            .data
+                            .replace(
+                                "<thead>",
+                                "<thead><tr><th colspan=\"4\" class=\"nested\">CSS tokens</th></tr>"
+                            );
+                    }
+                    return result.data;
+                }
+                return result;
+            },
+            //What is the lowercase tag name of the provided token?
+            tagName     = function markuppretty__tagName(el) {
+                var space = el
+                        .replace(/^(\{((%-?)|\{-?)\s*)/, "%")
+                        .replace(/\s+/, " ")
+                        .indexOf(" "),
+                    name  = (space < 0)
+                        ? el
+                            .replace(/^(\{((%-?)|\{-?)\s*)/, " ")
+                            .slice(1, el.length - 1)
+                            .toLowerCase()
+                        : el
+                            .replace(/^(\{((%-?)|\{-?)\s*)/, " ")
+                            .slice(1, space)
+                            .toLowerCase();
+                name = name.replace(/(\}\})$/, "");
+                if (name.indexOf("(") > 0) {
+                    name = name.slice(0, name.indexOf("("));
+                }
+                return name;
+            };
+
+        (function markuppretty__options() {
+            objsortop      = (
+                options.objsort === true || options.objsort === "true" || options.objsort === "all" || options.objsort === "markup"
+            );
+            options.source = (
+                typeof options.source === "string" && options.source.length > 0
+            )
+                ? options
+                    .source
+                    .replace(/\r\n?/g, "\n")
+                : "Error: no source code supplied to markuppretty!";
+            if (options.mode === "analysis") {
+                options.accessibility = true;
+            }
+        }());
+        //type definitions:
+        // * start      end     type
+        // * <![CDATA[   ]]>    cdata
+        // * <!--       -->     comment
+        // * <#--       -->     comment
+        // * <%--       --%>    comment
+        // * {!         !}      comment
+        // * <!--[if    -->     conditional
+        // * text       text    content
+        // * </         >       end
+        // * <pre       </pre>  ignore (html only)
+        // * text       text    script
+        // * <!         >       sgml
+        // * <          />      singleton
+        // * <          >       start
+        // * text       text    style
+        // * <!--#      -->     template
+        // * <%         %>      template
+        // * {{{        }}}     template
+        // * {{         }}      template
+        // * {%         %}      template
+        // * [%         %]      template
+        // * {@         @}      template
+        // * {#         #}      template
+        // * {#         /}      template
+        // * {?         /}      template
+        // * {^         /}      template
+        // * {@         /}      template
+        // * {<         /}      template
+        // * {+         /}      template
+        // * {~         }       template
+        // * <?         ?>      template
+        // * {:else}            template_else
+        // * <#else     >       template_else
+        // * {@}else{@}         template_else
+        // * <%}else{%>         template_else
+        // * {{         }}      template_end
+        // * <%\s*}     %>      template_end
+        // * [%\s*}     %]      template_end
+        // * {@\s*}     @}      template_end
+        // * {          }       template_end
+        // * {{#        }}      template_start
+        // * <%         {\s*%>  template_start
+        // * [%         {\s*%]  template_start
+        // * {@         {\s*@}  template_start
+        // * {#         }       template_start
+        // * {?         }       template_start
+        // * {^         }       template_start
+        // * {@         }       template_start
+        // * {<         }       template_start
+        // * {+         }       template_start
+        // * <?xml      ?>      xml
+        if (options.mode !== "diff") {
+            options.content = false;
+        }
+        if (options.jsx === true) {
+            options.dustjs = false;
+        }
+        (function markuppretty__tokenize() {
+            var a             = 0,
+                b             = options
+                    .source
+                    .split(""),
+                c             = b.length,
+                minspace      = "",
+                space         = "",
+                list          = 0,
+                litag         = 0,
+                linepreserve  = 0,
+                cftransaction = false,
+                sgmlflag      = 0,
+                ext           = false,
+                //cftags is a list of supported coldfusion tags
+                //* required - means must have a separate matching end tag
+                // * optional - means the tag could have a separate end tag, but is probably a
+                // singleton
+                //* prohibited - means there is not corresponding end tag
+                cftags        = {
+                    cfabort               : "prohibited",
+                    cfajaximport          : "optional",
+                    cfajaxproxy           : "optional",
+                    cfapplet              : "prohibited",
+                    cfapplication         : "prohibited",
+                    cfargument            : "prohibited",
+                    cfassociate           : "prohibited",
+                    cfauthenticate        : "prohibited",
+                    cfbreak               : "prohibited",
+                    cfcache               : "optional",
+                    cfcalendar            : "optional",
+                    cfcase                : "required",
+                    cfcatch               : "required",
+                    cfchart               : "optional",
+                    cfchartdata           : "prohibited",
+                    cfchartseries         : "optional",
+                    cfclient              : "required",
+                    cfclientsettings      : "optional",
+                    cfcol                 : "prohibited",
+                    cfcollection          : "prohibited",
+                    cfcomponent           : "required",
+                    cfcontent             : "optional",
+                    cfcontinue            : "prohibited",
+                    cfcookie              : "prohibited",
+                    cfdbinfo              : "prohibited",
+                    cfdefaultcase         : "required",
+                    cfdirectory           : "prohibited",
+                    cfdiv                 : "optional",
+                    cfdocument            : "optional",
+                    cfdocumentitem        : "optional",
+                    cfdocumentsection     : "optional",
+                    cfdump                : "optional",
+                    cfelse                : "prohibited",
+                    cfelseif              : "prohibited",
+                    cferror               : "prohibited",
+                    cfexchangecalendar    : "optional",
+                    cfexchangeconnection  : "optional",
+                    cfexchangecontact     : "optional",
+                    cfexchangeconversation: "optional",
+                    cfexchangefilter      : "optional",
+                    cfexchangefolder      : "optional",
+                    cfexchangemail        : "optional",
+                    cfexchangetask        : "optional",
+                    cfexecute             : "required",
+                    cfexit                : "prohibited",
+                    cffeed                : "prohibited",
+                    cffile                : "optional",
+                    cffileupload          : "optional",
+                    cffinally             : "required",
+                    cfflush               : "prohibited",
+                    cfform                : "required",
+                    cfformgroup           : "required",
+                    cfformitem            : "optional",
+                    cfforward             : "prohibited",
+                    cfftp                 : "prohibited",
+                    cffunction            : "required",
+                    cfgraph               : "required",
+                    cfgraphdata           : "prohibited",
+                    cfgrid                : "required",
+                    cfgridcolumn          : "optional",
+                    cfgridrow             : "optional",
+                    cfgridupdate          : "optional",
+                    cfheader              : "prohibited",
+                    cfhtmlbody            : "optional",
+                    cfhtmlhead            : "optional",
+                    cfhtmltopdf           : "optional",
+                    cfhtmltopdfitem       : "optional",
+                    cfhttp                : "optional",
+                    cfhttpparam           : "prohibited",
+                    cfif                  : "required",
+                    cfimage               : "prohibited",
+                    cfimap                : "prohibited",
+                    cfimapfilter          : "optional",
+                    cfimport              : "prohibited",
+                    cfinclude             : "prohibited",
+                    cfindex               : "prohibited",
+                    cfinput               : "prohibited",
+                    cfinsert              : "prohibited",
+                    cfinterface           : "required",
+                    cfinvoke              : "optional",
+                    cfinvokeargument      : "prohibited",
+                    cflayout              : "optional",
+                    cflayoutarea          : "optional",
+                    cfldap                : "prohibited",
+                    cflocation            : "prohibited",
+                    cflock                : "required",
+                    cflog                 : "prohibited",
+                    cflogic               : "required",
+                    cfloginuser           : "prohibited",
+                    cflogout              : "prohibited",
+                    cfloop                : "required",
+                    cfmail                : "required",
+                    cfmailparam           : "prohibited",
+                    cfmailpart            : "required",
+                    cfmap                 : "optional",
+                    cfmapitem             : "optional",
+                    cfmediaplayer         : "optional",
+                    cfmenu                : "required",
+                    cfmenuitem            : "optional",
+                    cfmessagebox          : "optional",
+                    cfmodule              : "optional",
+                    cfNTauthenticate      : "optional",
+                    cfoauth               : "optional",
+                    cfobject              : "prohibited",
+                    cfobjectcache         : "prohibited",
+                    cfoutput              : "required",
+                    cfpageencoding        : "optional",
+                    cfparam               : "prohibited",
+                    cfpdf                 : "optional",
+                    cfpdfform             : "optional",
+                    cfpdfformparam        : "optional",
+                    cfpdfparam            : "prohibited",
+                    cfpdfsubform          : "required",
+                    cfpod                 : "optional",
+                    cfpop                 : "prohibited",
+                    cfpresentation        : "required",
+                    cfpresentationslide   : "optional",
+                    cfpresenter           : "optional",
+                    cfprint               : "optional",
+                    cfprocessingdirective : "optional",
+                    cfprocparam           : "prohibited",
+                    cfprocresult          : "prohibited",
+                    cfprogressbar         : "optional",
+                    cfproperty            : "prohibited",
+                    cfquery               : "required",
+                    cfqueryparam          : "prohibited",
+                    cfregistry            : "prohibited",
+                    cfreport              : "optional",
+                    cfreportparam         : "optional",
+                    cfrethrow             : "prohibited",
+                    cfretry               : "prohibited",
+                    cfreturn              : "prohibited",
+                    cfsavecontent         : "required",
+                    cfschedule            : "prohibited",
+                    cfscript              : "required",
+                    cfsearch              : "prohibited",
+                    cfselect              : "required",
+                    cfservlet             : "prohibited",
+                    cfservletparam        : "prohibited",
+                    cfset                 : "prohibited",
+                    cfsetting             : "optional",
+                    cfsharepoint          : "optional",
+                    cfsilent              : "required",
+                    cfsleep               : "prohibited",
+                    cfslider              : "prohibited",
+                    cfspreadsheet         : "optional",
+                    cfsprydataset         : "optional",
+                    cfstatic              : "required",
+                    cfstopwatch           : "required",
+                    cfstoredproc          : "optional",
+                    cfswitch              : "required",
+                    cftable               : "required",
+                    cftextarea            : "optional",
+                    cfthread              : "optional",
+                    cfthrow               : "prohibited",
+                    cftimer               : "required",
+                    cftooltip             : "required",
+                    cftrace               : "optional",
+                    cftransaction         : "required",
+                    cftree                : "required",
+                    cftreeitem            : "optional",
+                    cftry                 : "required",
+                    cfupdate              : "prohibited",
+                    cfvideo               : "prohibited",
+                    cfvideoplayer         : "optional",
+                    cfwddx                : "prohibited",
+                    cfwebsocket           : "optional",
+                    cfwhile               : "required",
+                    cfwindow              : "optional",
+                    cfx_                  : "prohibited",
+                    cfxml                 : "required",
+                    cfzip                 : "optional",
+                    cfzipparam            : "prohibited"
+                },
+                // determine if spaces between nodes are absent, multiline, or merely there 2 -
+                // multiline 1 - space present 0 - no space present
+                spacer        = function markuppretty__tokenize_spacer() {
+                    var linea = 0;
+                    if (space.length > 0) {
+                        stats.space = stats.space + space.length;
+                        linea       = space
+                            .split("\n")
+                            .length - 1;
+                        if (options.preserve > 0 && linea > 1) {
+                            if (linea > options.preserve + 1) {
+                                lines.push(options.preserve + 1);
+                            } else {
+                                lines.push(linea);
+                            }
+                        } else {
+                            lines.push(1);
+                        }
+                    } else {
+                        lines.push(0);
+                    }
+                    minspace = space;
+                    space    = "";
+                },
+                //parses tags, attributes, and template elements
+                tag           = function markuppretty__tokenize_tag(end) {
+                    var lexer     = [],
+                        bcount    = 0,
+                        e         = 0,
+                        f         = 0,
+                        igcount   = 0,
+                        jsxcount  = 0,
+                        braccount = 0,
+                        parncount = 0,
+                        quote     = "",
+                        element   = "",
+                        lastchar  = "",
+                        jsxquote  = "",
+                        tname     = "",
+                        comment   = false,
+                        cheat     = false,
+                        endtag    = false,
+                        nopush    = false,
+                        nosort    = false,
+                        simple    = false,
+                        preserve  = false,
+                        stest     = false,
+                        liend     = false,
+                        ignoreme  = false,
+                        quotetest = false,
+                        parseFail = false,
+                        singleton = false,
+                        earlyexit = false,
+                        attribute = [],
+                        attstore  = [],
+                        presend   = {
+                            cfquery: true
+                        },
+                        arname    = function markuppretty__tokenize_tag_name(x) {
+                            var eq = x.indexOf("=");
+                            if (eq > 0 && ((eq < x.indexOf("\"") && x.indexOf("\"") > 0) || (eq < x.indexOf("'") && x.indexOf("'") > 0))) {
+                                return x.slice(0, eq);
+                            }
+                            return x;
+                        },
+                        slashy    = function markuppretty__tokenize_tag_slashy() {
+                            var x = a;
+                            do {
+                                x = x - 1;
+                            } while (b[x] === "\\");
+                            x = a - x;
+                            if (x % 2 === 1) {
+                                return false;
+                            }
+                            return true;
+                        },
+                        attrpush  = function markuppretty__tokenize_tag_attrpush(quotes) {
+                            var atty = "",
+                                name = "",
+                                aa   = 0,
+                                bb   = 0;
+                            if (quotes === true) {
+                                if (quote === "\"" && options.quoteConvert === "single") {
+                                    atty = attribute
+                                        .slice(0, attribute.length - 1)
+                                        .join("")
+                                        .replace(/'/g, "\"")
+                                        .replace(/"/, "'") + "'";
+                                } else if (quote === "'" && options.quoteConvert === "double") {
+                                    atty = attribute
+                                        .slice(0, attribute.length - 1)
+                                        .join("")
+                                        .replace(/"/g, "'")
+                                        .replace(/'/, "\"") + "\"";
+                                } else {
+                                    atty = attribute.join("");
+                                }
+                                name = arname(atty);
+                                if (name === "data-prettydiff-ignore") {
+                                    ignoreme = true;
+                                } else if (name === "id") {
+                                    ids.push(atty.slice(name.length + 2, atty.length - 1));
+                                } else if (name === "schemaLocation") {
+                                    reqs.push(atty.slice(name.length + 2, atty.length - 1));
+                                }
+                                quote = "";
+                            } else {
+                                atty = attribute
+                                    .join("")
+                                    .replace(/\s+/g, " ");
+                                name = arname(atty);
+                                if (name === "data-prettydiff-ignore") {
+                                    ignoreme = true;
+                                } else if (name === "id") {
+                                    ids.push(element.slice(name.length + 1, atty.length));
+                                }
+                                if (options.jsx === true && attribute[0] === "{" && attribute[attribute.length - 1] === "}") {
+                                    jsxcount = 0;
+                                }
+                            }
+                            if (atty.slice(0, 3) === "<%=" || atty.slice(0, 2) === "{%") {
+                                nosort = true;
+                            }
+                            atty      = atty
+                                .replace(/^\u0020/, "")
+                                .replace(/\u0020$/, "");
+                            attribute = atty
+                                .replace(/\r\n/g, "\n")
+                                .split("\n");
+                            bb        = attribute.length;
+                            for (aa = 0; aa < bb; aa = aa + 1) {
+                                attribute[aa] = attribute[aa].replace(/(\s+)$/, "");
+                            }
+                            atty = attribute.join(lf);
+                            if (atty === "=") {
+                                attstore[attstore.length - 1] = attstore[attstore.length - 1] + "=";
+                            } else if (atty.charAt(0) === "=" && attstore.length > 0 && attstore[attstore.length - 1].indexOf("=") < 0) {
+                                //if an attribute starts with a `=` then adjoin it to the last attribute
+                                attstore[attstore.length - 1] = attstore[attstore.length - 1] + atty;
+                            } else if (atty.charAt(0) !== "=" && attstore.length > 0 && attstore[attstore.length - 1].indexOf("=") === attstore[attstore.length - 1].length - 1) {
+                                // if an attribute follows an attribute ending with `=` then adjoin it to the
+                                // last attribute
+                                attstore[attstore.length - 1] = attstore[attstore.length - 1] + atty;
+                            } else if (atty !== "" && atty !== " ") {
+                                attstore.push(atty);
+                            }
+                            attribute = [];
+                        };
+                    spacer();
+                    jscom.push(false);
+                    linen.push(line);
+                    value.push("");
+                    ext = false;
+                    // this complex series of conditions determines an elements delimiters look to
+                    // the types being pushed to quickly reason about the logic no type is pushed
+                    // for start tags or singleton tags just yet some types set the `preserve` flag,
+                    // which means to preserve internal white space The `nopush` flag is set when
+                    // parsed tags are to be ignored and forgotten
+                    (function markuppretty__tokenize_types() {
+                        if (end === "]>") {
+                            end      = ">";
+                            sgmlflag = sgmlflag - 1;
+                            types.push("template_end");
+                        } else if (end === "---") {
+                            preserve = true;
+                            types.push("comment");
+                        } else if (b[a] === "<") {
+                            if (b[a + 1] === "/") {
+                                if (b[a + 2] === "#") {
+                                    types.push("template_end");
+                                } else {
+                                    types.push("end");
+                                }
+                                end = ">";
+                            } else if (b[a + 1] === "!") {
+                                if (b[a + 2] === "-" && b[a + 3] === "-") {
+                                    if (b[a + 4] === "#") {
+                                        end = "-->";
+                                        types.push("template");
+                                    } else if (b[a + 4] === "[" && b[a + 5] === "i" && b[a + 6] === "f" && options.conditional === true) {
+                                        end = "-->";
+                                        types.push("conditional");
+                                    } else if (b[a + 4] === "-" && (/<cf[a-z]/i).test(options.source) === true) {
+                                        preserve = true;
+                                        comment  = true;
+                                        end      = "--->";
+                                        types.push("comment");
+                                    } else {
+                                        end = "-->";
+                                        if (options.mode === "minify" || options.comments === "nocomment") {
+                                            nopush  = true;
+                                            comment = true;
+                                        } else {
+                                            if (options.preserveComment === true) {
+                                                preserve = true;
+                                            }
+                                            comment  = true;
+                                            if (options.commline === true) {
+                                                lines[lines.length - 1] = 2;
+                                            }
+                                            types.push("comment");
+                                        }
+                                    }
+                                } else if (b[a + 2] === "[" && b[a + 3] === "C" && b[a + 4] === "D" && b[a + 5] === "A" && b[a + 6] === "T" && b[a + 7] === "A" && b[a + 8] === "[") {
+                                    end      = "]]>";
+                                    preserve = true;
+                                    comment  = true;
+                                    types.push("cdata");
+                                } else {
+                                    end      = ">";
+                                    sgmlflag = sgmlflag + 1;
+                                    types.push("sgml");
+                                }
+                            } else if (b[a + 1] === "?") {
+                                end = "?>";
+                                if (b[a + 2] === "x" && b[a + 3] === "m" && b[a + 4] === "l") {
+                                    types.push("xml");
+                                } else {
+                                    preserve = true;
+                                    types.push("template");
+                                }
+                            } else if (b[a + 1] === "%") {
+                                if (b[a + 2] !== "=") {
+                                    preserve = true;
+                                }
+                                if (b[a + 2] === "-" && b[a + 3] === "-") {
+                                    end     = "--%>";
+                                    comment = true;
+                                    if (options.commline === true) {
+                                        line[line.length - 1] = 2;
+                                    }
+                                    types.push("comment");
+                                } else if (b[a + 2] === "#") {
+                                    end     = "%>";
+                                    comment = true;
+                                    if (options.commline === true) {
+                                        line[line.length - 1] = 2;
+                                    }
+                                    types.push("comment");
+                                } else {
+                                    end = "%>";
+                                    types.push("template");
+                                }
+                            } else if (b[a + 4] !== undefined && b[a + 1].toLowerCase() === "p" && b[a + 2].toLowerCase() === "r" && b[a + 3].toLowerCase() === "e" && (b[a + 4] === ">" || (/\s/).test(b[a + 4]) === true)) {
+                                end      = "</pre>";
+                                preserve = true;
+                                types.push("ignore");
+                            } else if (b[a + 4] !== undefined && b[a + 1].toLowerCase() === "x" && b[a + 2].toLowerCase() === "s" && b[a + 3].toLowerCase() === "l" && b[a + 4].toLowerCase() === ":" && b[a + 5].toLowerCase() === "t" && b[a + 6].toLowerCase() === "e" && b[a + 7].toLowerCase() === "x" && b[a + 8].toLowerCase() === "t" && (b[a + 9] === ">" || (/\s/).test(b[a + 9]) === true)) {
+                                end      = "</xsl:text>";
+                                preserve = true;
+                                types.push("ignore");
+                            } else if (b[a + 8] !== undefined && b[a + 1].toLowerCase() === "c" && b[a + 2].toLowerCase() === "f" && b[a + 3].toLowerCase() === "q" && b[a + 4].toLowerCase() === "u" && b[a + 5].toLowerCase() === "e" && b[a + 6].toLowerCase() === "r" && b[a + 7].toLowerCase() === "y" && (b[a + 8] === ">" || (/\s/).test(b[a + 8]))) {
+                                end          = ">";
+                                linepreserve = linepreserve + 1;
+                                types.push("linepreserve");
+                            } else if (b[a + 1] === "<") {
+                                if (b[a + 2] === "<") {
+                                    end = ">>>";
+                                } else {
+                                    end = ">>";
+                                }
+                                types.push("template");
+                            } else if (b[a + 1] === "#") {
+                                if (b[a + 2] === "e" && b[a + 3] === "l" && b[a + 4] === "s" && b[a + 5] === "e") {
+                                    end = ">";
+                                    types.push("template_else");
+                                } else if (b[a + 2] === "-" && b[a + 3] === "-") {
+                                    end = "-->";
+                                    types.push("comment");
+                                    preserve = true;
+                                } else {
+                                    end = ">";
+                                    types.push("template_start");
+                                }
+                            } else {
+                                simple = true;
+                                end    = ">";
+                            }
+                        } else if (b[a] === "{") {
+                            preserve = true;
+                            if (options.jsx === true) {
+                                end = "}";
+                                types.push("script");
+                            } else if (options.dustjs === true) {
+                                if (b[a + 1] === ":" && b[a + 2] === "e" && b[a + 3] === "l" && b[a + 4] === "s" && b[a + 5] === "e" && b[a + 6] === "}") {
+                                    a = a + 6;
+                                    token.push("{:else}");
+                                    presv.push(true);
+                                    daddy.push(parent[parent.length - 1][0]);
+                                    begin.push(parent[parent.length - 1][1]);
+                                    attrs.push({});
+                                    stats.template[0] = stats.template[0] + 1;
+                                    stats.template[1] = stats.template[1] + 7;
+                                    earlyexit         = true;
+                                    return types.push("template_else");
+                                }
+                                if (b[a + 1] === "!") {
+                                    end     = "!}";
+                                    comment = true;
+                                    types.push("comment");
+                                } else if (b[a + 1] === "/") {
+                                    end = "}";
+                                    types.push("template_end");
+                                } else if (b[a + 1] === "~") {
+                                    end = "}";
+                                    types.push("singleton");
+                                } else if (b[a + 1] === ">") {
+                                    end = "/}";
+                                    types.push("singleton");
+                                } else if (b[a + 1] === "#" || b[a + 1] === "?" || b[a + 1] === "^" || b[a + 1] === "@" || b[a + 1] === "<" || b[a + 1] === "+") {
+                                    end = "}";
+                                    types.push("template_start");
+                                } else {
+                                    end = "}";
+                                    types.push("template");
+                                }
+                            } else if (b[a + 1] === "{") {
+                                if (b[a + 2] === "{") {
+                                    end = "}}}";
+                                    types.push("template");
+                                } else if (b[a + 2] === "#") {
+                                    end = "}}";
+                                    types.push("template_start");
+                                } else if (b[a + 2] === "/") {
+                                    end = "}}";
+                                    types.push("template_end");
+                                } else if (b[a + 2] === "e" && b[a + 3] === "n" && b[a + 4] === "d") {
+                                    end = "}}";
+                                    types.push("template_end");
+                                } else if (b[a + 2] === "e" && b[a + 3] === "l" && b[a + 4] === "s" && b[a + 5] === "e") {
+                                    end = "}}";
+                                    types.push("template_else");
+                                } else {
+                                    end = "}}";
+                                    types.push("template");
+                                }
+                            } else if (b[a + 1] === "%") {
+                                end = "%}";
+                                types.push("template");
+                            } else if (b[a + 1] === "#") {
+                                end = "#}";
+                                types.push("comment");
+                                preserve = true;
+                                comment  = true;
+                            } else {
+                                end = b[a + 1] + "}";
+                                types.push("template");
+                            }
+                            if (b[a + 1] === "@" && b[a + 2] === "}" && b[a + 3] === "e" && b[a + 4] === "l" && b[a + 5] === "s" && b[a + 6] === "e" && b[a + 7] === "{" && b[a + 8] === "@" && b[a + 9] === "}") {
+                                a                       = a + 9;
+                                types[types.length - 1] = "template_else";
+                                presv.push(true);
+                                daddy.push(parent[parent.length - 1][0]);
+                                begin.push(parent[parent.length - 1][1]);
+                                attrs.push({});
+                                stats.template[0] = stats.template[0] + 1;
+                                stats.template[1] = stats.template[1] + 10;
+                                earlyexit         = true;
+                                return token.push("{@}else{@}");
+                            }
+                        } else if (b[a] === "[" && b[a + 1] === "%") {
+                            end = "%]";
+                            types.push("template");
+                        } else if (b[a] === "#" && options.apacheVelocity === true) {
+                            if (b[a + 1] === "*") {
+                                preserve = true;
+                                comment  = true;
+                                end      = "*#";
+                                types.push("comment");
+                            } else if (b[a + 1] === "[" && b[a + 2] === "[") {
+                                preserve = true;
+                                comment  = true;
+                                end      = "]]#";
+                                types.push("comment");
+                            } else if (b[a + 1] === "#") {
+                                preserve = true;
+                                comment  = true;
+                                end      = "\n";
+                                types.push("comment");
+                            } else if (b[a + 1] === "e" && b[a + 2] === "l" && b[a + 3] === "s" && b[a + 4] === "e" && (/\s/).test(b[a + 5]) === true) {
+                                end = "\n";
+                                types.push("template_else");
+                            } else if (b[a + 1] === "i" && b[a + 2] === "f") {
+                                end = "\n";
+                                types.push("template_start");
+                            } else if (b[a + 1] === "f" && b[a + 2] === "o" && b[a + 3] === "r" && b[a + 4] === "e" && b[a + 5] === "a" && b[a + 6] === "c" && b[a + 7] === "h") {
+                                end = "\n";
+                                types.push("template_start");
+                            } else if (b[a + 1] === "e" && b[a + 2] === "n" && b[a + 3] === "d") {
+                                end = "\n";
+                                types.push("template_end");
+                            } else {
+                                end = "\n";
+                                types.push("template");
+                            }
+                        } else if (b[a] === "$" && options.apacheVelocity === true) {
+                            end = "\n";
+                            types.push("template");
+                        }
+                        if (options.unformatted === true) {
+                            preserve = true;
+                        }
+                    }());
+                    if (earlyexit === true) {
+                        return;
+                    }
+                    // This loop is the logic that parses tags and attributes If the attribute
+                    // data-prettydiff-ignore is present the `ignore` flag is set The ignore flag is
+                    // identical to the preserve flag
+                    lastchar = end.charAt(end.length - 1);
+                    for (a = a; a < c; a = a + 1) {
+                        if (b[a] === "\n") {
+                            line = line + 1;
+                        }
+                        if (preserve === true || (/\s/).test(b[a]) === false) {
+                            lexer.push(b[a]);
+                        } else if (lexer[lexer.length - 1] !== " ") {
+                            lexer.push(" ");
+                        }
+                        if (comment === true) {
+                            quote = "";
+                            //comments must ignore fancy encapsulations and attribute parsing
+                            if (b[a] === lastchar && lexer.length > end.length + 1) {
+                                //if current character matches the last character of the tag ending sequence
+                                f = lexer.length;
+                                for (e = end.length - 1; e > -1; e = e - 1) {
+                                    f = f - 1;
+                                    if (lexer[f] !== end.charAt(e)) {
+                                        break;
+                                    }
+                                }
+                                if (e < 0) {
+                                    if (end === "endcomment") {
+                                        f = f - 1;
+                                        if ((/\s/).test(lexer[f]) === true) {
+                                            do {
+                                                f = f - 1;
+                                            } while ((/\s/).test(lexer[f]) === true);
+                                        }
+                                        if (lexer[f - 1] === "{" && lexer[f] === "%") {
+                                            end      = "%}";
+                                            lastchar = "}";
+                                        }
+                                    } else {
+                                        break;
+                                    }
+                                }
+                            }
+                        } else {
+                            if (quote === "") {
+                                if (options.jsx === true) {
+                                    if (b[a] === "{") {
+                                        jsxcount = jsxcount + 1;
+                                    } else if (b[a] === "}") {
+                                        jsxcount = jsxcount - 1;
+                                    }
+                                }
+                                if (types[types.length - 1] === "sgml" && b[a] === "[" && lexer.length > 4) {
+                                    types[types.length - 1] = "template_start";
+                                    break;
+                                }
+                                if (b[a] === "<" && preserve === false && lexer.length > 1 && end !== ">>" && end !== ">>>" && simple === true) {
+                                    parseError.push("Parse error on line " + line + " on element: ");
+                                    parseFail = true;
+                                }
+                                if (stest === true && (/\s/).test(b[a]) === false && b[a] !== lastchar) {
+                                    //attribute start
+                                    stest   = false;
+                                    quote   = jsxquote;
+                                    igcount = 0;
+                                    lexer.pop();
+                                    for (a = a; a < c; a = a + 1) {
+                                        if (b[a] === "\n") {
+                                            line = line + 1;
+                                        }
+                                        if (options.unformatted === true) {
+                                            lexer.push(b[a]);
+                                        }
+                                        attribute.push(b[a]);
+
+                                        if ((b[a] === "<" || b[a] === ">") && (quote === "" || quote === ">") && options.jsx === false) {
+                                            if (quote === "" && b[a] === "<") {
+                                                quote     = ">";
+                                                braccount = 1;
+                                            } else if (quote === ">") {
+                                                if (b[a] === "<") {
+                                                    braccount = braccount + 1;
+                                                } else if (b[a] === ">") {
+                                                    braccount = braccount - 1;
+                                                    if (braccount === 0) {
+                                                        // the following detects if a coldfusion tag is embedded within another markup
+                                                        // tag
+                                                        tname = tagName(attribute.join(""));
+                                                        if (cftags[tname] === "required") {
+                                                            quote = "</" + tname + ">";
+                                                        } else {
+                                                            quote   = "";
+                                                            igcount = 0;
+                                                            attrpush(false);
+                                                            break;
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        } else if (quote === "") {
+                                            if (b[a + 1] === lastchar) {
+                                                //if at end of tag
+                                                if (attribute[attribute.length - 1] === "/") {
+                                                    attribute.pop();
+                                                    if (preserve === true) {
+                                                        lexer.pop();
+                                                    }
+                                                    a = a - 1;
+                                                }
+                                                if (attribute.length > 0) {
+                                                    attrpush(false);
+                                                }
+                                                break;
+                                            }
+                                            if (b[a] === "{" && b[a - 1] === "=" && options.jsx === false) {
+                                                quote = "}";
+                                            } else if (b[a] === "\"" || b[a] === "'") {
+                                                quote = b[a];
+                                                if (b[a - 1] === "=" && (b[a + 1] === "<" || (b[a + 1] === "{" && b[a + 2] === "%") || (/\s/).test(b[a + 1]) === true)) {
+                                                    igcount = a;
+                                                }
+                                            } else if (b[a] === "(") {
+                                                quote     = ")";
+                                                parncount = 1;
+                                            } else if (options.jsx === true) {
+                                                //jsx variable attribute
+                                                if ((b[a - 1] === "=" || (/\s/).test(b[a - 1]) === true) && b[a] === "{") {
+                                                    quote  = "}";
+                                                    bcount = 1;
+                                                } else if (b[a] === "/") {
+                                                    //jsx comments
+                                                    if (b[a + 1] === "*") {
+                                                        quote = "*/";
+                                                    } else if (b[a + 1] === "/") {
+                                                        quote = "\n";
+                                                    }
+                                                }
+                                            } else if (lexer[0] !== "{" && b[a] === "{" && (options.dustjs === true || b[a + 1] === "{" || b[a + 1] === "%" || b[a + 1] === "@" || b[a + 1] === "#")) {
+                                                //opening embedded template expression
+                                                if (b[a + 1] === "{") {
+                                                    if (b[a + 2] === "{") {
+                                                        quote = "}}}";
+                                                    } else {
+                                                        quote = "}}";
+                                                    }
+                                                } else if (options.dustjs === true) {
+                                                    quote = "}";
+                                                } else {
+                                                    quote = b[a + 1] + "}";
+                                                }
+                                            }
+                                            if ((/\s/).test(b[a]) === true && quote === "") {
+                                                // testing for a run of spaces between an attribute's = and a quoted value.
+                                                // Unquoted values separated by space are separate attributes
+                                                if (attribute[attribute.length - 2] === "=") {
+                                                    for (e = a + 1; e < c; e = e + 1) {
+                                                        if ((/\s/).test(b[e]) === false) {
+                                                            if (b[e] === "\"" || b[e] === "'") {
+                                                                a         = e - 1;
+                                                                quotetest = true;
+                                                                attribute.pop();
+                                                            }
+                                                            break;
+                                                        }
+                                                    }
+                                                }
+                                                if (quotetest === true) {
+                                                    quotetest = false;
+                                                } else if (jsxcount === 0 || (jsxcount === 1 && attribute[0] === "{")) {
+                                                    //if there is an unquoted space attribute is complete
+                                                    attribute.pop();
+                                                    attrpush(false);
+                                                    stest = true;
+                                                    break;
+                                                }
+                                            }
+                                        } else if (b[a] === "(" && quote === ")") {
+                                            parncount = parncount + 1;
+                                        } else if (b[a] === ")" && quote === ")") {
+                                            parncount = parncount - 1;
+                                            if (parncount === 0) {
+                                                quote = "";
+                                                if (b[a + 1] === end.charAt(0)) {
+                                                    attrpush(false);
+                                                    break;
+                                                }
+                                            }
+                                        } else if (options.jsx === true && (quote === "}" || (quote === "\n" && b[a] === "\n") || (quote === "*/" && b[a - 1] === "*" && b[a] === "/"))) {
+                                            //jsx attributes
+                                            if (quote === "}") {
+                                                if (b[a] === "{") {
+                                                    bcount = bcount + 1;
+                                                } else if (b[a] === quote) {
+                                                    bcount = bcount - 1;
+                                                    if (bcount === 0) {
+                                                        jsxcount = 0;
+                                                        quote    = "";
+                                                        element  = attribute.join("");
+                                                        if (options.unformatted === false) {
+                                                            if (options.jsx === true) {
+                                                                if ((/^(\s*)$/).test(element) === false) {
+                                                                    attstore.push(element);
+                                                                }
+                                                            } else {
+                                                                element = element.replace(/\s+/g, " ");
+                                                                if (element !== " ") {
+                                                                    attstore.push(element);
+                                                                }
+                                                            }
+                                                        } else if ((/^(\s+)$/).test(element) === false) {
+                                                            attstore.push(element);
+                                                        }
+                                                        attribute = [];
+                                                        break;
+                                                    }
+                                                }
+                                            } else {
+                                                quote                   = "";
+                                                jsxquote                = "";
+                                                jscom[jscom.length - 1] = true;
+                                                element                 = attribute.join("");
+                                                if (element.charAt(1) === "*") {
+                                                    element = element + "\n";
+                                                }
+                                                attribute = [];
+                                                if (element !== " ") {
+                                                    attstore.push(element);
+                                                }
+                                                break;
+                                            }
+                                        } else if (b[a] === "{" && b[a + 1] === "%" && b[igcount - 1] === "=" && (quote === "\"" || quote === "'")) {
+                                            quote   = quote + "{%";
+                                            igcount = 0;
+                                        } else if (b[a - 1] === "%" && b[a] === "}" && (quote === "\"{%" || quote === "'{%")) {
+                                            quote   = quote.charAt(0);
+                                            igcount = 0;
+                                        } else if (b[a] === "<" && end === ">" && b[igcount - 1] === "=" && (quote === "\"" || quote === "'")) {
+                                            quote   = quote + "<";
+                                            igcount = 0;
+                                        } else if (b[a] === ">" && (quote === "\"<" || quote === "'<")) {
+                                            quote   = quote.charAt(0);
+                                            igcount = 0;
+                                        } else if (igcount === 0 && quote !== ">" && (quote.length < 2 || (quote.charAt(0) !== "\"" && quote.charAt(0) !== "'"))) {
+                                            //terminate attribute at the conclusion of a quote pair
+                                            f     = 0;
+                                            tname = lexer[1] + lexer[2];
+                                            tname = tname.toLowerCase();
+                                            // in coldfusion quotes are escaped in a string with double the characters:
+                                            // "cat"" and dog"
+                                            if (tname === "cf" && b[a] === b[a + 1] && (b[a] === "\"" || b[a] === "'")) {
+                                                attribute.push(b[a + 1]);
+                                                a = a + 1;
+                                            } else {
+                                                for (e = quote.length - 1; e > -1; e = e - 1) {
+                                                    if (b[a - f] !== quote.charAt(e)) {
+                                                        break;
+                                                    }
+                                                    f = f + 1;
+                                                }
+                                                if (e < 0) {
+                                                    attrpush(true);
+                                                    if (b[a + 1] === lastchar) {
+                                                        break;
+                                                    }
+                                                }
+                                            }
+                                        } else if (igcount > 0 && (/\s/).test(b[a]) === false) {
+                                            igcount = 0;
+                                        }
+                                    }
+                                } else if (end !== "%>" && end !== "\n" && (b[a] === "\"" || b[a] === "'")) {
+                                    //opening quote
+                                    quote = b[a];
+                                } else if (comment === false && end !== "\n" && b[a] === "<" && b[a + 1] === "!" && b[a + 2] === "-" && b[a + 3] === "-" && b[a + 4] !== "#" && types[types.length - 1] !== "conditional") {
+                                    quote = "-->";
+                                } else if (lexer[0] !== "{" && end !== "\n" && b[a] === "{" && end !== "%>" && end !== "%]" && (options.dustjs === true || b[a + 1] === "{" || b[a + 1] === "%" || b[a + 1] === "@" || b[a + 1] === "#")) {
+                                    //opening embedded template expression
+                                    if (b[a + 1] === "{") {
+                                        if (b[a + 2] === "{") {
+                                            quote = "}}}";
+                                        } else {
+                                            quote = "}}";
+                                        }
+                                    } else if (options.dustjs === true) {
+                                        quote = "}";
+                                    } else {
+                                        quote = b[a + 1] + "}";
+                                    }
+                                    if (quote === end) {
+                                        quote = "";
+                                    }
+                                } else if (simple === true && end !== "\n" && (/\s/).test(b[a]) === true && b[a - 1] !== "<") {
+                                    //identify a space in a regular start or singleton tag
+                                    stest = true;
+                                } else if (simple === true && options.jsx === true && b[a] === "/" && (b[a + 1] === "*" || b[a + 1] === "/")) {
+                                    //jsx comment immediately following tag name
+                                    stest                   = true;
+                                    lexer[lexer.length - 1] = " ";
+                                    attribute.push(b[a]);
+                                    if (b[a + 1] === "*") {
+                                        jsxquote = "*/";
+                                    } else {
+                                        jsxquote = "\n";
+                                    }
+                                } else if ((b[a] === lastchar || (end === "\n" && b[a + 1] === "<")) && (lexer.length > end.length + 1 || lexer[0] === "]") && (options.jsx === false || jsxcount === 0)) {
+                                    if (end === "\n") {
+                                        if ((/\s/).test(lexer[lexer.length - 1]) === true) {
+                                            do {
+                                                lexer.pop();
+                                                a = a - 1;
+                                            } while ((/\s/).test(lexer[lexer.length - 1]) === true);
+                                        }
+                                        break;
+                                    }
+                                    if (lexer[0] === "{" && lexer[1] === "%" && lexer.join("").replace(/\s+/g, "") === "{%comment%}") {
+                                        end                     = "endcomment";
+                                        lastchar                = "t";
+                                        preserve                = true;
+                                        comment                 = true;
+                                        types[types.length - 1] = "comment";
+                                    } else {
+                                        //if current character matches the last character of the tag ending sequence
+                                        f = lexer.length;
+                                        for (e = end.length - 1; e > -1; e = e - 1) {
+                                            f = f - 1;
+                                            if (lexer[f] !== end.charAt(e)) {
+                                                break;
+                                            }
+                                        }
+                                        if (e < 0) {
+                                            break;
+                                        }
+                                    }
+                                }
+                            } else if (b[a] === quote.charAt(quote.length - 1) && ((options.jsx === true && end === "}" && (b[a - 1] !== "\\" || slashy() === false)) || options.jsx === false || end !== "}")) {
+                                //find the closing quote or embedded template expression
+                                f     = 0;
+                                tname = lexer[1] + lexer[2];
+                                tname = tname.toLowerCase();
+                                // in coldfusion quotes are escaped in a string with double the characters:
+                                // "cat"" and dog"
+                                if (tname === "cf" && b[a] === b[a + 1] && (b[a] === "\"" || b[a] === "'")) {
+                                    attribute.push(b[a + 1]);
+                                    a = a + 1;
+                                } else {
+                                    for (e = quote.length - 1; e > -1; e = e - 1) {
+                                        if (b[a - f] !== quote.charAt(e)) {
+                                            break;
+                                        }
+                                        f = f + 1;
+                                    }
+                                    if (e < 0) {
+                                        quote = "";
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    //nopush flags mean an early exit
+                    if (nopush === true) {
+                        jscom.pop();
+                        linen.pop();
+                        lines.pop();
+                        value.pop();
+                        space = minspace;
+                        return;
+                    }
+
+                    if (preserve === true) {
+                        presv.push(true);
+                    } else {
+                        presv.push(false);
+                    }
+
+                    if (options.correct === true) {
+                        if (b[a + 1] === ">" && lexer[0] === "<" && lexer[1] !== "<") {
+                            do {
+                                a = a + 1;
+                            } while (b[a + 1] === ">");
+                        } else if (lexer[0] === "<" && lexer[1] === "<" && b[a + 1] !== ">" && lexer[lexer.length - 2] !== ">") {
+                            do {
+                                lexer.splice(1, 1);
+                            } while (lexer[1] === "<");
+                        }
+                    }
+                    igcount = 0;
+                    element = lexer.join("");
+                    if (element.indexOf("{{") === 0 && element.slice(element.length - 2) === "}}") {
+                        if (tagName(element) === "end") {
+                            types[types.length - 1] = "template_end";
+                        } else if (tagName(element) === "else") {
+                            types[types.length - 1] = "template_else";
+                        }
+                    } else if (element.slice(0, 2) === "<%" && element.slice(element.length - 2) === "%>") {
+                        if ((/^(<%\s+end\s+-?%>)$/).test(element) === true) {
+                            types[types.length - 1] = "template_end";
+                        } else if (((/\sdo\s/).test(element) === true && element.indexOf("-%>") === element.length - 3) || (/^(<%(%|-)?\s*if)/).test(element) === true) {
+                            types[types.length - 1] = "template_start";
+                        }
+                    }
+                    tname = tagName(element);
+                    if (options.html === true && element.charAt(0) === "<" && element.charAt(1) !== "!" && element.charAt(1) !== "?" && (types.length === 0 || types[types.length - 1].indexOf("template") < 0) && options.jsx === false && cftags[tname] === undefined && cftags[tname.slice(1)] === undefined && tname.slice(0, 3) !== "cf_") {
+                        element = element.toLowerCase();
+                    }
+                    if (tname === "comment" && element.slice(0, 2) === "{%") {
+                        element = element
+                            .replace(/^(\{%\s*comment\s*%\}\s*)/, "")
+                            .replace(/(\s*\{%\s*endcomment\s*%\})$/, "");
+
+                        attrs.push({});
+                        attrs.push({});
+                        value.push("");
+                        value.push("");
+                        jscom.push(false);
+                        jscom.push(false);
+                        e = linen[linen.length - 1];
+                        linen.push(e);
+                        linen.push(e);
+                        types[types.length - 1] = "template_start";
+                        token.push("{% comment %}");
+                        types.push("comment");
+                        daddy.push(parent[parent.length - 1][0]);
+                        begin.push(parent[parent.length - 1][1]);
+                        stats.template[0] = stats.template[0] + 1;
+                        stats.template[1] = stats.template[1] + 13;
+                        token.push(element);
+                        types.push("template_end");
+                        daddy.push(parent[parent.length - 1][0]);
+                        begin.push(parent[parent.length - 1][1]);
+                        stats.template[0] = stats.template[0] + 1;
+                        stats.template[1] = stats.template[1] + element.length;
+                        return token.push("{% endcomment %}");
+                    }
+
+                    if (end !== "]>" && sgmlflag > 0 && element.charAt(element.length - 1) !== "[" && (element.slice(element.length - 2) === "]>" || (/^(<!((doctype)|(notation))\s)/i).test(element) === true)) {
+                        sgmlflag = sgmlflag - 1;
+                    }
+
+                    //fix singleton tags and sort attributes
+                    if (attstore.length > 0) {
+                        if (attstore[attstore.length - 1] === "/") {
+                            attstore.pop();
+                            lexer.splice(lexer.length - 1, 0, "/");
+                        }
+                        f = attstore.length;
+                        for (e = 1; e < f; e = e + 1) {
+                            quote = attstore[e - 1];
+                            if (quote.charAt(quote.length - 1) === "=" && attstore[e].indexOf("=") < 0) {
+                                attstore[e - 1] = quote + attstore[e];
+                                attstore.splice(e, 1);
+                                f = f - 1;
+                                e = e - 1;
+                            }
+                        }
+                        if (objsortop === true && jscom[jscom.length - 1] === false && options.jsx === false && nosort === false && tname !== "cfif" && tname !== "cfelseif" && tname !== "cfset") {
+                            attstore = safeSort(attstore);
+                        }
+                    }
+                    attrs.push(function markuppretty__tokenize_attribute() {
+                        var ind    = 0,
+                            len    = attstore.length,
+                            obj    = {},
+                            eq     = 0,
+                            dq     = 0,
+                            sq     = 0,
+                            syntax = "<{\"'=/",
+                            slice  = "",
+                            store  = [],
+                            name   = "",
+                            cft    = cftags[tname];
+                        if (tname.slice(0, 3) === "cf_") {
+                            cft = "required";
+                        }
+                        if (objsortop === true && options.jsx === false && cft === undefined) {
+                            attstore = safeSort(attstore);
+                        }
+                        for (ind = 0; ind < len; ind = ind + 1) {
+                            eq = attstore[ind].indexOf("=");
+                            dq = attstore[ind].indexOf("\"");
+                            sq = attstore[ind].indexOf("'");
+                            if (eq > -1 && store.length > 0) {
+                                obj[store.join(" ")] = "";
+                                store                = [];
+                                obj[attstore[ind]]   = "";
+                            } else if (cft !== undefined && eq < 0 && attstore[ind].indexOf("=") < 0) {
+                                store.push(attstore[ind]);
+                            } else if ((cft !== undefined && eq < 0) || (dq > 0 && dq < eq) || (sq > 0 && sq < eq) || syntax.indexOf(attstore[ind].charAt(0)) > -1) {
+                                obj[attstore[ind]] = "";
+                            } else if (eq < 0 && cft === undefined) {
+                                name = attstore[ind];
+                                if (options.html === true && options.jsx === false && cft === undefined) {
+                                    name = name.toLowerCase();
+                                }
+                                if (options.quoteConvert === "single") {
+                                    obj[name] = "'" + attstore[ind] + "'";
+                                } else {
+                                    obj[name] = "\"" + attstore[ind] + "\"";
+                                }
+                            } else {
+                                slice = attstore[ind].slice(eq + 1);
+                                if (syntax.indexOf(slice.charAt(0)) < 0 && cft === undefined) {
+                                    if (options.quoteConvert === "single") {
+                                        slice = "'" + slice + "'";
+                                    } else {
+                                        slice = "\"" + slice + "\"";
+                                    }
+                                }
+                                name = attstore[ind].slice(0, eq);
+                                if (options.html === true && options.jsx === false && cft === undefined) {
+                                    name = name.toLowerCase();
+                                }
+                                obj[name] = slice;
+                            }
+                        }
+                        if (store.length > 0) {
+                            obj[store.join(" ")] = "";
+                        }
+                        return obj;
+                    }());
+
+                    if (parseFail === true) {
+                        if (element.indexOf("<!--<![") === 0) {
+                            parseError.pop();
+                        } else {
+                            parseError[parseError.length - 1] = parseError[parseError.length - 1] +
+                                    element;
+                            if (element.indexOf("</") > 0) {
+                                token.push(element);
+                                daddy.push(parent[parent.length - 1][0]);
+                                begin.push(parent[parent.length - 1][1]);
+                                stats.end[0] = stats.end[0] + 1;
+                                stats.end[1] = stats.end[1] + token[token.length - 1].length;
+                                return types.push("end");
+                            }
+                        }
+                    }
+                    // cheat identifies HTML singleton elements as singletons even if formatted as
+                    // start tags
+                    cheat = (function markuppretty__tokenize_tag_cheat() {
+                        var atty         = [],
+                            attn         = token[token.length - 1],
+                            atval        = "",
+                            type         = "",
+                            d            = 0,
+                            ee           = 1,
+                            cfval        = "",
+                            ender        = (/(\/>)$/),
+                            htmlsings    = {
+                                area       : "singleton",
+                                base       : "singleton",
+                                basefont   : "singleton",
+                                br         : "singleton",
+                                col        : "singleton",
+                                embed      : "singleton",
+                                eventsource: "singleton",
+                                frame      : "singleton",
+                                hr         : "singleton",
+                                img        : "singleton",
+                                input      : "singleton",
+                                keygen     : "singleton",
+                                link       : "singleton",
+                                meta       : "singleton",
+                                param      : "singleton",
+                                progress   : "singleton",
+                                source     : "singleton",
+                                wbr        : "singleton"
+                            },
+                            fixsingleton = function markuppretty__tokenize_tag_cheat_fixsingleton() {
+                                var aa    = 0,
+                                    bb    = 0,
+                                    vname = tname.slice(1);
+                                for (aa = token.length - 1; aa > -1; aa = aa - 1) {
+                                    if (types[aa] === "end") {
+                                        bb = bb + 1;
+                                    } else if (types[aa] === "start") {
+                                        bb = bb - 1;
+                                        if (bb < 0) {
+                                            return false;
+                                        }
+                                    }
+                                    if (bb === 0 && token[aa].toLowerCase().indexOf(vname) === 1) {
+                                        if (cftags[tagName(token[aa])] !== undefined) {
+                                            types[aa] = "template_start";
+                                        } else {
+                                            types[aa]          = "start";
+                                            stats.singleton[0] = stats.singleton[0] - 1;
+                                            stats.singleton[1] = stats.singleton[1] - token[token.length - 1].length;
+                                            stats.start[0]     = stats.start[0] + 1;
+                                            stats.start[1]     = stats.start[1] + token[token.length - 1].length;
+                                        }
+                                        if (Object.keys(attrs[aa]).length > 0) {
+                                            token[aa] = token[aa].replace(/(\s*\/>)$/, " >");
+                                        } else {
+                                            token[aa] = token[aa].replace(/(\s*\/>)$/, ">");
+                                        }
+                                        return false;
+                                    }
+                                }
+                            };
+                        if (presend["/" + tname] === true) {
+                            linepreserve = linepreserve - 1;
+                        }
+                        if (types[types.length - 1] === "end" && tname.slice(0, 3) !== "/cf") {
+                            if (types[types.length - 2] === "singleton" && attn.charAt(attn.length - 2) !== "/" && "/" + tagName(attn) === tname) {
+                                types[types.length - 2] = "start";
+                            } else if ((types[types.length - 2] === "start" || htmlsings[tname.slice(1)] === "singleton") && tname !== "/span" && tname !== "/div" && tname !== "/script" && (options.html === false || (options.html === true && tname !== "/li")) && tname === "/" + tagName(token[token.length - 1]) && options.tagmerge === true) {
+                                types.pop();
+                                attrs.pop();
+                                jscom.pop();
+                                linen.pop();
+                                lines.pop();
+                                presv.pop();
+                                value.pop();
+                                if (types[types.length - 1] === "start") {
+                                    token[token.length - 1] = token[token.length - 1].replace(/>$/, "/>");
+                                }
+                                types[types.length - 1] = "singleton";
+                                singleton               = true;
+                                return;
+                            }
+                        }
+                        for (d = attstore.length - 1; d > -1; d = d - 1) {
+                            atty = arname(attstore[d]);
+                            if (atty[0] === "type") {
+                                type = atty[1];
+                                if (type.charAt(0) === "\"" || type.charAt(0) === "'") {
+                                    type = type.slice(1, type.length - 1);
+                                }
+                            } else if (atty[0] === "src" && (tname === "embed" || tname === "img" || tname === "script" || tname === "iframe")) {
+                                atval = atty[1];
+                                if (atval.charAt(0) === "\"" || atval.charAt(0) === "'") {
+                                    atval = atval.slice(1, atval.length - 1);
+                                }
+                                reqs.push(atval);
+                            } else if (tname === "link" && atty === "href") {
+                                atval = atty[1];
+                                if (atval.charAt(0) === "\"" || atval.charAt(0) === "'") {
+                                    atval = atval.slice(1, atval.length - 1);
+                                }
+                                reqs.push(atval);
+                            }
+                        }
+
+                        if ((tname === "script" || tname === "style" || tname === "cfscript") && element.slice(element.length - 2) !== "/>") {
+                            //identify if there is embedded code requiring an external parser
+                            if (tname === "script" && (type === "" || type === "text/javascript" || type === "babel" || type === "module" || type === "application/javascript" || type === "application/x-javascript" || type === "text/ecmascript" || type === "application/ecmascript" || type === "text/jsx" || type === "application/jsx" || type === "text/cjs")) {
+                                ext = true;
+                            } else if (tname === "style" && (type === "" || type === "text/css")) {
+                                ext = true;
+                            } else if (tname === "cfscript") {
+                                ext = true;
+                            }
+                            if (ext === true) {
+                                for (d = a + 1; d < c; d = d + 1) {
+                                    if ((/\s/).test(b[d]) === false) {
+                                        if (b[d] === "<") {
+                                            if (b.slice(d + 1, d + 4).join("") === "!--") {
+                                                for (d = d + 4; d < c; d = d + 1) {
+                                                    if ((/\s/).test(b[d]) === false) {
+                                                        ext = false;
+                                                        break;
+                                                    }
+                                                    if (b[d] === "\n" || b[d] === "\r") {
+                                                        break;
+                                                    }
+                                                }
+                                            } else if (b.slice(d + 1, d + 9).join("") !== "![CDATA[") {
+                                                ext = false;
+                                            }
+                                        }
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        if (tname === "/#assign" || tname === "/#global") {
+                            for (d = types.length - 2; d > -1; d = d - 1) {
+                                if (types[d] === "start" || types[d] === "template_start") {
+                                    ee = ee - 1;
+                                } else if (types[d] === "end" || types[d] === "template_end") {
+                                    ee = ee + 1;
+                                }
+                                if (ee === 1) {
+                                    if ((token[d].indexOf("<#assign") === 0 && tname === "/#assign") || (token[d].indexOf("<#global") === 0 && tname === "/#global")) {
+                                        types[d] = "template_start";
+                                        return false;
+                                    }
+                                }
+                                if (ee === 0) {
+                                    return false;
+                                }
+                            }
+                            return false;
+                        }
+                        if (tname.charAt(0) === "#" && types[types.length - 1] === "start" && (tname === "#assign" || tname === "#break" || tname === "#case" || tname === "#default" || tname === "#fallback" || tname === "#flush" || tname === "#ftl" || tname === "#global" || tname === "#import" || tname === "#include" || tname === "#local" || tname === "#t" || tname === "#lt" || tname === "#rt" || tname === "#nested" || tname === "#nt" || tname === "#recover" || tname === "#recurse" || tname === "#return" || tname === "#sep" || tname === "#setting" || tname === "#stop" || tname === "#visit")) {
+                            simple = true;
+                            return true;
+                        }
+                        if (options.html === true) {
+                            //simple means of looking for missing li end tags
+                            if (options.jsx === false) {
+                                if (tname === "li") {
+                                    if (litag === list && (list !== 0 || (list === 0 && types.length > 0 && types[types.length - 1].indexOf("template") < 0))) {
+                                        for (d = types.length - 1; d > -1; d = d - 1) {
+                                            if (types[d] === "start" || types[d] === "template_start") {
+                                                ee = ee - 1;
+                                            } else if (types[d] === "end" || types[d] === "template_end") {
+                                                ee = ee + 1;
+                                            }
+                                            if (ee === -1 && (tagName(token[d]) === "li" || (tagName(token[d + 1]) === "li" && (tagName(token[d]) === "ul" || tagName(token[d]) === "ol")))) {
+                                                liend = true;
+                                                break;
+                                            }
+                                            if (ee < 0) {
+                                                break;
+                                            }
+                                        }
+                                    } else {
+                                        litag = litag + 1;
+                                    }
+                                } else if (tname === "/li" && litag === list) {
+                                    litag = litag - 1;
+                                } else if (tname === "ul" || tname === "ol") {
+                                    list = list + 1;
+                                } else if (tname === "/ul" || tname === "/ol") {
+                                    if (litag === list) {
+                                        liend = true;
+                                        litag = litag - 1;
+
+                                    }
+                                    list = list - 1;
+                                }
+                            }
+                            if (types[types.length - 1] === "end" && htmlsings[tname.slice(1)] === "singleton" && tname !== "/cftransaction") {
+                                return fixsingleton();
+                            }
+                            if (htmlsings[tname] === "singleton") {
+                                if (options.correct === true && ender.test(element) === false) {
+                                    lexer.pop();
+                                    lexer.push(" ");
+                                    lexer.push("/");
+                                    lexer.push(">");
+                                    element = lexer.join("");
+                                }
+                                return true;
+                            }
+                        }
+                        if (types[types.length - 1] === "end" && tname.slice(0, 3) === "/cf" && cftags[tname.slice(1)] !== undefined) {
+                            cfval = cftags[tname.slice(1)];
+                            if (tname === "/cftransaction") {
+                                cftransaction = false;
+                            }
+                            if (cfval !== undefined) {
+                                types[types.length - 1] = "template_end";
+                            }
+                            if ((cfval === "optional" || cfval === "prohibited") && tname !== "/cftransaction") {
+                                return fixsingleton();
+                            }
+                            return false;
+                        }
+                        if (tname.slice(0, 2) === "cf") {
+                            if (tname === "cfelse" || tname === "cfelseif") {
+                                types.push("template_else");
+                                token.push(lexer.join(""));
+                                daddy.push(parent[parent.length - 1][0]);
+                                begin.push(parent[parent.length - 1][1]);
+                                stats.template[0] = stats.template[0] + 1;
+                                stats.template[1] = stats.template[1] + token[token.length - 1].length;
+                                singleton         = true;
+                                return false;
+                            }
+                            if (tname === "cftransaction" && cftransaction === true) {
+                                cfval = "prohibited";
+                            } else {
+                                cfval = cftags[tname];
+                            }
+                            if (cfval === "optional" || cfval === "prohibited" || tname.slice(0, 3) === "cf_") {
+                                if (options.correct === true && ender.test(element) === false) {
+                                    lexer.pop();
+                                    lexer.push(" ");
+                                    lexer.push("/");
+                                    lexer.push(">");
+                                }
+                                types.push("template");
+                                token.push(lexer.join("").replace(/\s+/, " "));
+                                daddy.push(parent[parent.length - 1][0]);
+                                begin.push(parent[parent.length - 1][1]);
+                                stats.template[0] = stats.template[0] + 1;
+                                stats.template[1] = stats.template[1] + token[token.length - 1].length;
+                                singleton         = true;
+                                return false;
+                            }
+                            if (cfval === "required" && tname !== "cfquery") {
+                                if (tname === "cftransaction" && cftransaction === false) {
+                                    cftransaction = true;
+                                }
+                                types.push("template_start");
+                                token.push(lexer.join(""));
+                                daddy.push(parent[parent.length - 1][0]);
+                                if (parent[parent.length - 1][1] === -1) {
+                                    begin.push(token.length - 1);
+                                } else {
+                                    begin.push(parent[parent.length - 1][1]);
+                                }
+                                stats.template[0] = stats.template[0] + 1;
+                                stats.template[1] = stats.template[1] + token[token.length - 1].length;
+                                singleton         = true;
+                            }
+                            return false;
+                        }
+                        if (options.dustjs === true && types[types.length - 1] === "template_start") {
+                            type  = element.charAt(1);
+                            atval = element.slice(element.length - 2);
+                            if ((atval === "/}" || atval.charAt(0) === type) && (type === "#" || type === "?" || type === "^" || type === "@" || type === "<" || type === "+")) {
+                                types[types.length - 1] = "template";
+                            }
+                        }
+                        return false;
+                    }());
+
+                    if (singleton === true) {
+                        return;
+                    }
+                    //am I a singleton or a start type?
+                    if (simple === true && ignoreme === false) {
+                        if (cheat === true || (lexer[lexer.length - 2] === "/" && lexer[lexer.length - 1] === ">")) {
+                            types.push("singleton");
+                        } else {
+                            types.push("start");
+                        }
+                    }
+                    // additional logic is required to find the end of a tag with the attribute
+                    // data-prettydiff-ignore
+                    if (simple === true && preserve === false && ignoreme === true && end === ">" && element.slice(element.length - 2) !== "/>") {
+                        if (cheat === true) {
+                            types.push("singleton");
+                        } else {
+                            preserve                = true;
+                            presv[presv.length - 1] = true;
+                            types.push("ignore");
+                            a     = a + 1;
+                            quote = "";
+                            for (a = a; a < c; a = a + 1) {
+                                if (b[a] === "\n") {
+                                    line = line + 1;
+                                }
+                                lexer.push(b[a]);
+                                if (quote === "") {
+                                    if (b[a] === "\"") {
+                                        quote = "\"";
+                                    } else if (b[a] === "'") {
+                                        quote = "'";
+                                    } else if (lexer[0] !== "{" && b[a] === "{" && (options.dustjs === true || b[a + 1] === "{" || b[a + 1] === "%" || b[a + 1] === "@" || b[a + 1] === "#")) {
+                                        if (b[a + 1] === "{") {
+                                            if (b[a + 2] === "{") {
+                                                quote = "}}}";
+                                            } else {
+                                                quote = "}}";
+                                            }
+                                        } else if (options.dustjs === true) {
+                                            quote = "}";
+                                        } else {
+                                            quote = b[a + 1] + "}";
+                                        }
+                                    } else if (b[a] === "<" && simple === true) {
+                                        if (b[a + 1] === "/") {
+                                            endtag = true;
+                                        } else {
+                                            endtag = false;
+                                        }
+                                    } else if (b[a] === lastchar) {
+                                        if (b[a - 1] !== "/") {
+                                            if (b[a - 1] !== "/") {
+                                                if (endtag === true) {
+                                                    igcount = igcount - 1;
+                                                    if (igcount < 0) {
+                                                        break;
+                                                    }
+                                                } else {
+                                                    igcount = igcount + 1;
+                                                }
+                                            }
+                                        }
+                                    }
+                                } else if (b[a] === quote.charAt(quote.length - 1)) {
+                                    f = 0;
+                                    for (e = quote.length - 1; e > -1; e = e - 1) {
+                                        if (b[a - f] !== quote.charAt(e)) {
+                                            break;
+                                        }
+                                        f = f + 1;
+                                    }
+                                    if (e < 0) {
+                                        quote = "";
+                                    }
+                                }
+                            }
+                        }
+                        element = lexer.join("");
+                        if (options.mode === "diff") {
+                            element = element.replace(" >", " />");
+                            element = element.slice(0, element.indexOf(" />") + 3);
+                            if (options.quotes === "single") {
+                                attstore = ["data-prettydiff-ignore='true'"];
+                            } else {
+                                attstore = ["data-prettydiff-ignore=\"true\""];
+                            }
+                        }
+                    }
+
+                    //some template tags can be evaluated as a block start/end based on syntax alone
+                    e = types.length - 1;
+                    if (types[e].indexOf("template") > -1) {
+                        if (element.slice(0, 2) === "{%") {
+                            lexer = [
+                                "autoescape",
+                                "block",
+                                "capture",
+                                "case",
+                                "comment",
+                                "embed",
+                                "filter",
+                                "for",
+                                "form",
+                                "if",
+                                "macro",
+                                "paginate",
+                                "raw",
+                                "sandbox",
+                                "spaceless",
+                                "tablerow",
+                                "unless",
+                                "verbatim"
+                            ];
+                            if (tname === "else" || tname === "elseif" || tname === "when" || tname === "elif") {
+                                types[e] = "template_else";
+                            } else {
+                                for (f = lexer.length - 1; f > -1; f = f - 1) {
+                                    if (tname === lexer[f]) {
+                                        types[e] = "template_start";
+                                        break;
+                                    }
+                                    if (tname === "end" + lexer[f]) {
+                                        types[e] = "template_end";
+                                        break;
+                                    }
+                                }
+                            }
+                        } else if (element.slice(0, 2) === "{{" && element.charAt(3) !== "{") {
+                            if ((/^(\{\{\s*end\s*\}\})$/).test(element) === true) {
+                                types[e] = "template_end";
+                            } else if (tname === "block" || tname === "define" || tname === "form" || tname === "if" || tname === "range" || tname === "with") {
+                                if (tname !== "block" || (/\{%\s*\w/).test(options.source) === false) {
+                                    types[e] = "template_start";
+                                }
+                            }
+                        } else if (types[e] === "template") {
+                            if (element.indexOf("else") > 2) {
+                                types[e] = "template_else";
+                            } else if ((/^(<%\s*\})/).test(element) === true || (/^(\[%\s*\})/).test(element) === true || (/^(\{@\s*\})/).test(element) === true) {
+                                types[e] = "template_end";
+                            } else if ((/(\{\s*%>)$/).test(element) === true || (/(\{\s*%\])$/).test(element) === true || (/(\{\s*@\})$/).test(element) === true) {
+                                types[e] = "template_start";
+                            }
+                        }
+                    }
+
+                    // HTML5 does not require an end tag for an opening list item <li> this logic
+                    // temprorarily creates a pseudo end tag
+                    if (liend === true && (options.mode === "beautify" || options.mode === "diff" || options.mode === "parse")) {
+                        token.push("</prettydiffli>");
+                        daddy.push(parent[parent.length - 1][0]);
+                        begin.push(parent[parent.length - 1][1]);
+                        lines.push(lines[lines.length - 1]);
+                        linen.push(line);
+                        lines[lines.length - 2] = 0;
+                        attrs.push({});
+                        if (types[types.length - 1] === "start") {
+                            types.splice(types.length - 1, 0, "end");
+                        } else {
+                            types.push("end");
+                        }
+                        presv.push(false);
+                        jscom.push(false);
+                        value.push("");
+                        if (parent.length > 1) {
+                            parent.pop();
+                        }
+                        stats.end[0] = stats.end[0] + 1;
+                        stats.end[1] = stats.end[1] + 5;
+                    }
+                    if (parent[parent.length - 1][1] === -1) {
+                        parent[parent.length - 1] = ["root", token.length];
+                    }
+                    if (preserve === true) {
+                        token.push(element);
+                        daddy.push(parent[parent.length - 1][0]);
+                        begin.push(parent[parent.length - 1][1]);
+                        stats.ignore[0] = stats.ignore[0] + 1;
+                        stats.ignore[1] = stats.ignore[1] + token[token.length - 1].length;
+                    } else {
+                        if (options.jsx === true) {
+                            token.push(element);
+                        } else {
+                            token.push(element.replace(/\s+/g, " "));
+                        }
+                        daddy.push(parent[parent.length - 1][0]);
+                        begin.push(parent[parent.length - 1][1]);
+                        if (types[types.length - 1].indexOf("template") > -1) {
+                            stats.template[0] = stats.template[0] + 1;
+                            stats.template[1] = stats.template[1] + token[token.length - 1].length;
+                        } else if (types[types.length - 1].indexOf("linepreserve") > -1) {
+                            stats.ignore[0] = stats.ignore[0] + 1;
+                            stats.ignore[1] = stats.ignore[1] + token[token.length - 1].length;
+                        } else {
+                            stats[types[types.length - 1]][0] = stats[types[types.length - 1]][0] + 1;
+                            stats[types[types.length - 1]][1] = stats[types[types.length - 1]][1] +
+                                    token[token.length - 1].length;
+                        }
+                    }
+                    if (options.tagsort === true && types[types.length - 1] === "end" && types[types.length - 2] !== "start") {
+                        (function markuppretty__tokenize_tag_sorttag() {
+                            var children   = [],
+                                bb         = 0,
+                                d          = 0,
+                                endStore   = 0,
+                                startStore = 0,
+                                endData    = {},
+                                store      = {
+                                    attrs: [],
+                                    begin: [],
+                                    daddy: [],
+                                    jscom: [],
+                                    linen: [],
+                                    lines: [],
+                                    presv: [],
+                                    token: [],
+                                    types: [],
+                                    value: []
+                                },
+                                sortName   = function markuppretty__tokenize_tag_sorttag_sortName(x, y) {
+                                    if (token[x[0]] < token[y[0]]) {
+                                        return 1;
+                                    }
+                                    return -1;
+                                },
+                                pushy      = function markuppretty__tokenize_tag_sorttag_pushy(index) {
+                                    store
+                                        .attrs
+                                        .push(attrs[index]);
+                                    store
+                                        .begin
+                                        .push(begin[index]);
+                                    store
+                                        .daddy
+                                        .push(daddy[index]);
+                                    store
+                                        .jscom
+                                        .push(jscom[index]);
+                                    store
+                                        .linen
+                                        .push(linen[index]);
+                                    store
+                                        .lines
+                                        .push(lines[index]);
+                                    store
+                                        .presv
+                                        .push(presv[index]);
+                                    store
+                                        .token
+                                        .push(token[index]);
+                                    store
+                                        .types
+                                        .push(types[index]);
+                                    store
+                                        .value
+                                        .push(value[index]);
+                                };
+                            for (bb = token.length - 2; bb > -1; bb = bb - 1) {
+                                if (types[bb] === "start") {
+                                    d = d - 1;
+                                    if (d < 0) {
+                                        startStore = bb + 1;
+                                        break;
+                                    }
+                                } else if (types[bb] === "end") {
+                                    d = d + 1;
+                                    if (d === 1) {
+                                        endStore = bb;
+                                    }
+                                }
+                                if (d === 0) {
+                                    if (types[bb] === "start") {
+                                        children.push([bb, endStore]);
+                                    } else {
+                                        children.push([bb, bb]);
+                                    }
+                                }
+                            }
+                            if (children.length < 2) {
+                                return;
+                            }
+                            children.sort(sortName);
+                            for (bb = children.length - 1; bb > -1; bb = bb - 1) {
+                                pushy(children[bb][0]);
+                                if (children[bb][0] !== children[bb][1]) {
+                                    for (d = children[bb][0] + 1; d < children[bb][1]; d = d + 1) {
+                                        pushy(d);
+                                    }
+                                    pushy(children[bb][1]);
+                                }
+                            }
+                            endData.attrs = attrs.pop();
+                            endData.begin = begin.pop();
+                            endData.daddy = daddy.pop();
+                            endData.jscom = jscom.pop();
+                            endData.linen = linen.pop();
+                            endData.lines = lines.pop();
+                            endData.presv = presv.pop();
+                            endData.token = token.pop();
+                            endData.types = types.pop();
+                            endData.value = value.pop();
+                            attrs         = attrs
+                                .slice(0, startStore)
+                                .concat(store.attrs);
+                            begin         = begin
+                                .slice(0, startStore)
+                                .concat(store.begin);
+                            daddy         = daddy
+                                .slice(0, startStore)
+                                .concat(store.daddy);
+                            jscom         = jscom
+                                .slice(0, startStore)
+                                .concat(store.jscom);
+                            linen         = linen
+                                .slice(0, startStore)
+                                .concat(store.linen);
+                            lines         = lines
+                                .slice(0, startStore)
+                                .concat(store.lines);
+                            presv         = presv
+                                .slice(0, startStore)
+                                .concat(store.presv);
+                            token         = token
+                                .slice(0, startStore)
+                                .concat(store.token);
+                            types         = types
+                                .slice(0, startStore)
+                                .concat(store.types);
+                            value         = value
+                                .slice(0, startStore)
+                                .concat(store.value);
+                            attrs.push(endData.attrs);
+                            begin.push(endData.begin);
+                            daddy.push(endData.daddy);
+                            jscom.push(endData.jscom);
+                            linen.push(endData.linen);
+                            lines.push(endData.lines);
+                            presv.push(endData.presv);
+                            token.push(endData.token);
+                            types.push(endData.types);
+                            value.push(endData.value);
+                        }());
+                    }
+                    e = token.length - 1;
+                    if (types[e] === "start") {
+                        parent.push([tname, e]);
+                    } else if (types[e] === "end" && parent.length > 1) {
+                        parent.pop();
+                    }
+                    if (options.attributetoken === true && options.mode === "parse") {
+                        attribute = Object.keys(attrs[e]);
+                        bcount    = attribute.length;
+                        if ((types[e] === "start" || types[e] === "singleton") && bcount > 0) {
+                            for (f = 0; f < bcount; f = f + 1) {
+                                attrs.push({});
+                                begin.push(begin[e]);
+                                if (daddy[e] === "root") {
+                                    daddy.push(tname);
+                                } else {
+                                    daddy.push(daddy[e]);
+                                }
+                                jscom.push(false);
+                                linen.push(linen[e]);
+                                lines.push(0);
+                                presv.push(presv[e]);
+                                token.push(attribute[f]);
+                                if (attribute[f] === "") {
+                                    types.push("template_attribute");
+                                    value.push("");
+                                } else {
+                                    types.push("attribute");
+                                    value.push(attrs[e][attribute[f]]);
+                                }
+                            }
+                        }
+                    }
+                },
+                content       = function markuppretty__tokenize_content() {
+                    var lexer     = [],
+                        quote     = "",
+                        end       = "",
+                        square    = (
+                            types[types.length - 1] === "template_start" && token[token.length - 1].indexOf("<!") === 0 && token[token.length - 1].indexOf("<![") < 0 && token[token.length - 1].charAt(token[token.length - 1].length - 1) === "["
+                        ),
+                        tailSpace = function markuppretty__tokenize_content_tailSpace(spacey) {
+                            if (linepreserve > 0 && spacey.indexOf("\n") < 0 && spacey.indexOf("\r") < 0) {
+                                spacey = "";
+                            }
+                            space = spacey;
+                            return "";
+                        },
+                        esctest   = function markuppretty__tokenize_content_esctest() {
+                            var aa = 0,
+                                bb = 0;
+                            if (b[a - 1] !== "\\") {
+                                return false;
+                            }
+                            for (aa = a - 1; aa > -1; aa = aa - 1) {
+                                if (b[aa] !== "\\") {
+                                    break;
+                                }
+                                bb = bb + 1;
+                            }
+                            if (bb % 2 === 1) {
+                                return true;
+                            }
+                            return false;
+                        },
+                        name      = "";
+                    spacer();
+                    attrs.push({});
+                    jscom.push(false);
+                    linen.push(line);
+                    value.push("");
+                    if (linepreserve > 0) {
+                        presv.push(true);
+                    } else {
+                        presv.push(false);
+                    }
+                    if (ext === true) {
+                        name = tagName(token[token.length - 1]);
+                    }
+                    for (a = a; a < c; a = a + 1) {
+                        if (b[a] === "\n") {
+                            line = line + 1;
+                        }
+                        // external code requires additional parsing to look for the appropriate end
+                        // tag, but that end tag cannot be quoted or commented
+                        if (ext === true) {
+                            if (quote === "") {
+                                if (b[a] === "/") {
+                                    if (b[a + 1] === "*") {
+                                        quote = "*";
+                                    } else if (b[a + 1] === "/") {
+                                        quote = "/";
+                                    } else if (name === "script" && "([{!=,;.?:&<>".indexOf(b[a - 1]) > -1) {
+                                        quote = "reg";
+                                    }
+                                } else if ((b[a] === "\"" || b[a] === "'" || b[a] === "`") && esctest() === false) {
+                                    quote = b[a];
+                                }
+                                end = b
+                                    .slice(a, a + 10)
+                                    .join("")
+                                    .toLowerCase();
+                                if (name === "cfscript" && end === "</cfscript") {
+                                    a   = a - 1;
+                                    ext = false;
+                                    if (lexer.length < 1) {
+                                        attrs.pop();
+                                        jscom.pop();
+                                        linen.pop();
+                                        presv.pop();
+                                        value.pop();
+                                        return lines.pop();
+                                    }
+                                    token.push(lexer.join("").replace(/^(\s+)/, "").replace(/(\s+)$/, ""));
+                                    daddy.push(parent[parent.length - 1][0]);
+                                    begin.push(parent[parent.length - 1][1]);
+                                    stats.script[0] = stats.script[0] + 1;
+                                    stats.script[1] = stats.script[1] + token[token.length - 1].length;
+                                    if (typeof global.prettydiff.jspretty === "function") {
+                                        return types.push(name);
+                                    }
+                                    return types.push("content");
+                                }
+                                if (name === "script") {
+                                    if (a === c - 9) {
+                                        end = end.slice(0, end.length - 1);
+                                    } else {
+                                        end = end.slice(0, end.length - 2);
+                                    }
+                                    if (end === "</script") {
+                                        a   = a - 1;
+                                        ext = false;
+                                        if (lexer.length < 1) {
+                                            attrs.pop();
+                                            jscom.pop();
+                                            linen.pop();
+                                            presv.pop();
+                                            value.pop();
+                                            return lines.pop();
+                                        }
+                                        token.push(lexer.join("").replace(/^(\s+)/, "").replace(/(\s+)$/, ""));
+                                        daddy.push(parent[parent.length - 1][0]);
+                                        begin.push(parent[parent.length - 1][1]);
+                                        stats.script[0] = stats.script[0] + 1;
+                                        stats.script[1] = stats.script[1] + token[token.length - 1].length;
+                                        if (typeof global.prettydiff.jspretty === "function") {
+                                            return types.push(name);
+                                        }
+                                        return types.push("content");
+                                    }
+                                }
+                                if (name === "style") {
+                                    if (a === c - 8) {
+                                        end = end.slice(0, end.length - 1);
+                                    } else if (a === c - 9) {
+                                        end = end.slice(0, end.length - 2);
+                                    } else {
+                                        end = end.slice(0, end.length - 3);
+                                    }
+                                    if (end === "</style") {
+                                        a   = a - 1;
+                                        ext = false;
+                                        if (lexer.length < 1) {
+                                            attrs.pop();
+                                            jscom.pop();
+                                            linen.pop();
+                                            presv.pop();
+                                            value.pop();
+                                            return lines.pop();
+                                        }
+                                        token.push(lexer.join("").replace(/^(\s+)/, "").replace(/(\s+)$/, ""));
+                                        daddy.push(parent[parent.length - 1][0]);
+                                        begin.push(parent[parent.length - 1][1]);
+                                        stats.style[0] = stats.style[0] + 1;
+                                        stats.style[1] = stats.style[1] + token[token.length - 1].length;
+                                        if (typeof global.prettydiff.csspretty === "function") {
+                                            return types.push(name);
+                                        }
+                                        return types.push("content");
+                                    }
+                                }
+                            } else if (quote === b[a] && (quote === "\"" || quote === "'" || quote === "`" || (quote === "*" && b[a + 1] === "/")) && esctest() === false) {
+                                quote = "";
+                            } else if (quote === "`" && b[a] === "$" && b[a + 1] === "{" && esctest() === false) {
+                                quote = "}";
+                            } else if (quote === "}" && b[a] === "}" && esctest() === false) {
+                                quote = "`";
+                            } else if (quote === "/" && (b[a] === "\n" || b[a] === "\r")) {
+                                quote = "";
+                            } else if (quote === "reg" && b[a] === "/" && esctest() === false) {
+                                quote = "";
+                            } else if (quote === "/" && b[a] === ">" && b[a - 1] === "-" && b[a - 2] === "-") {
+                                end = b
+                                    .slice(a + 1, a + 11)
+                                    .join("")
+                                    .toLowerCase();
+                                if (name === "cfscript" && end === "</cfscript") {
+                                    quote = "";
+                                }
+                                end = end.slice(0, end.length - 2);
+                                if (name === "script" && end === "</script") {
+                                    quote = "";
+                                }
+                                end = end.slice(0, end.length - 1);
+                                if (name === "style" && end === "</style") {
+                                    quote = "";
+                                }
+                            }
+                        }
+                        if (square === true && b[a] === "]") {
+                            a = a - 1;
+                            spacer();
+                            if (options.content === true) {
+                                token.push("text");
+                            } else if (options.textpreserve === true) {
+                                token.push(minspace + lexer.join(""));
+                                lines[lines.length - 1] = 0;
+                            } else if (linepreserve > 0) {
+                                token.push(minspace + lexer.join("").replace(/(\s+)$/, tailSpace));
+                                lines[lines.length - 1] = 0;
+                            } else {
+                                token.push(lexer.join("").replace(/(\s+)$/, tailSpace).replace(/\s+/g, " "));
+                            }
+                            stats.content[0] = stats.content[0] + 1;
+                            stats.content[1] = stats.content[1] + token[token.length - 1].length;
+                            daddy.push(parent[parent.length - 1][0]);
+                            begin.push(parent[parent.length - 1][1]);
+                            return types.push("content");
+                        }
+
+                        if (ext === false && lexer.length > 0 && ((b[a] === "<" && b[a + 1] !== "=" && (/\s|\d/).test(b[a + 1]) === false) || (b[a] === "[" && b[a + 1] === "%") || (b[a] === "{" && (options.jsx === true || options.dustjs === true || b[a + 1] === "{" || b[a + 1] === "%" || b[a + 1] === "@" || b[a + 1] === "#")))) {
+                            if (options.dustjs === true && b[a] === "{" && b[a + 1] === ":" && b[a + 2] === "e" && b[a + 3] === "l" && b[a + 4] === "s" && b[a + 5] === "e" && b[a + 6] === "}") {
+                                a = a + 6;
+                                if (options.content === true) {
+                                    token.push("text");
+                                } else if (options.textpreserve === true) {
+                                    token.push(minspace + lexer.join(""));
+                                    lines[lines.length - 1] = 0;
+                                } else {
+                                    token.push(lexer.join("").replace(/(\s+)$/, tailSpace).replace(/\s+/g, " "));
+                                }
+                                stats.content[0] = stats.content[0] + 1;
+                                stats.content[1] = stats.content[1] + token[token.length - 1].length;
+                                types.push("content");
+                                spacer();
+                                attrs.push({});
+                                jscom.push(false);
+                                linen.push(line);
+                                presv.push(false);
+                                token.push("{:else}");
+                                value.push("");
+                                stats.template[0] = stats.template[0] + 1;
+                                stats.template[1] = stats.template[1] + token[token.length - 1].length;
+                                daddy.push(parent[parent.length - 1][0]);
+                                begin.push(parent[parent.length - 1][1]);
+                                return types.push("template_else");
+                            }
+                            a = a - 1;
+                            if (options.content === true) {
+                                token.push("text");
+                            } else if (options.textpreserve === true) {
+                                token.push(minspace + lexer.join(""));
+                                lines[lines.length - 1] = 0;
+                            } else if (linepreserve > 0) {
+                                token.push(minspace + lexer.join("").replace(/(\s+)$/, tailSpace));
+                                lines[lines.length - 1] = 0;
+                            } else {
+                                token.push(lexer.join("").replace(/(\s+)$/, tailSpace).replace(/\s+/g, " "));
+                            }
+                            stats.content[0] = stats.content[0] + 1;
+                            stats.content[1] = stats.content[1] + token[token.length - 1].length;
+                            daddy.push(parent[parent.length - 1][0]);
+                            begin.push(parent[parent.length - 1][1]);
+                            return types.push("content");
+                        }
+                        lexer.push(b[a]);
+                    }
+                    spacer();
+                    if (options.content === true) {
+                        token.push("text");
+                    } else if (options.textpreserve === true) {
+                        token.push(minspace + lexer.join(""));
+                        lines[lines.length - 1] = 0;
+                    } else {
+                        token.push(lexer.join("").replace(/(\s+)$/, tailSpace));
+                    }
+                    stats.content[0] = stats.content[0] + 1;
+                    stats.content[1] = stats.content[1] + token[token.length - 1].length;
+                    daddy.push(parent[parent.length - 1][0]);
+                    begin.push(parent[parent.length - 1][1]);
+                    return types.push("content");
+                };
+
+            for (a = 0; a < c; a = a + 1) {
+                if ((/\s/).test(b[a]) === true) {
+                    space = space + b[a];
+                    if (b[a] === "\n") {
+                        line = line + 1;
+                    }
+                } else if (ext === true) {
+                    content();
+                } else if (b[a] === "<") {
+                    tag("");
+                } else if (b[a] === "[" && b[a + 1] === "%") {
+                    tag("%]");
+                } else if (b[a] === "{" && (options.jsx === true || options.dustjs === true || b[a + 1] === "{" || b[a + 1] === "%" || b[a + 1] === "@" || b[a + 1] === "#")) {
+                    tag("");
+                } else if (b[a] === "]" && sgmlflag > 0) {
+                    tag("]>");
+                } else if (b[a] === "-" && b[a + 1] === "-" && b[a + 2] === "-" && options.jekyll === true) {
+                    tag("---");
+                } else if (b[a] === "#" && options.apacheVelocity === true && (/\d/).test(b[a + 1]) === false && (/\s/).test(b[a + 1]) === false && ((/\w/).test(b[a + 1]) === true || b[a + 1] === "*" || b[a + 1] === "#" || (b[a + 1] === "[" && b[a + 2] === "["))) {
+                    tag("");
+                } else if (b[a] === "$" && options.apacheVelocity === true && (/\d/).test(b[a + 1]) === false && (/\s/).test(b[a + 1]) === false && b[a + 1] !== "$" && b[a + 1] !== "=" && b[a + 1] !== "[") {
+                    tag("");
+                } else {
+                    content();
+                }
+            }
+            lines[0] = 0;
+        }());
+
+        if (token.length === 0) {
+            if (options.nodeasync === true) {
+                return [options.source, "Error: source does not appear to be markup."];
+            }
+            if (global.prettydiff.meta === undefined) {
+                global.prettydiff.meta = {};
+            }
+            global.prettydiff.meta.error = "Error: source does not appear to be markup.";
+            return options.source;
+        }
+
+        globalerror = (function markuppretty__globalerror() {
+            var startend = stats.start[0] - stats.end[0],
+                error    = "";
+            if (startend > 0) {
+                error = startend + " more start tag";
+                if (startend > 1) {
+                    error = error + "s";
+                }
+                error = error + " than start tag";
+                if (startend > 1) {
+                    error = error + "s";
+                }
+                error = error + "!";
+                return error;
+            } else if (startend < 0) {
+                startend = startend * -1;
+                error    = startend + " more end tag";
+                if (startend > 1) {
+                    error = error + "s";
+                }
+                error = error + " than start tag";
+                if (startend > 1) {
+                    error = error + "s";
+                }
+                error = error + "!";
+                return error;
+            } else {
+                return "";
+            }
+        }());
+
+        if (options.nodeasync === false) {
+            if (global.prettydiff.meta === undefined) {
+                global.prettydiff.meta       = {};
+                global.prettydiff.meta.error = "";
+            }
+            if (global.prettydiff.meta.error === "") {
+                global.prettydiff.meta.error = globalerror;
+            }
+        }
+
+        if (options.mode === "parse") {
+            return (function markuppretty__parse() {
+                var a        = 0,
+                    c        = token.length,
+                    record   = [],
+                    wspace   = "",
+                    data     = {},
+                    def      = {
+                        attrs: "array - List of attributes (if any) for the given token.",
+                        begin: "number - Index where the parent element occurs.",
+                        daddy: "string - Tag name of the parent element. Tokens of type 'template_start' are n" +
+                                "ot considered as parent elements.  End tags reflect their matching start tag.",
+                        jscom: "boolean - Whether the token is a JavaScript comment if in JSX format.",
+                        linen: "number - The line number in the original source where the token started, which" +
+                                " is used for reporting and analysis.",
+                        lines: "number - Whether the token is preceeded any space and/or line breaks in the or" +
+                                "iginal code source.",
+                        presv: "boolean - Whether the token is preserved verbatim as found.  Useful for commen" +
+                                "ts and HTML 'pre' tags.",
+                        token: "string - The parsed code tokens.",
+                        types: "string - Data types of the tokens: cdata, comment, conditional, content, end, " +
+                                "ignore, linepreserve, script, sgml, singleton, start, template, template_else," +
+                                " template_end, template_start, xml",
+                        value: "string - The attribute's value if the current type is attribute"
+                    },
+                    //white space token to insertion logic
+                    insert   = function markuppretty__parse_insert(string) {
+                        if (types[a] === "content") {
+                            token[a] = string + token[a];
+                            return;
+                        }
+                        if (types[a - 1] === "content" && token[a] !== "content") {
+                            token[a - 1] = token[a - 1] + string;
+                            return;
+                        }
+                        attrs.splice(a, 0, {});
+                        begin.splice(a, 0, begin[a]);
+                        daddy.splice(a, 0, daddy[a]);
+                        jscom.splice(a, 0, false);
+                        linen.splice(a, 0, linen[a]);
+                        lines.splice(a, 0, 1);
+                        presv.splice(a, 0, false);
+                        token.splice(a, 0, string);
+                        types.splice(a, 0, "content");
+                        value.splice(a, 0, "");
+                        c = c + 1;
+                        a = a + 1;
+                    },
+                    attApply = function markuppretty__parse_attApply(atty) {
+                        var string = "",
+                            xlen   = atty.length,
+                            xind   = 0,
+                            toke   = token[a],
+                            atts   = "";
+                        for (xind = 0; xind < xlen; xind = xind + 1) {
+                            if (attrs[a][atty[xind]] === "") {
+                                atts = atts + " " + atty[xind];
+                            } else {
+                                atts = atts + " " + atty[xind] + "=" + attrs[a][atty[xind]];
+                            }
+                        }
+                        if (presv[a] === true) {
+                            token[a] = toke.replace(" ", atts);
+                        } else {
+                            string   = ((/(\/>)$/).test(toke) === true)
+                                ? "/>"
+                                : ">";
+                            xlen     = (string === "/>")
+                                ? 3
+                                : 2;
+                            token[a] = (toke.slice(0, toke.length - xlen) + atts + string);
+                        }
+                    };
+                if (options.attributetoken === true) {
+                    delete def.attrs;
+                } else {
+                    delete def.value;
+                }
+                for (a = 0; a < c; a = a + 1) {
+                    wspace = "";
+                    record = Object.keys(attrs[a]);
+                    if (record.length > 0 && options.unformatted === false) {
+                        attApply(record);
+                    }
+                    if (token[a] === "</prettydiffli>") {
+                        if (options.correct === true) {
+                            token[a] = "</li>";
+                        } else {
+                            attrs.splice(a, 1);
+                            begin.splice(a, 1);
+                            daddy.splice(a, 1);
+                            jscom.splice(a, 1);
+                            linen.splice(a, 1);
+                            lines.splice(a, 1);
+                            presv.splice(a, 1);
+                            token.splice(a, 1);
+                            types.splice(a, 1);
+                            value.splice(a, 1);
+                            a = a - 1;
+                            c = c - 1;
+                        }
+                    }
+                    if (options.parseFormat !== "htmltable") {
+                        if (types[a] === "script") {
+                            options.source = token[a];
+                            token[a]       = extlib("script");
+                        } else if (types[a] === "style") {
+                            options.source = token[a];
+                            token[a]       = extlib("style");
+                        }
+                    }
+                    if (options.parseSpace === true) {
+                        if (lines[a] > 1) {
+                            if (options.preserve > 1) {
+                                if (options.parseFormat === "htmltable") {
+                                    wspace = "(empty line)";
+                                } else {
+                                    wspace = lf + lf;
+                                }
+                            } else if (types[a] === "singleton" || types[a] === "content" || types[a] === "template") {
+                                wspace = " ";
+                            }
+                        } else if (lines[a] === 1) {
+                            if (types[a] === "singleton" || types[a] === "content" || types[a] === "template") {
+                                wspace = " ";
+                            } else if (types[a] !== types[a - 1] && (types[a - 1] === "singleton" || types[a - 1] === "content" || types[a - 1] === "template")) {
+                                wspace = " ";
+                            }
+                        }
+                        if (wspace !== "") {
+                            if (wspace === " " && options.parseFormat === "htmltable") {
+                                wspace = "(space)";
+                            }
+                            insert(wspace);
+                        }
+                    }
+                }
+                if (options.parseFormat === "sequential") {
+                    if (options.attributetoken === true) {
+                        def.order = "[token, types, value, lines, linen, jscom, presv, daddy, begin]";
+                    } else {
+                        def.order = "[token, types, attrs, lines, linen, jscom, presv, daddy, begin]";
+                    }
+                    for (a = 0; a < c; a = a + 1) {
+                        if (options.attributetoken === true) {
+                            record.push([
+                                token[a],
+                                types[a],
+                                value[a],
+                                lines[a],
+                                linen[a],
+                                jscom[a],
+                                presv[a],
+                                daddy[a],
+                                begin[a]
+                            ]);
+                        } else {
+                            record.push([
+                                token[a],
+                                types[a],
+                                attrs[a],
+                                lines[a],
+                                linen[a],
+                                jscom[a],
+                                presv[a],
+                                daddy[a],
+                                begin[a]
+                            ]);
+                        }
+                    }
+                    if (options.nodeasync === true) {
+                        return [
+                            {
+                                data      : record,
+                                definition: def
+                            },
+                            globalerror
+                        ];
+                    }
+                    return {data: record, definition: def};
+                }
+                if (options.parseFormat === "htmltable") {
+                    return (function markuppretty__parse_html() {
+                        var report = [],
+                            header = "<tr class=\"header\"><th>index</th><th>token</th><th>types</th>",
+                            aa     = 0,
+                            len    = 0;
+                        if (options.attributetoken === true) {
+                            header = header + "<th>value</th>";
+                        } else {
+                            header = header + "<th>attrs</th>";
+                        }
+                        header = header + "<th>linen</th><th>jscom</th><th>presv</th><th>daddy</th><th>" +
+                                "begin</th><th>lines</th></tr>";
+                        report.push("<table summary='markup parse table'><thead>");
+                        report.push(header);
+                        report.push("</thead><tbody>");
+                        len = token.length;
+                        for (aa = 0; aa < len; aa = aa + 1) {
+                            if (types[aa] === "script") {
+                                options.source = token[aa];
+                                report.push("<tr><td colspan=\"10\" class=\"nested\">");
+                                report.push(extlib("script"));
+                                report.push("</td></tr>");
+                                report.push("<tr><th colspan=\"10\" class=\"nested\">Markup tokens</th></tr>");
+                                report.push(header);
+                            } else if (types[aa] === "style") {
+                                options.source = token[aa];
+                                report.push("<tr><td colspan=\"10\" class=\"nested\">");
+                                report.push(extlib("style"));
+                                report.push("</td></tr>");
+                                report.push("<tr><th colspan=\"10\" class=\"nested\">Markup tokens</th></tr>");
+                                report.push(header);
+                            } else {
+                                report.push("<tr><td>");
+                                report.push(aa);
+                                report.push("</td><td style=\"white-space:pre\">");
+                                report.push(
+                                    token[aa].replace(/&/g, "&amp;").replace(/>/g, "&gt;").replace(/</g, "&lt;")
+                                );
+                                report.push("</td><td>");
+                                report.push(types[aa]);
+                                report.push("</td>");
+                                if (options.attributetoken === true) {
+                                    report.push("<td style=\"white-space:pre\">");
+                                    report.push(
+                                        value[aa].replace(/&/g, "&amp;").replace(/>/g, "&gt;").replace(/</g, "&lt;")
+                                    );
+                                    report.push("</td><td>");
+                                } else {
+                                    report.push("<td style=\"white-space:pre\">");
+                                    report.push(
+                                        JSON.stringify(attrs[aa]).replace(/&/g, "&amp;").replace(/>/g, "&gt;").replace(/</g, "&lt;")
+                                    );
+                                    report.push("</td><td>");
+                                }
+                                report.push(linen[aa]);
+                                report.push("</td><td>");
+                                report.push(jscom[aa]);
+                                report.push("</td><td>");
+                                report.push(presv[aa]);
+                                report.push("</td><td>");
+                                report.push(daddy[aa]);
+                                report.push("</td><td>");
+                                report.push(begin[aa]);
+                                report.push("</td><td>");
+                                report.push(lines[aa]);
+                                report.push("</td></tr>");
+                            }
+                        }
+                        report.push("</tbody></table>");
+                        if (options.nodeasync === true) {
+                            return [
+                                {
+                                    data      : report.join(""),
+                                    definition: def
+                                },
+                                globalerror
+                            ];
+                        }
+                        return {data: report.join(""), definition: def};
+                    }());
+                }
+                if (options.attributetoken === true) {
+                    data.value = value;
+                } else {
+                    data.attrs = attrs;
+                }
+                data.begin = begin;
+                data.daddy = daddy;
+                data.jscom = jscom;
+                data.linen = linen;
+                data.lines = lines;
+                data.presv = presv;
+                data.token = token;
+                data.types = types;
+                if (options.nodeasync === true) {
+                    return [
+                        {
+                            data      : data,
+                            definition: def
+                        },
+                        globalerror
+                    ];
+                }
+                return {data: data, definition: def};
+            }());
+        }
+
+        if (options.mode === "minify") {
+            (function markuppretty__minify() {
+                var a      = 0,
+                    c      = token.length,
+                    script = function markuppretty__minify_script() {
+                        options.source = token[a];
+                        token[a]       = extlib("script");
+                        level.push(-20);
+                    },
+                    style  = function markuppretty__minify_style() {
+                        options.source = token[a];
+                        token[a]       = extlib("style");
+                        level.push(-20);
+                    };
+                for (a = 0; a < c; a = a + 1) {
+                    if (types[a] === "script") {
+                        script();
+                    } else if (types[a] === "style") {
+                        style();
+                    } else if (lines[a] > 0) {
+                        if (types[a] === "singleton" || types[a] === "content" || types[a] === "template") {
+                            level.push(0);
+                        } else if (types[a - 1] === "singleton" || types[a - 1] === "content" || types[a] === "template") {
+                            level.push(0);
+                        } else {
+                            level.push(-20);
+                        }
+                    } else {
+                        level.push(-20);
+                    }
+                }
+            }());
+        }
+
+        output = (function markuppretty__beautify() {
+            var a            = 0,
+                c            = token.length,
+                lprescount   = [],
+                ltype        = "",
+                lline        = 0,
+                indent       = options.inlevel,
+                cdataS       = "",
+                cdataE       = "",
+                commentS     = "",
+                commentE     = "",
+                cdataStart   = (/^(\s*(\/)*<!?\[+[A-Z]+\[+)/),
+                cdataEnd     = (/((\/)*\]+>\s*)$/),
+                commentStart = (/^(\s*<!--)/),
+                commentEnd   = (/((\/\/)?-->\s*)$/),
+                tabs         = "",
+                twigStart    = (/^(\{%\s+)/),
+                twigEnd      = (/(\s%\})$/),
+                xslline      = function markuppretty__beautify_xslline() {
+                    var tname = false;
+                    if (lines[a] > 1 || (types[a] !== "start" && types[a] !== "singleton") || (types[a - 1] === "comment" && lines[a - 1] > 1)) {
+                        return;
+                    }
+                    tname = (tagName(token[a]).indexOf("xsl:") === 0);
+                    if (tname === false) {
+                        return;
+                    }
+                    if (types[a] === "start") {
+                        lines[a] = 2;
+                    } else if (types[a - 1] !== "start" || types[a + 1] !== "end" || (types[a - 1] !== "start" && types[a + 1] !== "end")) {
+                        lines[a] = 2;
+                    }
+                },
+                tab          = (function markuppretty__beautify_tab() {
+                    var b   = options.insize,
+                        ind = [];
+                    for (b = b; b > 0; b = b - 1) {
+                        ind.push(options.inchar);
+                    }
+                    return new RegExp("^(" + ind.join("") + "+)");
+                }()),
+                end          = function markuppretty__beautify_end() {
+                    var b = 0;
+                    indent = indent - 1;
+                    if ((types[a] === "end" && ltype === "start") || (types[a] === "template_end" && ltype === "template_start") || (options.jsx === true && (/^\s+\{/).test(token[a - 1]) === true && lines[a] === 0)) {
+                        return level.push(-20);
+                    }
+                    if (lines[a] < 1 && options.html === true && tagName(token[a - 1]) === "/span") {
+                        b = a;
+                        do {
+                            b = b - 1;
+                        } while (lines[b] < 1);
+                        if (types[b] === "content" || types[b] === "singleton" || types[b] === "start" || types[b] === "comment" || types[b].indexOf("template") > -1) {
+                            level[a - 1] = -20;
+                            return level.push(-20);
+                        }
+                    }
+                    if (options.force_indent === false) {
+                        if (lines[a] === 0 && (ltype === "singleton" || ltype === "content" || (ltype === "template" && types[a] !== "template_end"))) {
+                            return level.push(-20);
+                        }
+                        if (ltype === "comment") {
+                            for (b = a - 1; b > -1; b = b - 1) {
+                                if (types[b] !== "comment") {
+                                    if (lines[b + 1] === 0 && (types[b] === "singleton" || types[b] === "content" || ltype === "template")) {
+                                        for (b = b + 1; b < a; b = b + 1) {
+                                            level[b] = -20;
+                                        }
+                                        return level.push(-20);
+                                    }
+                                    return level.push(indent);
+                                }
+                            }
+                        }
+                        return level.push(indent);
+                    }
+                    level.push(indent);
+                },
+                content      = function markuppretty__beautify_content() {
+                    var b       = 0,
+                        spanfix = function markuppretty__beautify_content_spanfix() {
+                            b = b - 1;
+                            if (types[b] === "comment") {
+                                do {
+                                    b = b - 1;
+                                } while (b > 0 && types[b] === "comment" && lines[b] < 1);
+                            }
+                            if (lines[b] === 0 && tagName(token[b]) === "span" && (tagName(token[b - 1]) === "span" || tagName(token[b - 1]) === "/span")) {
+                                do {
+                                    level[b] = -20;
+                                    b        = b - 1;
+                                } while (
+                                    b > 0 && lines[b] < 1 && (tagName(token[b]) === "span" || types[b] === "comment")
+                                );
+                            }
+                        };
+                    if (lines[a] === 0 && options.force_indent === false && (presv[a] === false || types[a] !== "content")) {
+                        if (ltype === "comment" && lline === 0) {
+                            for (b = a - 1; b > -1; b = b - 1) {
+                                if (types[b - 1] !== "comment" && types[b] === "comment") {
+                                    if (lines[b] === 0) {
+                                        for (b = b; b < a; b = b + 1) {
+                                            level[b] = -20;
+                                        }
+                                        if (options.html === true && tagName(token[begin[a]]) === "span") {
+                                            spanfix();
+                                        }
+                                        return level.push(-20);
+                                    }
+                                    return level.push(indent);
+                                }
+                                if (lines[b] > 0) {
+                                    return level.push(indent);
+                                }
+                            }
+                            return level.push(indent);
+                        }
+                        level.push(-20);
+                        if (options.html === true && begin[a] > -1 && tagName(token[begin[a]]) === "span") {
+                            b = a;
+                            spanfix();
+                        }
+                    } else {
+                        level.push(indent);
+                    }
+                },
+                script       = function markuppretty__beautify_script(twig) {
+                    var list    = [],
+                        source  = "",
+                        twigfix = function markuppretty__beautify_script_twigfix(item) {
+                            var fixnumb = function markupretty__beautify_script_twigfix_fixnumb(xx) {
+                                return xx.replace(". .", "..");
+                            };
+                            item = item
+                                .replace(tab, "")
+                                .replace(/\)\s*and\s*\(/g, ") and (")
+                                .replace(/in\u0020?\(?\d+\.\u0020\.\d\(?/g, fixnumb);
+                            if (options.correct === true) {
+                                item = item.replace(/;$/, "") + " %}";
+                            } else {
+                                item = item + " %}";
+                            }
+                            return "{% " + item;
+                        },
+                        inle    = options.inlevel,
+                        mode    = options.mode;
+                    if (twig === true) {
+                        options.twig = true;
+                        token[a]     = token[a]
+                            .replace(twigStart, "")
+                            .replace(twigEnd, "");
+                    }
+                    stats.script[0] = stats.script[0] + 1;
+                    stats.script[1] = stats.script[1] + token[a]
+                        .replace(/\s+/g, " ")
+                        .length;
+                    if (cdataStart.test(token[a]) === true) {
+                        cdataS   = cdataStart
+                            .exec(token[a])[0]
+                            .replace(/^\s+/, "") + lf;
+                        token[a] = token[a].replace(cdataStart, "");
+                    } else if (commentStart.test(token[a]) === true) {
+                        commentS = commentStart
+                            .exec(token[a])[0]
+                            .replace(/^\s+/, "") + lf;
+                        token[a] = token[a].replace(commentStart, "");
+                    }
+                    if (cdataEnd.test(token[a]) === true) {
+                        cdataE   = cdataEnd.exec(token[a])[0];
+                        token[a] = token[a].replace(cdataEnd, "");
+                    } else if (commentEnd.test(token[a]) === true) {
+                        commentE = commentEnd.exec(token[a])[0];
+                        token[a] = token[a].replace(commentEnd, "");
+                    }
+                    source          = token[a].replace(/^(\s+)/, "");
+                    options.source  = source;
+                    options.inlevel = (options.style === "noinde")
+                        ? 0
+                        : indent;
+                    options.mode    = "beautify";
+                    token[a]        = extlib("script");
+                    options.inlevel = inle;
+                    options.mode    = mode;
+                    options.twig    = false;
+                    list            = tab.exec(token[a]);
+                    if (list !== null) {
+                        tabs = list[0];
+                    }
+                    if (cdataS !== "") {
+                        token[a] = tabs + cdataS + token[a];
+                        cdataS   = "";
+                    } else if (commentS !== "") {
+                        token[a] = tabs + commentS + token[a];
+                        commentS = "";
+                    }
+                    if (cdataE !== "") {
+                        token[a] = token[a] + lf + tabs + cdataE;
+                        cdataE   = "";
+                    } else if (commentE !== "") {
+                        token[a] = token[a] + lf + tabs + commentE;
+                        commentE = "";
+                    }
+                    if ((/^(\s+\{)/).test(token[a]) === true && options.jsx === true) {
+                        if (ltype === "content" || ltype === "singleton" || ltype === "template") {
+                            token[a] = token[a].replace(/^(\s+)/, "");
+                            if (lines[a] < 1) {
+                                level.push(-20);
+                            } else {
+                                level.push(-10);
+                            }
+                        } else {
+                            token[a] = token[a].replace(/^(\s+)/, "");
+                            if (lines[a] === 0) {
+                                level.push(-20);
+                            } else {
+                                level.push(indent);
+                                token[a] = token[a].replace(/(\r?\n\})$/, lf + tabs + "}");
+                            }
+                        }
+                        if (token[a].indexOf(";") < 0 && token[a].replace(/^(\{\s+)/, "").replace(/(\s+\})$/, "").indexOf("\n") < 0) {
+                            token[a] = token[a]
+                                .replace(/^(\{\s+)/, "{")
+                                .replace(/(\s+\})$/, "}");
+                        }
+                    } else if (twig === true) {
+                        token[a] = twigfix(token[a]);
+                    } else if (twig === true && lines[a] === 0) {
+                        level.push(-20);
+                        types[a] = "singleton";
+                    } else {
+                        level.push(0);
+                    }
+                },
+                style        = function markuppretty__beautify_style() {
+                    var list = [],
+                        inle = options.inlevel,
+                        mode = options.mode;
+                    stats.style[0] = stats.style[0] + 1;
+                    stats.style[1] = stats.style[1] + token[a]
+                        .replace(/\s+/g, " ")
+                        .length;
+                    if (cdataStart.test(token[a]) === true) {
+                        cdataS   = cdataStart
+                            .exec(token[a])[0]
+                            .replace(/^\s+/, "") + lf;
+                        token[a] = token[a].replace(cdataStart, "");
+                    } else if (commentStart.test(token[a]) === true) {
+                        commentS = commentStart
+                            .exec(token[a])[0]
+                            .replace(/^\s+/, "") + lf;
+                        token[a] = token[a].replace(commentStart, "");
+                    }
+                    if (cdataEnd.test(token[a]) === true) {
+                        cdataE   = cdataEnd.exec(token[a])[0];
+                        token[a] = token[a].replace(cdataEnd, "");
+                    } else if (commentEnd.test(token[a]) === true) {
+                        commentE = commentEnd.exec(token[a])[0];
+                        token[a] = token[a].replace(commentEnd, "");
+                    }
+                    options.inlevel = (options.style === "noindent")
+                        ? 0
+                        : indent;
+                    options.mode    = "beautify";
+                    options.source  = token[a].replace(/^(\s+)/, "");
+                    token[a]        = extlib("style");
+                    options.inlevel = inle;
+                    options.mode    = mode;
+                    list            = tab.exec(token[a]);
+                    if (list !== null) {
+                        tabs = list[0];
+                    }
+                    if (cdataS !== "") {
+                        token[a] = tabs + cdataS + token[a];
+                        cdataS   = "";
+                    } else if (commentS !== "") {
+                        token[a] = tabs + commentS + token[a];
+                        commentS = "";
+                    }
+                    if (cdataE !== "") {
+                        token[a] = token[a] + lf + tabs + cdataE;
+                        cdataE   = "";
+                    } else if (commentE !== "") {
+                        token[a] = token[a] + lf + tabs + commentE;
+                        commentE = "";
+                    }
+                    token[a] = token[a].replace(/(\s+)$/, "");
+                    level.push(0);
+                },
+                apply        = function markuppretty__beautify_apply() {
+                    var x            = 0,
+                        y            = level.length,
+                        build        = [],
+                        attrib       = [],
+                        //tab builds out the character sequence for one step of indentation
+                        ind          = (function markuppretty__beautify_apply_tab() {
+                            var aa   = 0,
+                                indy = [options.inchar],
+                                size = options.insize - 1;
+                            for (aa = 0; aa < size; aa = aa + 1) {
+                                indy.push(options.inchar);
+                            }
+                            return indy.join("");
+                        }()),
+                        // a new line character plus the correct amount of identation for the given line
+                        // of code
+                        nl           = function markuppretty__beautify_apply_nl(indy, item) {
+                            var aa          = 0,
+                                indentation = [lf];
+                            if (options.mode === "minify") {
+                                return build.push(lf);
+                            }
+                            if (indy === -10) {
+                                item.push(" ");
+                            } else if (indy > -9) {
+                                if (lines[x] > 1 && item === build) {
+                                    do {
+                                        lines[x] = lines[x] - 1;
+                                        indentation.push(lf);
+                                    } while (lines[x] > 1);
+                                }
+                                for (aa = 0; aa < indy; aa = aa + 1) {
+                                    indentation.push(ind);
+                                }
+                                item.push(indentation.join(""));
+                            }
+                        },
+                        // populates attributes onto start and singleton tags it also checks to see if a
+                        // tag or content should wrap
+                        wrapper      = function markuppretty__beautify_apply_wrapper() {
+                            var b      = 0,
+                                len    = 0,
+                                xlen   = 0,
+                                list   = attrib,
+                                lev    = level[x],
+                                atty   = "",
+                                string = "",
+                                indy   = "",
+                                name   = "",
+                                text   = [],
+                                tname  = tagName(token[x]);
+                            if (lev === -20) {
+                                b = x;
+                                do {
+                                    b    = b - 1;
+                                    lev  = level[b];
+                                    xlen = xlen + token[b].length;
+                                } while (lev === -20 && b > -1);
+                                if (lev === -20) {
+                                    lev = 1;
+                                }
+                            }
+                            if (lev === 0) {
+                                lev = lev + options.inlevel;
+                            }
+                            if (list.length > 0) {
+                                if (options.force_attribute === true) {
+                                    len = list.length;
+                                    text.push(list[0]);
+                                    if (len > 1) {
+                                        b = 1;
+                                        do {
+                                            nl(lev + 1, text);
+                                            text.push(list[b]);
+                                            b = b + 1;
+                                        } while (b < len);
+                                        b = 0;
+                                    }
+                                    atty = text.join("");
+                                    text = [];
+                                } else {
+                                    atty = list.join(" ");
+                                }
+                                if ((types[x] === "template_start" || types[x] === "template" || types[x] === "template_else") && options.jsx === false) {
+                                    len = list.length;
+                                    for (b = 0; b < len; b = b + 1) {
+                                        xlen = list[b].indexOf("{");
+                                        if (list[b].indexOf("}") > xlen && xlen > 0) {
+                                            options.source  = list[b].slice(xlen, list[b].indexOf("}") + 1);
+                                            options.inlevel = lev;
+                                            list[b]         = list[b].slice(0, xlen) + extlib("script").replace(/^(\s+)/, "") +
+                                                    list[b].slice(list[b].indexOf("}") + 1);
+                                        }
+                                    }
+                                }
+                                indy   = (function markuppretty__beautify_apply_wrapper_indy() {
+                                    var atline = lf,
+                                        atnum  = lev + 1;
+                                    do {
+                                        atline = atline + ind;
+                                        atnum  = atnum - 1;
+                                    } while (atnum > 0);
+                                    return atline;
+                                }());
+                                string = tagName(token[x]);
+                                len    = string.length + 3 + atty.length;
+                                if (token[x].charAt(token[x].length - 2) === "/") {
+                                    len = len + 1;
+                                }
+                                if (wrap === 0 || len <= wrap || tname === "cfset" || tname === "cfreturn" || tname === "cfif" || tname === "cfelseif") {
+                                    if (presv[x] === true) {
+                                        token[x] = token[x].replace(" ", " " + atty);
+                                    } else {
+                                        string = ((/(\/>)$/).test(token[x]) === true)
+                                            ? "/>"
+                                            : ">";
+                                        xlen   = (string === "/>")
+                                            ? 3
+                                            : 2;
+                                        name   = token[x].slice(1, token[x].length - xlen);
+                                        if (options.force_attribute === true) {
+                                            token[x] = "<" + name + indy + atty + string;
+                                        } else {
+                                            token[x] = "<" + name + " " + atty + string;
+                                        }
+                                    }
+                                    if (types[x] === "singleton" || types[x] === "template") {
+                                        if (options.spaceclose === true) {
+                                            token[x] = token[x].replace(/(\u0020*\/>)$/, " />");
+                                        } else {
+                                            token[x] = token[x].replace(/(\u0020*\/>)$/, "/>");
+                                        }
+                                    }
+                                    return;
+                                }
+                                text.push(token[x].slice(0, token[x].indexOf(" ")));
+                                len = list.length;
+                                for (b = 0; b < len; b = b + 1) {
+                                    nl(lev + 1, text);
+                                    text.push(list[b]);
+                                }
+                                text.push(token[x].slice(token[x].indexOf(" ") + 1));
+                                token[x] = text.join("");
+                                if (types[x] === "singleton" || types[x] === "template") {
+                                    if ((/(>\}+\/>)$/).test(token[x]) === true) {
+                                        b    = 0;
+                                        atty = lf;
+                                        if (lev > 1) {
+                                            do {
+                                                atty = atty + ind;
+                                                b    = b + 1;
+                                            } while (b < lev);
+                                            atty = atty + ind + "}" + atty + "/>";
+                                        } else {
+                                            atty = atty + "}/>";
+                                        }
+                                        token[x] = token[x].replace(/(\u0020*\}\u0020*\/>)$/, atty);
+                                    } else if (options.spaceclose === true) {
+                                        token[x] = token[x].replace(/(\u0020*\/>)$/, " />");
+                                    } else {
+                                        token[x] = token[x].replace(/(\u0020*\/>)$/, "/>");
+                                    }
+                                }
+                            } else {
+                                list = token[x]
+                                    .replace(/\s+/g, " ")
+                                    .split(" ");
+                                len  = list.length;
+                                if (level[x] === -20 && types[x - 1] === "end") {
+                                    b   = x - 1;
+                                    lev = 1;
+                                    do {
+                                        b = b - 1;
+                                        if (types[b] === "start") {
+                                            lev = lev - 1;
+                                        } else if (types[b] === "end") {
+                                            lev = lev + 1;
+                                        }
+                                    } while (lev > 0 && b > 0);
+                                    lev = level[b];
+                                }
+                                for (b = 0; b < len; b = b + 1) {
+                                    string = string + list[b];
+                                    if (list[b + 1] !== undefined && string.length + list[b + 1].length + 1 > wrap - xlen) {
+                                        text.push(string);
+                                        xlen = 0;
+                                        if (level[x] === -20 && types[x - 1] !== "end") {
+                                            nl(lev + 1, text);
+                                        } else {
+                                            nl(lev, text);
+                                        }
+                                        string = "";
+                                    } else {
+                                        string = string + " ";
+                                    }
+                                }
+                                text.push(string.replace(/\s$/, ""));
+                                token[x] = text.join("");
+                                if (types[x] === "singleton") {
+                                    if (options.spaceclose === true) {
+                                        token[x] = token[x].replace(/(\u0020*\/>)$/, " />");
+                                    } else {
+                                        token[x] = token[x].replace(/(\u0020*\/>)$/, "/>");
+                                    }
+                                }
+                            }
+                        },
+                        // JSX tags may contain comments, which are captured as attributes in this
+                        // parser.  These attributes demand unique care to be correctly applied.
+                        attrcom      = function markuppretty__beautify_apply_attrcom() {
+                            var toke  = token[x].split(" "),
+                                attr  = attrib,
+                                len   = attr.length,
+                                ilen  = 0,
+                                item  = [toke[0]],
+                                temp  = [],
+                                tempx = [],
+                                index = 0,
+                                b     = 0,
+                                xx    = 0,
+                                yy    = 0;
+                            nl(level[x], build);
+                            for (b = 0; b < len; b = b + 1) {
+                                index = attr[b].indexOf("\n");
+                                if (index > 0 && index !== attr[b].length - 1 && attr[b].indexOf("/*") === 0) {
+                                    temp = (lf === "\r\n")
+                                        ? attr[b].split("\r\n")
+                                        : attr[b].split("\n");
+                                    yy   = temp.length;
+                                    for (xx = 0; xx < yy; xx = xx + 1) {
+                                        if (temp[xx] === "") {
+                                            temp[xx] = lf;
+                                        } else {
+                                            nl(level[x] + 1, tempx);
+                                            tempx.push(temp[xx].replace(/^(\s+)/, ""));
+                                        }
+                                    }
+                                    tempx.push(lf);
+                                    attr[b] = tempx.join("");
+                                }
+                                if (b > 0 && attr[b - 1].charAt(attr[b - 1].length - 1) === "\n" && (/^(\s*\/\/)/).test(attr[b]) === false) {
+                                    nl(level[x] + 1, item);
+                                    ilen       = item.length - 1;
+                                    item[ilen] = item[ilen].slice(1);
+                                } else if ((/^\s/).test(attr[b]) === false && (/^(\s*\/\/)/).test(attr[b - 1]) === false) {
+                                    item.push(" ");
+                                }
+                                item.push(attr[b]);
+                            }
+                            if (attr[len - 1].charAt(attr[len - 1].length - 1) === "\n") {
+                                nl(level[x], item);
+                                ilen       = item.length - 1;
+                                item[ilen] = item[ilen].slice(1);
+                            }
+                            item.push(toke[1]);
+                            build.push(item.join(""));
+                        },
+                        jsxattribute = function markuppretty__beautify_apply_jsxattribute() {
+                            var attr     = Object.keys(attrs[x]),
+                                b        = 0,
+                                yy       = 0,
+                                xx       = attr.length,
+                                inlevel  = (level[x] < 1)
+                                    ? options.inlevel + 1
+                                    : level[x] + 1,
+                                builder  = "",
+                                inle     = options.inlevel,
+                                mode     = options.mode,
+                                vertical = options.vertical;
+                            for (b = 0; b < xx; b = b + 1) {
+                                if (attrs[x][attr[b]].charAt(0) === "{") {
+                                    options.mode      = "beautify";
+                                    options.inlevel   = inlevel;
+                                    options.source    = attrs[x][attr[b]].slice(1, attrs[x][attr[b]].length - 1);
+                                    options.vertical  = (
+                                        options.vertical === "jsonly" || options.vertical === true || options.vertical === "true"
+                                    );
+                                    attrs[x][attr[b]] = extlib("script");
+                                    options.mode      = mode;
+                                    options.inlevel   = inle;
+                                    options.vertical  = vertical;
+                                    attrib[b]         = attr[b] + "={" + attrs[x][attr[b]].replace(/^\s+/, "") + "}";
+                                } else if (attr[b].charAt(0) === "/" && attr[b].charAt(1) === "/" && attr[b].charAt(attr[b].length - 1) === "\n") {
+                                    builder = "";
+                                    yy      = inlevel;
+                                    do {
+                                        builder = builder + ind;
+                                        yy      = yy - 1;
+                                    } while (yy > 0);
+                                    if (b < attrib.length - 1) {
+                                        builder = lf + builder + attr[b].slice(0, attr[b].length - 1) + lf +
+                                                builder;
+                                    } else {
+                                        builder = lf + builder + attr[b].slice(0, attr[b].length - 1) + lf;
+                                    }
+                                    attrib[b] = builder;
+                                }
+                            }
+                        },
+                        linepreserve = function markuppretty__beautify_apply_linepreserve() {
+                            var str  = token[x]
+                                    .replace(/\r\n/g, "\n")
+                                    .replace(/^(\n)/, ""),
+                                item = str.split("\n"),
+                                aa   = 0,
+                                bb   = item.length,
+                                out  = [],
+                                taby = new RegExp("^(" + ind + "+)");
+                            lines[x] = 1;
+                            for (aa = 0; aa < bb; aa = aa + 1) {
+                                item[aa] = item[aa]
+                                    .replace(/^(\s+)/, "")
+                                    .replace(taby, "");
+                                if (item[aa] === "" && item[aa - 1] !== "" && aa < bb - 1) {
+                                    nl(0, out);
+                                } else if (item[aa] !== "") {
+                                    if (aa > 0) {
+                                        nl(level[x], out);
+                                    }
+                                    if (item[aa].indexOf(ind) === 0) {
+                                        do {
+                                            item[aa] = item[aa].slice(ind.length);
+                                        } while (item[aa].indexOf(ind) === 0);
+                                    }
+                                    out.push(item[aa].replace(/(\s+)$/, ""));
+                                }
+                            }
+                            if (out[out.length - 1] === "") {
+                                out.pop();
+                            }
+                            if (types[x + 1] === "template_end" && out[out.length - 1].indexOf(ind) > 0 && (/^(\s+)$/).test(out[out.length - 1]) === false) {
+                                out.pop();
+                            }
+                            token[x] = out.join("");
+                        },
+                        attArray     = function markuppretty__beautify_apply_attArray() {
+                            var list = Object.keys(attrs[x]),
+                                len  = list.length,
+                                b    = 0,
+                                attr = [];
+                            if (len < 1) {
+                                return [];
+                            }
+                            do {
+                                if (attrs[x][list[b]] === "") {
+                                    attr.push(list[b]);
+                                } else {
+                                    attr.push(list[b] + "=" + attrs[x][list[b]]);
+                                }
+                                b = b + 1;
+                            } while (b < len);
+                            return attr;
+                        };
+                    for (x = 0; x < y; x = x + 1) {
+                        attrib = attArray();
+                        if (options.jsx === true && attrib.length > 0) {
+                            jsxattribute();
+                        }
+                        if (jscom[x] === true) {
+                            attrcom();
+                        } else if (types[x] === "content" && x < y - 1) {
+                            if (presv[x] === true) {
+                                linepreserve();
+                            } else if (wrap > 0 && token[x].length > wrap && (options.mode === "beautify" || options.mode === "diff")) {
+                                wrapper();
+                            }
+                        } else if (types[x] !== "content" && options.unformatted === false && (options.mode === "beautify" || options.mode === "diff") && presv[x] === false && (attrib.length > 0 || (wrap > 0 && token[x].length > wrap)) && (types[x] === "content" || types[x] === "start" || types[x] === "singleton" || types[x] === "template_start" || types[x] === "template" || types[x] === "comment") && (types[x] !== "singleton" || token[x].charAt(0) !== "{")) {
+                            wrapper();
+                        } else if (options.unformatted === false && attrib.length > 0) {
+                            token[x] = token[x].replace(" ", " " + attrib.join(" "));
+                        } else if (types[x] === "singleton") {
+                            if (options.spaceclose === true) {
+                                token[x] = token[x].replace(/(\u0020*\/>)$/, " />");
+                            } else {
+                                token[x] = token[x].replace(/(\u0020*\/>)$/, "/>");
+                            }
+                        }
+                        if (token[x] === "</prettydiffli>" && options.correct === true) {
+                            token[x] = "</li>";
+                        }
+                        if (token[x] !== "</prettydiffli>" && jscom[x] === false) {
+                            if ((types[x] === "template" || types[x] === "template_start") && types[x - 1] === "content" && presv[x - 1] === true && options.mode === "beautify" && level[x] === -20) {
+                                build.push(" ");
+                            }
+                            if (level[x] > -9) {
+                                if (options.mode === "minify") {
+                                    build.push(" ");
+                                } else {
+                                    nl(level[x], build);
+                                }
+                            } else if (level[x] === -10) {
+                                build.push(" ");
+                            }
+                            build.push(token[x]);
+                        }
+                    }
+                    if (build[0] === lf || build[0] === " ") {
+                        build[0] = "";
+                    }
+                    if (options.newline === true) {
+                        if (options.crlf === true) {
+                            build.push("\r\n");
+                        } else {
+                            build.push("\n");
+                        }
+                    }
+                    if (options.nodeasync === true) {
+                        return [build.join(""), globalerror];
+                    }
+                    return build.join("");
+                };
+
+            if (options.mode !== "minify") {
+                for (a = 0; a < c; a = a + 1) {
+                    if (twigStart.test(token[a]) === true && twigEnd.test(token[a]) === true && (a === 0 || (tagName(token[a - 1]) !== "script" && tagName(token[a - 1]) !== "style")) && (/\D-+\D/).test(token[a]) === false && (/^(\{%\s*((comment)|(else))\s*)/).test(token[a]) === false) {
+                        script(true);
+                    }
+                    if (types[a] === "start") {
+                        level.push(indent);
+                        indent = indent + 1;
+                        xslline();
+                    } else if (types[a] === "template_start" || types[a] === "linepreserve") {
+                        if (types[a] === "linepreserve") {
+                            lprescount.push(tagName(token[a]));
+                        }
+                        level.push(indent);
+                        indent = indent + 1;
+                    } else if (types[a] === "template_else") {
+                        level.push(indent - 1);
+                    } else if (types[a] === "end") {
+                        end();
+                    } else if (types[a] === "template_end") {
+                        if (lprescount.length > 0 && tagName(token[a]) === "/" + lprescount[lprescount.length - 1]) {
+                            lprescount.pop();
+                        }
+                        end();
+                    } else if (lines[a] === 0 && (types[a] === "singleton" || types[a] === "content" || types[a] === "template")) {
+                        if (types[a] === "content" && options.textpreserve === true) {
+                            level.push(-20);
+                        } else {
+                            content();
+                        }
+                        xslline();
+                    } else if (types[a] === "script" || types[a] === "cfscript") {
+                        script(false);
+                    } else if (types[a] === "style") {
+                        style();
+                    } else if (types[a] === "comment" && options.comments === "noindent") {
+                        level.push(0);
+                    } else if (types[a] === "linepreserve") {
+                        level.push(indent);
+                    } else {
+                        level.push(indent);
+                        xslline();
+                    }
+                    if (types[a] !== "content" && types[a] !== "comment" && types[a - 1] === "content" && types[a - 2] !== "linepreserve" && lprescount.length > 0) {
+                        level[a] = -20;
+                    }
+                    if (lines[a] === 0 && (ltype === "content" || (ltype === "script" && token[a - 1].charAt(0) === "{" && options.jsx === true))) {
+                        level[a] = -20;
+                    }
+                    ltype = types[a];
+                    lline = lines[a];
+                }
+            }
+            level[0] = 0;
+            return apply();
+        }());
+
+        if (options.mode === "analysis") {
+            options.accessibility = true;
+            return (function markuppretty__beautify_apply_summary() {
+                var len           = token.length,
+                    sum           = [],
+                    data          = {
+                        violations: 0
+                    },
+                    numformat     = function markuppretty__beautify_apply_summary_numformat(x) {
+                        var y    = String(x).split(""),
+                            z    = 0,
+                            xlen = y.length,
+                            dif  = 0;
+                        if (xlen % 3 === 2) {
+                            dif = 2;
+                        } else if (xlen % 3 === 1) {
+                            dif = 1;
+                        }
+                        for (z = xlen - 1; z > 0; z = z - 1) {
+                            if ((z % 3) - dif === 0) {
+                                y[z] = "," + y[z];
+                            }
+                        }
+                        return y.join("");
+                    },
+                    analysis      = function markuppretty__beautify_apply_summary_analysis(arr) {
+                        var x       = arr.length,
+                            idtest  = (arr === ids),
+                            y       = 0,
+                            adata   = [],
+                            content = [];
+                        if (x > 0) {
+                            arr = safeSort(arr);
+                            for (y = 0; y < x; y = y + 1) {
+                                if (arr[y] === arr[y + 1]) {
+                                    if (idtest === true && (adata.length === 0 || adata[adata.length - 1][1] !== arr[y])) {
+                                        adata.push([
+                                            2, arr[y]
+                                        ]);
+                                    }
+                                    if (adata.length > 0) {
+                                        adata[adata.length - 1][0] = adata[adata.length - 1][0] + 1;
+                                    }
+                                } else if (idtest === false) {
+                                    adata.push([
+                                        1, arr[y]
+                                    ]);
+                                }
+                            }
+                            x = adata.length;
+                            if (idtest === true) {
+                                if (x === 0) {
+                                    return "";
+                                }
+                                content.push("<h4>Duplicate id attribute values</h4>");
+                            } else {
+                                content.push("<h4>HTTP requests:</h4>");
+                            }
+                            content.push("<ul>");
+                            for (y = 0; y < x; y = y + 1) {
+                                if (idtest === true && adata[y][0] > 1) {
+                                    data.violations = data.violations + (adata[y][0] - 1);
+                                }
+                                content.push("<li>");
+                                content.push(adata[y][0]);
+                                content.push("x - ");
+                                content.push(adata[y][1].replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(
+                                    />/g,
+                                    "&gt;"
+                                ));
+                                content.push("</li>");
+                            }
+                            content.push("</ul>");
+                            return content.join("");
+                        }
+                        return "";
+                    },
+                    accessibility = (
+                        function markuppretty__beautify_apply_summary_accessibility() {
+                            var findings   = [],
+                                tagsbyname = function markuppretty__beautify_apply_summary_accessibility_tagsbyname() {
+                                    var b            = 0,
+                                        c            = 0,
+                                        x            = 0,
+                                        y            = 0,
+                                        z            = 0,
+                                        tagname      = "",
+                                        tabindex     = "",
+                                        alttest      = false,
+                                        id           = false,
+                                        fortest      = false,
+                                        hidden       = false,
+                                        html         = false,
+                                        headtest     = (/^(h\d)$/),
+                                        obsoleteAttr = [
+                                            "alink",
+                                            "align",
+                                            "background",
+                                            "border",
+                                            "color",
+                                            "compact",
+                                            "face",
+                                            "height",
+                                            "language",
+                                            "link",
+                                            "nowrap",
+                                            "size",
+                                            "start",
+                                            "text",
+                                            "version",
+                                            "vlink",
+                                            "width"
+                                        ],
+                                        attr         = [],
+                                        formID       = [],
+                                        labelFor     = [],
+                                        nofor        = [],
+                                        namestack    = [];
+
+                                    // badnest - checks for improperly orderd tags [tagname, start index, end index]
+                                    data.badnest      = [];
+                                    // obsoleteTags - checks for obsolete or presentation only tag names of start
+                                    // and singleton tags token index
+                                    data.obsoleteTags = [];
+                                    // obsoleteAttr - checks for obsolete or presentation attribute names [token
+                                    // index, attr index]
+                                    data.obsoleteAttr = [];
+                                    // headings - stores heading tag data [token index, number from tag name, if
+                                    // violation]
+                                    data.headings     = [];
+                                    // emptyalt - if an img tag contains an alt attribute with no values token index
+                                    data.emptyalt     = [];
+                                    //noalt - if an img tag does not contain an alt attribute token index
+                                    data.noalt        = [];
+                                    //formNoId - if a form control is missing an id attribute token index
+                                    data.formNoId     = [];
+                                    // formNoLabel - if a form control is missing a binding to a label [token index,
+                                    // id attr index]
+                                    data.formNoLabel  = [];
+                                    // tabindex - identifies elements with a tabindex attribute [token index, if
+                                    // value is greater than 0]
+                                    data.tabindex     = [];
+                                    // htmllang - if there is an <html> tag does it contain a lang or xml:lang
+                                    // attribute? boolean
+                                    data.htmllang     = false;
+
+                                    c                 = token.length;
+                                    for (b = 0; b < c; b = b + 1) {
+                                        hidden  = false;
+                                        tagname = tagName(token[b]);
+                                        if ((types[b] === "start" || types[b] === "singleton") && (tagname === "font" || tagname === "center" || tagname === "basefont" || tagname === "b" || tagname === "i" || tagname === "u" || tagname === "small" || tagname === "big" || tagname === "blink" || tagname === "plaintext" || tagname === "spacer" || tagname === "strike" || tagname === "tt" || tagname === "xmp")) {
+                                            data
+                                                .obsoleteTags
+                                                .push(b);
+                                        } else {
+                                            if (types[b] === "start" && headtest.test(tagname) === true) {
+                                                z = Number(tagname.charAt(1));
+                                                if (data.headings.length > 0 && z - data.headings[data.headings.length - 1][1] > 1) {
+                                                    data.violations = data.violations + 1;
+                                                    data
+                                                        .headings
+                                                        .push([b, z, true]);
+                                                } else {
+                                                    data
+                                                        .headings
+                                                        .push([b, z, false]);
+                                                }
+                                            }
+                                            if (attrs[b].alt !== undefined && tagname === "img") {
+                                                alttest = true;
+                                                if (attrs[b].alt === "") {
+                                                    data
+                                                        .emptyalt
+                                                        .push(b);
+                                                }
+                                            }
+                                            if (attrs[b].for !== undefined && tagname === "label") {
+                                                labelFor.push(attrs[b].for);
+                                                fortest = true;
+                                            }
+                                            if (tagname === "select" || tagname === "input" || tagname === "textarea") {
+                                                if (typeof attrs[b].id === "string" || (tagname === "input" && typeof attrs[b].type === "string" && (attrs[b].type.toLowerCase() === "hidden" || attrs[b].type.toLowerCase() === "submit"))) {
+                                                    id = true;
+                                                    if (tagname === "input" && attrs[b].type === "hidden") {
+                                                        hidden = true;
+                                                    }
+                                                    if (typeof attrs[b].id === "string") {
+                                                        formID.push(b);
+                                                    }
+                                                } else {
+                                                    z = namestack.length;
+                                                    if (z > 0) {
+                                                        do {
+                                                            z = z - 1;
+                                                        } while (z > 0 && namestack[z][0] === "span");
+                                                        if (namestack[z][0] === "label") {
+                                                            hidden = true;
+                                                        }
+                                                    }
+                                                }
+                                            } else if (tagname === "html") {
+                                                html = true;
+                                                if (typeof attrs[b].lang === "string" || typeof attrs[b]["xml:lang"] === "string") {
+                                                    data.htmllang = true;
+                                                }
+                                            }
+                                            if (data.obsoleteTags[data.obsoleteTags.length - 1] !== b) {
+                                                if (typeof attrs[b].name === "string" && tagname !== "meta" && tagname !== "iframe" && tagname !== "select" && tagname !== "input" && tagname !== "textarea") {
+                                                    data
+                                                        .obsoleteAttr
+                                                        .push([b, "name"]);
+                                                }
+                                                if (typeof attrs[b].type === "string" && tagname !== "script" && tagname !== "style" && tagname !== "input" && tagname !== "button" && tagname !== "link") {
+                                                    data
+                                                        .obsoleteAttr
+                                                        .push([b, "type"]);
+                                                }
+                                                if (typeof attrs[b].value === "string" && tagname !== "input" && tagname !== "option" && tagname !== "textarea" && tagname !== "button") {
+                                                    data
+                                                        .obsoleteAttr
+                                                        .push([b, "value"]);
+                                                }
+                                                z = obsoleteAttr.length;
+                                                for (y = 0; y < z; y = y + 1) {
+                                                    if (typeof attrs[b][obsoleteAttr[y]] === "string") {
+                                                        data
+                                                            .obsoleteAttr
+                                                            .push([
+                                                                b, obsoleteAttr[y]
+                                                            ]);
+                                                    }
+                                                }
+                                            }
+                                            if (typeof attrs[b].tabindex === "string") {
+                                                tabindex = attrs[b]
+                                                    .tabindex
+                                                    .slice(1, attrs[b].tabindex.length - 1);
+                                                if (isNaN(tabindex) === true || Number(tabindex) > 0) {
+                                                    data
+                                                        .tabindex
+                                                        .push([b, true]);
+                                                    data.violations = data.violations + 1;
+                                                } else {
+                                                    data
+                                                        .tabindex
+                                                        .push([b, false]);
+                                                }
+                                            }
+                                            if (fortest === true) {
+                                                fortest = false;
+                                            } else if (tagname === "label") {
+                                                nofor.push(b);
+                                            }
+                                            if (id === true) {
+                                                id = false;
+                                            } else if (hidden === false && (tagname === "select" || tagname === "input" || tagname === "textarea")) {
+                                                data
+                                                    .formNoId
+                                                    .push(b);
+                                            }
+                                            if (alttest === true) {
+                                                alttest = false;
+                                            } else if (tagname === "img") {
+                                                data
+                                                    .noalt
+                                                    .push(b);
+                                            }
+                                        }
+                                        if (types[b] === "start" || types[b] === "template_start") {
+                                            namestack.push([tagname, b]);
+                                        } else if (types[b] === "end" || types[b] === "template_end") {
+                                            if (namestack.length > 0 && tagname !== "/" + namestack[namestack.length - 1][0]) {
+                                                namestack[namestack.length - 1].push(b);
+                                                data
+                                                    .badnest
+                                                    .push(namestack[namestack.length - 1]);
+                                            }
+                                            namestack.pop();
+                                        }
+                                    }
+                                    attr = [];
+                                    if (html === false) {
+                                        data.htmllang = true;
+                                    }
+                                    attr.push("<div id='a11y'>");
+                                    //missing lang attribute
+                                    attr.push("<div>");
+                                    if (data.htmllang === false) {
+                                        data.violations = data.violations + 1;
+                                        attr.push(
+                                            "<h4>HTML tag is a <strong>missing</strong> lang or xml:lang attribute</h4>"
+                                        );
+                                    } else {
+                                        attr.push("<h4>HTML lang or xml:lang attribute is present</h4>");
+                                    }
+                                    attr.push(
+                                        "<p>The lang attribute ensures the natural language is properly understood by a" +
+                                        "ssisting applications.</p>"
+                                    );
+                                    attr.push("</div><div>");
+                                    //improperly nested tags
+                                    b               = data.badnest.length;
+                                    data.violations = data.violations + b;
+                                    if (b > 0) {
+                                        attr.push("<h4><strong>");
+                                        attr.push(b);
+                                        attr.push("</strong> improperly nested tag");
+                                        if (b > 1) {
+                                            attr.push("s");
+                                        }
+                                        attr.push(
+                                            "</h4> <p>Improperly nested tags produce unexpected behaviors.</p> <ol>"
+                                        );
+                                        for (x = 0; x < b; x = x + 1) {
+                                            attr.push("<li><code>");
+                                            attr.push(
+                                                token[data.badnest[x][2]].replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+                                            );
+                                            attr.push("</code> on input line number ");
+                                            attr.push(linen[data.badnest[x][2]]);
+                                            attr.push(" does not match start tag <code>");
+                                            attr.push(
+                                                token[data.badnest[x][1]].replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+                                            );
+                                            attr.push("</code> from input line number ");
+                                            attr.push(linen[data.badnest[x][1]]);
+                                            attr.push("</li>");
+                                        }
+                                        attr.push("</ol>");
+                                    } else {
+                                        attr.push("<h4><strong>0</strong> improperly nested tags</h4>");
+                                        attr.push("<p>Improperly nested tags produce unexpected behaviors.</p>");
+                                    }
+                                    attr.push("</div><div>");
+                                    //obsolete tags
+                                    b               = data.obsoleteTags.length;
+                                    data.violations = data.violations + b;
+                                    if (b > 0) {
+                                        attr.push("<h4><strong>");
+                                        attr.push(b);
+                                        attr.push("</strong> obsolete HTML tag");
+                                        if (b > 1) {
+                                            attr.push("s");
+                                        }
+                                        attr.push(
+                                            "</h4> <p>Obsolete elements do not appropriately describe content.</p> <ol>"
+                                        );
+                                        for (x = 0; x < b; x = x + 1) {
+                                            attr.push("<li><code>");
+                                            attr.push(
+                                                token[data.obsoleteTags[x]].replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+                                            );
+                                            attr.push("</code> on input line number ");
+                                            attr.push(linen[data.obsoleteTags[x]]);
+                                            attr.push("</li>");
+                                        }
+                                        attr.push("</ol>");
+                                    } else {
+                                        attr.push("<h4><strong>0</strong> obsolete HTML tags</h4>");
+                                        attr.push("<p>Obsolete elements do not appropriately describe content.</p>");
+                                    }
+                                    attr.push("</div><div>");
+                                    //obsolete attributes
+                                    b = data.obsoleteAttr.length;
+                                    if (b > 0) {
+                                        z = 0;
+                                        attr.push("<h4><strong>");
+                                        y = attr.length;
+                                        attr.push("</strong> HTML tag");
+                                        if (b > 1) {
+                                            attr.push("s");
+                                        }
+                                        attr.push(
+                                            " containing obsolete or inappropriate attributes</h4> <p>Obsolete attributes d" +
+                                            "o not appropriately describe content.</p> <ol>"
+                                        );
+                                        for (x = 0; x < b; x = x + 1) {
+                                            tagname = token[data.obsoleteAttr[x][0]]
+                                                .replace(/&/g, "&amp;")
+                                                .replace(/</g, "&lt;")
+                                                .replace(/>/g, "&gt;")
+                                                .replace(
+                                                    attrs[data.obsoleteAttr[x][0]][data.obsoleteAttr[x][1]],
+                                                    "<strong>" + attrs[data.obsoleteAttr[x][0]][data.obsoleteAttr[x][1]] + "</stron" +
+                                                            "g>"
+                                                );
+                                            if (x < b - 1 && data.obsoleteAttr[x][0] === data.obsoleteAttr[x + 1][0]) {
+                                                do {
+                                                    tagname = tagname.replace(
+                                                        attrs[data.obsoleteAttr[x][0]][data.obsoleteAttr[x + 1][1]],
+                                                        "<strong>" + attrs[data.obsoleteAttr[x][0]][data.obsoleteAttr[x + 1][1]] + "</s" +
+                                                                "trong>"
+                                                    );
+                                                    x       = x + 1;
+                                                } while (x < b - 1 && data.obsoleteAttr[x][0] === data.obsoleteAttr[x + 1][0]);
+                                            }
+                                            z = z + 1;
+                                            attr.push("<li><code>");
+                                            attr.push(tagname);
+                                            attr.push("</code> on input line number ");
+                                            attr.push(linen[data.obsoleteAttr[x][0]]);
+                                            attr.push("</li>");
+                                        }
+                                        attr.splice(y, 0, z);
+                                        data.violations = data.violations + z;
+                                        attr.push("</ol>");
+                                    } else {
+                                        attr.push(
+                                            "<h4><strong>0</strong> HTML tags containing obsolete or inappropriate attribut" +
+                                            "es</h4>"
+                                        );
+                                        attr.push("<p>Obsolete attributes do not appropriately describe content.</p>");
+                                    }
+                                    attr.push("</div><div>");
+                                    //form controls missing a required 'id' attribute
+                                    b               = data.formNoId.length;
+                                    data.violations = data.violations + b;
+                                    if (b > 0) {
+                                        attr.push("<h4><strong>");
+                                        attr.push(b);
+                                        attr.push("</strong> form control element");
+                                        if (b > 1) {
+                                            attr.push("s");
+                                        }
+                                        attr.push(
+                                            " missing a required <em>id</em> attribute</h4> <p>The id attribute is required" +
+                                            " to bind a point of interaction to an HTML label.</p> <ol>"
+                                        );
+                                        for (x = 0; x < b; x = x + 1) {
+                                            attr.push("<li><code>");
+                                            attr.push(
+                                                token[data.formNoId[x]].replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+                                            );
+                                            attr.push("</code> on input line number ");
+                                            attr.push(linen[data.formNoId[x]]);
+                                            attr.push("</li>");
+                                        }
+                                        attr.push("</ol>");
+                                    } else {
+                                        attr.push(
+                                            "<h4><strong>0</strong> form control elements missing a required <em>id</em> at" +
+                                            "tribute</h4> <p>The id attribute is required to bind a point of interaction to" +
+                                            " an HTML label.</p>"
+                                        );
+                                    }
+                                    attr.push("</div><div>");
+                                    //form controls missing a binding to a label
+                                    b                = formID.length;
+                                    data.formNoLabel = [];
+                                    for (x = 0; x < b; x = x + 1) {
+                                        for (y = labelFor.length - 1; y > -1; y = y - 1) {
+                                            if (attrs[formID[x]].id === labelFor[y]) {
+                                                break;
+                                            }
+                                        }
+                                        if (y < 0) {
+                                            data
+                                                .formNoLabel
+                                                .push(formID[x]);
+                                        }
+                                    }
+                                    b               = data.formNoLabel.length;
+                                    data.violations = data.violations + b;
+                                    if (b > 0) {
+                                        attr.push("<h4><strong>");
+                                        attr.push(b);
+                                        attr.push("</strong> form control element");
+                                        if (b > 1) {
+                                            attr.push("s");
+                                        }
+                                        attr.push(
+                                            " not bound to a label</h4> <p>The <em>id</em> of a form control must match the" +
+                                            " <em>for</em> of a label.</p><ol>"
+                                        );
+                                        for (x = 0; x < b; x = x + 1) {
+                                            attr.push("<li><code>");
+                                            attr.push(
+                                                token[data.formNoLabel[x][0]].replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+                                            );
+                                            attr.push("</code> on input line number ");
+                                            attr.push(linen[data.formNoLabel[x][0]]);
+                                            attr.push("</li>");
+                                        }
+                                        attr.push("</ol>");
+                                    } else {
+                                        attr.push(
+                                            "<h4><strong>0</strong> form control elements not bound to a label</h4> <p>The " +
+                                            "<em>id</em> of a form control must match the <em>for</em> of a label.</p>"
+                                        );
+                                    }
+                                    attr.push("</div><div>");
+                                    //elements with tabindex
+                                    b = data.tabindex.length;
+                                    if (b > 0) {
+                                        attr.push("<h4><strong>");
+                                        y = attr.length;
+                                        z = 0;
+                                        attr.push(0);
+                                        attr.push("</strong> <em>tabindex</em>");
+                                        attr.push(" violation");
+                                        attr.push(
+                                            "</h4> <p>The tabindex attribute should have a 0 or -1 value and should not be " +
+                                            "over used. Only tabindexes with a value greater than 0 are counted as violatio" +
+                                            "ns, but every element with a tabindex attribute is listed to quickly indicate " +
+                                            "if it used excessively.</p> <ol>"
+                                        );
+                                        for (x = 0; x < b; x = x + 1) {
+                                            attr.push("<li><code>");
+                                            if (data.tabindex[x][1] === true) {
+                                                attr.push("<strong>");
+                                                z = z + 1;
+                                            }
+                                            attr.push(
+                                                token[data.tabindex[x][0]].replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+                                            );
+                                            if (data.tabindex[x][1] === true) {
+                                                attr.push("</strong>");
+                                            }
+                                            attr.push("</code> on input line number ");
+                                            attr.push(linen[data.tabindex[x][0]]);
+                                            attr.push("</li>");
+                                        }
+                                        attr[y] = z;
+                                        if (z !== 1) {
+                                            attr[y + 2] = attr[y + 2] + "s";
+                                        }
+                                        attr.push("</ol>");
+                                    } else {
+                                        attr.push(
+                                            "<h4><strong>0</strong> elements with a <em>tabindex</em> attribute</h4> <p>The" +
+                                            " tabindex attribute should have a 0 or -1 value and should not be over used.</" +
+                                            "p>"
+                                        );
+                                    }
+                                    attr.push("</div><div>");
+                                    //headings
+                                    b = data.headings.length;
+                                    if (b > 0) {
+                                        attr.push("<h4><strong>");
+                                        attr.push(b);
+                                        attr.push("</strong> HTML heading tag");
+                                        if (b > 1) {
+                                            attr.push("s");
+                                        }
+                                        attr.push(
+                                            " and their order</h4> <p>Poorly ordered tags are described with a <strong>stro" +
+                                            "ng</strong> tag (color red).</p> <ol>"
+                                        );
+                                        for (x = 0; x < b; x = x + 1) {
+                                            attr.push("<li><code>");
+                                            if (data.headings[x][2] === true) {
+                                                attr.push("<strong>");
+                                            }
+                                            attr.push(
+                                                token[data.headings[x][0]].replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+                                            );
+                                            if (data.headings[x][2] === true) {
+                                                attr.push("</strong>");
+                                            }
+                                            attr.push("</code> on input line number ");
+                                            attr.push(linen[data.headings[x][0]]);
+                                            attr.push("</li>");
+                                        }
+                                        attr.push("</ol>");
+                                    } else {
+                                        attr.push("<h4><strong>0</strong> HTML heading elements</h4>");
+                                        attr.push(
+                                            "<p>When heading tags are present it is important they are properly ordered so " +
+                                            "that the content they describe can be navigated in the proper order.</p>"
+                                        );
+                                    }
+                                    attr.push("</div><div>");
+                                    //missing alt attributes on images
+                                    b               = data.noalt.length;
+                                    data.violations = data.violations + b;
+                                    if (b > 0) {
+                                        attr.push("<h4><strong>");
+                                        attr.push(b);
+                                        attr.push("</strong> image");
+                                        if (b > 1) {
+                                            attr.push("s");
+                                        }
+                                        attr.push(
+                                            " missing a required <em>alt</em> attribute</h4> <p>The alt attribute is requir" +
+                                            "ed even if it contains no value.</p> <ol>"
+                                        );
+                                        for (x = 0; x < b; x = x + 1) {
+                                            attr.push("<li><code>");
+                                            attr.push(
+                                                token[data.noalt[x]].replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+                                            );
+                                            attr.push("</code> on input line number ");
+                                            attr.push(linen[data.noalt[x]]);
+                                            attr.push("</li>");
+                                        }
+                                        attr.push("</ol>");
+                                    } else {
+                                        attr.push(
+                                            "<h4><strong>0</strong> images missing a required <em>alt</em> attribute</h4> <" +
+                                            "p>The alt attribute is required even if it contains no value.</p>"
+                                        );
+                                    }
+                                    attr.push("</div><div>");
+                                    //alt attributes with empty values
+                                    b               = data.emptyalt.length;
+                                    data.violations = data.violations + b;
+                                    if (b > 0) {
+                                        attr.push("<h4><strong>");
+                                        attr.push(b);
+                                        attr.push("</strong> image");
+                                        if (b > 1) {
+                                            attr.push("s");
+                                        }
+                                        attr.push(
+                                            " have an empty <em>alt</em> attribute value</h4> <p>Empty alt text is not nece" +
+                                            "ssarily a violation, such as the case of tracking pixels. If an image has embe" +
+                                            "dded text this content should be supplied in the alt attribute.</p>"
+                                        );
+                                        for (x = 0; x < b; x = x + 1) {
+                                            attr.push("<li><code>");
+                                            attr.push(
+                                                token[data.emptyalt[x]].replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+                                            );
+                                            attr.push("</code> on input line number ");
+                                            attr.push(linen[data.emptyalt[x]]);
+                                            attr.push("</li>");
+                                        }
+                                        attr.push("</ol>");
+                                    } else {
+                                        attr.push(
+                                            "<h4><strong>0</strong> images have an empty <em>alt</em> attribute value</h4>"
+                                        );
+                                        attr.push(
+                                            "<p>Empty alt text is not necessarily a violation, such as the case of tracking" +
+                                            " pixels. If an image has embedded text this content should be supplied in the " +
+                                            "alt attribute.</p>"
+                                        );
+                                    }
+                                    attr.push("</div>");
+                                    attr.push("</div>");
+                                    return attr.join("");
+                                };
+                            if (options.accessibility === false) {
+                                return "";
+                            }
+                            findings.push(tagsbyname());
+                            return findings.join("");
+                        }()
+                    ),
+                    parseErrors   = (function markuppretty__beautify_apply_summary_parseErrors() {
+                        var x     = parseError.length,
+                            y     = 0,
+                            fails = [];
+                        data.violations = data.violations + x;
+                        if (parseError.length > 1) {
+                            globalerror = parseError[0].replace(options.functions.binaryCheck, "");
+                        }
+                        if (x === 0) {
+                            return "";
+                        }
+                        fails.push("<h4><strong>");
+                        fails.push(x);
+                        fails.push("</strong> errors interpreting markup</h4> <ol>");
+                        for (y = 0; y < x; y = y + 1) {
+                            fails.push("<li>");
+                            fails.push(
+                                parseError[y].replace(options.functions.binaryCheck, "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace("element: ", "element: <code>")
+                            );
+                            fails.push("</code></li>");
+                        }
+                        fails.push("</ol>");
+                        return fails.join("");
+                    }()),
+                    sizes         = (function markuppretty__beautify_apply_summary_sizes() {
+                        var table      = [],
+                            outlines   = output
+                                .split(lf)
+                                .length,
+                            outsize    = output.length,
+                            linechange = (outlines / line) * 100,
+                            charchange = (outsize / sourceSize) * 100;
+                        table.push("<h4>Data sizes</h4>");
+                        table.push(
+                            "<table class='analysis' summary='Data sizes'><caption>This table shows changes" +
+                            " in sizes of the data due to beautification.</caption>"
+                        );
+                        table.push(
+                            "<thead><tr><th>Data figure</th><th>Input</th><th>Output</th><th>Percent change" +
+                            "</th></tr></thead><tbody>"
+                        );
+                        table.push("<tr><th>Lines of code</th><td>");
+                        table.push(numformat(line));
+                        table.push("</td><td>");
+                        table.push(numformat(outlines));
+                        table.push("</td><td>");
+                        table.push(linechange.toFixed(2));
+                        table.push("%</td></tr>");
+                        table.push("<tr><th>Character size</th><td>");
+                        table.push(numformat(sourceSize));
+                        table.push("</td><td>");
+                        table.push(numformat(outsize));
+                        table.push("</td><td>");
+                        table.push(charchange.toFixed(2));
+                        table.push("%</td></tr>");
+                        table.push("</tbody></table>");
+                        return table.join("");
+                    }()),
+                    statistics    = (function markuppretty__beautify_apply_summary_statistics() {
+                        var stat       = [],
+                            totalItems = stats.cdata[0] + stats.comment[0] + stats.content[0] + stats.end[0] +
+                                    stats.ignore[0] + stats.script[0] + stats.sgml[0] + stats.singleton[0] +
+                                    stats.start[0] + stats.style[0] + stats.template[0] + stats.text[0] + stats.xml[0],
+                            totalSizes = stats.cdata[1] + stats.comment[1] + stats.content[1] + stats.end[1] +
+                                    stats.ignore[1] + stats.script[1] + stats.sgml[1] + stats.singleton[1] +
+                                    stats.start[1] + stats.style[1] + stats.template[1] + stats.text[1] + stats.xml[1],
+                            rowBuilder = function markuppretty__beautify_apply_summary_statistics_rowBuilder(
+                                type
+                            ) {
+                                var itema = (type === "Total*")
+                                        ? totalItems
+                                        : stats[type][0],
+                                    itemb = (type === "Total*")
+                                        ? totalSizes
+                                        : stats[type][1],
+                                    ratio = 0;
+                                stat.push("<tr><th>");
+                                stat.push(type);
+                                if (itema > 0 && (type === "script" || type === "style")) {
+                                    stat.push("**");
+                                }
+                                stat.push("</th><td");
+                                if ((globalerror.indexOf(" more start tag") || globalerror.indexOf(" more end tag")) && (type === "start" || type === "end")) {
+                                    stat.push(" class=\"bad\"");
+                                }
+                                stat.push(">");
+                                stat.push(itema);
+                                stat.push("</td><td>");
+                                ratio = ((itema / totalItems) * 100);
+                                stat.push(ratio.toFixed(2));
+                                stat.push("%</td><td>");
+                                stat.push(itemb);
+                                stat.push("</td><td");
+                                if (itema > 0 && (type === "script" || type === "style")) {
+                                    stat.push(" class='bad'");
+                                }
+                                stat.push(">");
+                                ratio = ((itemb / totalSizes) * 100);
+                                stat.push(ratio.toFixed(2));
+                                stat.push("%</td></tr>");
+                            };
+                        stat.push("<h4>Statistics and analysis of parsed code</h4>");
+                        stat.push(
+                            "<table class='analysis' summary='Statistics'><caption>This table provides basi" +
+                            "c statistics about the parsed components of the given code sample after beauti" +
+                            "fication.</caption>"
+                        );
+                        stat.push(
+                            "<thead><tr><th>Item type</th><th>Number of instances</th><th>Percentage of tot" +
+                            "al items</th><th>Character size</th><th>Percentage of total size</th></tr></th" +
+                            "ead>"
+                        );
+                        stat.push("<tbody>");
+                        rowBuilder("Total*");
+                        rowBuilder("cdata");
+                        rowBuilder("comment");
+                        rowBuilder("content");
+                        rowBuilder("end");
+                        rowBuilder("ignore");
+                        rowBuilder("script");
+                        rowBuilder("sgml");
+                        rowBuilder("singleton");
+                        rowBuilder("start");
+                        rowBuilder("style");
+                        rowBuilder("template");
+                        rowBuilder("text");
+                        rowBuilder("xml");
+                        stat.push("<tr><th>space between tags***</th><td colspan='4'>");
+                        stat.push(stats.space);
+                        stat.push("</td></tr>");
+                        stat.push("</tbody></table> ");
+                        stat.push(
+                            "<p>* Totals are accounted for parsed code/content tokens only and not extraneo" +
+                            "us space for beautification.</p> "
+                        );
+                        stat.push(
+                            "<p>** Script and Style code is measured with minimal white space.</p>"
+                        );
+                        stat.push(
+                            "<p>*** This is space that is not associated with text, tags, script, or css.</" +
+                            "p> "
+                        );
+                        return stat.join("");
+                    }()),
+                    zipf          = (function markuppretty__beautify_apply_summary_zipf() {
+                        var x          = 0,
+                            ratio      = 0,
+                            wordlen    = 0,
+                            wordcount  = 0,
+                            word       = "",
+                            wordlist   = [],
+                            wordtotal  = [],
+                            wordproper = [],
+                            zipfout    = [],
+                            identical  = true,
+                            sortchild  = function markuppretty__beautify_apply_summary_zipf_sortchild(y, z) {
+                                return z[0] - y[0];
+                            };
+                        for (x = x; x < len; x = x + 1) {
+                            if (types[x] === "content") {
+                                wordlist.push(token[x]);
+                            }
+                        }
+                        wordlist = safeSort(
+                            wordlist.join(" ").replace(options.functions.binaryCheck, "").toLowerCase().replace(/&nbsp;/gi, " ").replace(/(,|\.|\?|!|:|\(|\)|"|\{|\}|\[|\])/g, "").replace(/\s+/g, " ").replace(/&/g, "&amp;").replace(/>/g, "&gt;").replace(/</g, "&lt;").split(" ")
+                        );
+                        wordlen  = wordlist.length;
+                        for (x = 0; x < wordlen; x = x + 1) {
+                            word = wordlist[x];
+                            if (word.length > 2 && word.length < 30 && (/&#?\w+;/).test(word) === false && word !== "the" && word !== "and" && word !== "for" && word !== "are" && word !== "this" && word !== "from" && word !== "with" && word !== "that" && word !== "to") {
+                                if (wordproper.length === 0 || word !== wordproper[wordproper.length - 1][1]) {
+                                    wordproper.push([1, word]);
+                                } else {
+                                    wordproper[wordproper.length - 1][0] = wordproper[wordproper.length - 1][0] + 1;
+                                }
+                            }
+                            if (word !== wordlist[x - 1]) {
+                                wordtotal.push([1, word]);
+                            } else {
+                                wordtotal[wordtotal.length - 1][0] = wordtotal[wordtotal.length - 1][0] + 1;
+                            }
+                        }
+                        wordtotal  = wordtotal
+                            .sort(sortchild)
+                            .slice(0, 11);
+                        wordproper = wordproper
+                            .sort(sortchild)
+                            .slice(0, 11);
+                        wordlen    = (wordproper.length > 10)
+                            ? 11
+                            : wordproper.length;
+                        for (x = 0; x < wordlen; x = x + 1) {
+                            if (wordtotal[x][1] !== wordproper[x][1]) {
+                                identical = false;
+                                break;
+                            }
+                        }
+                        wordlen = (wordtotal.length > 10)
+                            ? 10
+                            : wordtotal.length;
+                        if (wordlen > 1) {
+                            wordcount = wordlist.length;
+                            zipfout.push("<h4>Zipf's Law analysis of content</h4>");
+                            zipfout.push(
+                                "<table class='analysis' summary='Zipf&#39;s Law'><caption>This table demonstra" +
+                                "tes <em>Zipf&#39;s Law</em> by listing the 10 most occuring words in the conte" +
+                                "nt and the number of times they occurred.</caption>"
+                            );
+                            zipfout.push(
+                                "<thead><tr><th>Word Rank</th><th>Most Occurring Word by Rank</th><th>Number of" +
+                                " Instances</th><th>Ratio Increased Over Next Most Frequence Occurance</th><th>" +
+                                "Percentage from "
+                            );
+                            zipfout.push(wordcount);
+                            zipfout.push(" total words</th></tr></thead><tbody>");
+                            if (identical === false) {
+                                zipfout.push("<tr><th colspan='5'>Unfiltered Word Set</th></tr>");
+                            }
+                            for (x = 0; x < wordlen; x = x + 1) {
+                                ratio = (wordtotal[x + 1] !== undefined)
+                                    ? (wordtotal[x][0] / wordtotal[x + 1][0])
+                                    : 1;
+                                zipfout.push("<tr><td>");
+                                zipfout.push(x + 1);
+                                zipfout.push("</td><td>");
+                                zipfout.push(wordtotal[x][1]);
+                                zipfout.push("</td><td>");
+                                zipfout.push(wordtotal[x][0]);
+                                zipfout.push("</td><td>");
+                                zipfout.push(ratio.toFixed(2));
+                                zipfout.push("</td><td>");
+                                ratio = ((wordtotal[x][0] / wordcount) * 100);
+                                zipfout.push(ratio.toFixed(2));
+                                zipfout.push("%</td></tr>");
+                            }
+                            wordlen = (wordproper.length > 10)
+                                ? 10
+                                : wordproper.length;
+                            if (wordlen > 1 && identical === false) {
+                                zipfout.push("<tr><th colspan='5'>Filtered Word Set</th></tr>");
+                                for (x = 0; x < wordlen; x = x + 1) {
+                                    ratio = (wordproper[x + 1] !== undefined)
+                                        ? (wordproper[x][0] / wordproper[x + 1][0])
+                                        : 1;
+                                    zipfout.push("<tr><td>");
+                                    zipfout.push(x + 1);
+                                    zipfout.push("</td><td>");
+                                    zipfout.push(wordproper[x][1]);
+                                    zipfout.push("</td><td>");
+                                    zipfout.push(wordproper[x][0]);
+                                    zipfout.push("</td><td>");
+                                    zipfout.push(ratio.toFixed(2));
+                                    zipfout.push("</td><td>");
+                                    ratio = ((wordproper[x][0] / wordcount) * 100);
+                                    zipfout.push(ratio.toFixed(2));
+                                    zipfout.push("%</td></tr>");
+                                }
+                            }
+                            zipfout.push("</tbody></table>");
+                        }
+                        return zipfout.join("");
+                    }());
+
+                sum.push(
+                    "<p><strong>Total number of HTTP requests (presuming HTML or XML Schema):</stro" +
+                    "ng> <em>"
+                );
+                sum.push(reqs.length);
+                sum.push("</em></p>");
+                sum.push("<div class='report'>");
+                sum.push(analysis(ids));
+                sum.push(sizes);
+                sum.push(parseErrors);
+                if (options.accessibility === true) {
+                    sum.push(accessibility);
+                }
+                sum.push(statistics);
+                sum.push(analysis(reqs));
+                sum.push(zipf);
+                sum.push("</div>");
+                if (options.accessibility === true) {
+                    if (options.nodeasync === true) {
+                        return [
+                            sum
+                                .join("")
+                                .replace(
+                                    "<div class='report'>",
+                                    "<p><strong>Total potential accessibility violations:</strong> <em>" + data.violations +
+                                            "</em></p> <div class='report'>"
+                                ),
+                            globalerror
+                        ];
+                    }
+                    return sum
+                        .join("")
+                        .replace(
+                            "<div class='report'>",
+                            "<p><strong>Total potential accessibility violations:</strong> <em>" + data.violations +
+                                    "</em></p> <div class='report'>"
+                        );
+                }
+                if (options.nodeasync === true) {
+                    return [sum.join(""), globalerror];
+                }
+                return sum.join("");
+            }());
+        }
+        return output;
+    };
+    if ((typeof define === "object" || typeof define === "function") && (typeof ace !== "object" || ace.prettydiffid === undefined)) {
+        //requirejs support
+        define(function markuppretty_requirejs() {
+            return function markuppretty_requirejs_wrapper(x) {
+                return markuppretty(x);
+            };
+        });
+    } else if (typeof module === "object" && typeof module.parent === "object") {
+        //commonjs and nodejs support
+        module.exports = markuppretty;
+        if (typeof require === "function" && (typeof ace !== "object" || ace.prettydiffid === undefined)) {
+            (function glib_markuppretty() {
+                var localPath = (
+                    typeof process === "object" && typeof process.cwd === "function" && (process.cwd() === "/" || (/^([a-z]:\\)$/).test(process.cwd()) === true) && typeof __dirname === "string"
+                )
+                    ? __dirname
+                    : ".";
+                if (global.prettydiff.csspretty === undefined) {
+                    global.prettydiff.csspretty = require(
+                        localPath + "/csspretty.js"
+                    );
+                }
+                if (global.prettydiff.jspretty === undefined) {
+                    global.prettydiff.jspretty = require(
+                        localPath + "/jspretty.js"
+                    );
+                }
+                if (global.prettydiff.safeSort === undefined) {
+                    global.prettydiff.safeSort = require(
+                        localPath + "/safeSort.js"
+                    );
+                }
+            }());
+        }
+    } else {
+        global.prettydiff.markuppretty = markuppretty;
+    }
+}());

--- a/node_modules/prettydiff/lib/options.js
+++ b/node_modules/prettydiff/lib/options.js
@@ -1,0 +1,2064 @@
+/*global __dirname, ace, define, global, module, process, require, WScript*/
+/*jslint for: true, this: true*/
+/*
+
+ Please see the license.txt file associated with the Pretty Diff
+ application for license information.
+
+ How to define a new option:
+
+ 1. definitions - define the option
+ 2. validate    - logic to assign values against accepted criteria
+ 3. pdcomment   - only necessary if option is string type with a list of accepted values
+ 4. domops      - associate ID names (from HTML) to values for populating the pretty diff comment in the web tool
+
+ Functions map:
+
+ * definitions   - a big object defining all the options
+ * default       - pulls default values out of the definitions object. This is necessary to prevent collisions when processing multiple files simultanesouly
+ * versionString - a function to build out human readable messaging about the current version from data in prettydiff.js
+ * consolePrint  - a handy function to print documentation on all options and usage data to the console in the browser or command line.
+    ** to execute in the browser console: global.prettydiff.options.functions.consolePrint()
+    ** or use the alias document.consolePrint() from api/dom.js
+ * pdcomment     - processes option overrides from the prettydiff.com code comment
+ * validate      - process user input against supported options and their acceptable values.  I have plans to merge this into the definitions object
+ * domops        - updates the comment string that appears in the options area of the web tool
+ * node          - parses node arguments into options for submission to the validate function
+ * binary        - a handy dandy tool to remove control characters from text output
+*/
+(function options_init() {
+    "use strict";
+    var options = {
+        functions: {}
+    };
+    global.prettydiff.options = options;
+    options.functions.definitions   = {
+        apacheVelocity : {
+            type      : "boolean",
+            definition: "Provides support for Apache Velocity template language.",
+            default   : false
+        },
+        api            : {
+            type      : "string",
+            definition: "An enternal option to help identify environment specific needs.",
+            default   : false
+        },
+        attributetoken : {
+            type      : "boolean",
+            definition: "Provides markups attributes as separate tokens in the parse table of mode pars" +
+                    "e, otherwise attributes are a data property of their respective element.",
+            default   : false
+        },
+        brace_style    : {
+            type      : "string",
+            definition: "Emulates JSBeautify's brace_style option using existing Pretty Diff options.",
+            values    : [
+                "collapse", "collapse-preserve-inline", "expand", "none"
+            ],
+            default   : "none"
+        },
+        braceline      : {
+            type      : "boolean",
+            definition: "If true a new line character will be inserted after opening curly braces and b" +
+                    "efore closing curly braces.",
+            default   : false
+        },
+        bracepadding   : {
+            type      : "boolean",
+            definition: "Inserts a space after the start of a contain and before the end of the contain" +
+                    "er in JavaScript if the contents of that container are not indented; such as: " +
+                    "conditions, function arguments, and escaped sequences of template strings.",
+            default   : false
+        },
+        braces         : {
+            type      : "string",
+            definition: "If lang is 'javascript' and mode is 'beautify' this determines if opening curl" +
+                    "y braces will exist on the same line as their condition or be forced onto a ne" +
+                    "w line.",
+            values    : [
+                "knr", "allman"
+            ],
+            default   : "knr"
+        },
+        color          : {
+            type      : "string",
+            definition: "The color scheme of the reports.",
+            default   : "white",
+            values    : ["canvas", "shadow", "white"]
+        },
+        comments       : {
+            type      : "string",
+            definition: "If mode is 'beautify' this will determine whether comments should always start" +
+                    " at position 0 of each line or if comments should be indented according to the" +
+                    " code.",
+            default   : "indent",
+            values    : ["indent", "noindent"]
+        },
+        commline       : {
+            type      : "boolean",
+            definition: "If a blank new line should be forced above comments in markup.",
+            default   : false
+        },
+        compressedcss  : {
+            type      : "boolean",
+            definition: "If CSS should be beautified in a style where the properties and values are min" +
+                    "ifed for faster reading of selectors.",
+            default   : false
+        },
+        conditional    : {
+            type      : "boolean",
+            definition: "If true then conditional comments used by Internet Explorer are preserved at m" +
+                    "inification of markup.",
+            default   : false
+        },
+        content        : {
+            type      : "boolean",
+            definition: "If true and mode is 'diff' this will normalize all string literals in JavaScri" +
+                    "pt to 'text' and all content in markup to 'text' so as to eliminate some diffe" +
+                    "rences from the HTML diff report.",
+            default   : false
+        },
+        context        : {
+            type      : "number",
+            definition: "This shortens the diff output by allowing a specified number of equivalent lin" +
+                    "es between each line of difference.",
+            default   : -1
+        },
+        correct        : {
+            type      : "boolean",
+            definition: "Automatically correct some sloppiness in JavaScript and markup.",
+            default   : false
+        },
+        crlf           : {
+            type      : "boolean",
+            definition: "If line termination should be Windows (CRLF) format.  Unix (LF) format is the " +
+                    "default.",
+            default   : false
+        },
+        cssinsertlines : {
+            type      : "boolean",
+            definition: "Inserts new line characters between every CSS code block.",
+            default   : false
+        },
+        csvchar        : {
+            type      : "string",
+            definition: "The character to be used as a separator if lang is 'csv'.  Any string combinat" +
+                    "ion is accepted.",
+            default   : ","
+        },
+        diff           : {
+            type      : "string",
+            definition: "The code sample to be compared to 'source' option. This is required if mode is" +
+                    " 'diff'.",
+            default   : ""
+        },
+        diffcli        : {
+            type      : "boolean",
+            definition: "If true only text lines of the code differences are returned instead of an HTM" +
+                    "L diff report.",
+            default   : false
+        },
+        diffcomments   : {
+            type      : "boolean",
+            definition: "If true then comments will be preserved so that both code and comments are com" +
+                    "pared by the diff engine.",
+            default   : false
+        },
+        difflabel      : {
+            type      : "string",
+            definition: "This allows for a descriptive label for the diff file code of the diff HTML ou" +
+                    "tput.",
+            default   : "New Sample"
+        },
+        diffspaceignore: {
+            type      : "boolean",
+            definition: "If white space only differences should be ignored by the diff tool.",
+            default   : false
+        },
+        diffview       : {
+            type      : "string",
+            definition: "This determines whether the diff HTML output should display as a side-by-side " +
+                    "comparison or if the differences should display in a single table column.",
+            values    : [
+                "inline", "sidebyside"
+            ],
+            default   : "sidebyside"
+        },
+        dustjs         : {
+            type      : "boolean",
+            definition: "If the provided markup code is a Dust.js template.",
+            default   : false
+        },
+        elseline       : {
+            type      : "boolean",
+            definition: "If elseline is true then the keyword 'else' is forced onto a new line in JavaS" +
+                    "cript beautification.",
+            default   : false
+        },
+        endcomma       : {
+            type      : "string",
+            definition: "If there should be a trailing comma in JavaScript arrays and objects. Value \"" +
+                    "multiline\" only applies to modes beautify and diff.",
+            values    : [
+                "always", "multiline", "never"
+            ],
+            default   : "never"
+        },
+        endquietly     : {
+            type      : "string",
+            definition: "A node only option to determine if terminal logging should be allowed or suppr" +
+                    "essed.",
+            values    : [
+                "", "log", "quiet"
+            ],
+            default   : ""
+        },
+        force_attribute: {
+            type      : "boolean",
+            definition: "If all markup attributes should be indented each onto their own line.",
+            default   : false
+        },
+        force_indent   : {
+            type      : "boolean",
+            definition: "If lang is 'markup' this will force indentation upon all content and tags with" +
+                    "out regard for the creation of new text nodes.",
+            default   : false
+        },
+        formatArray    : {
+            type      : "string",
+            definition: "Determines if all JavaScript array indexes should be indented, never indented," +
+                    " or left to the default.",
+            values    : [
+                "default", "indent", "inline"
+            ],
+            default   : "default"
+        },
+        formatObject   : {
+            type      : "string",
+            definition: "Determines if all JavaScript array indexes should be indented, never indented," +
+                    " or left to the default.",
+            values    : [
+                "default", "indent", "inline"
+            ],
+            default   : "default"
+        },
+        functionname   : {
+            type      : "boolean",
+            definition: "If a space should follow a JavaScript function name.",
+            default   : false
+        },
+        help           : {
+            type      : "number",
+            definition: "A node only option to print documentation to the console. The value determines" +
+                    " where to wrap text.",
+            default   : 80
+        },
+        html           : {
+            type      : "boolean",
+            definition: "If lang is 'markup' this will provide extra support for HTML specific sloppine" +
+                    "ss.",
+            default   : false
+        },
+        inchar         : {
+            type      : "string",
+            definition: "The string characters to comprise a single indentation. Any string combination" +
+                    " is accepted.",
+            default   : " "
+        },
+        inlevel        : {
+            type      : "number",
+            definition: "How much indentation padding should be applied to JavaScript beautification?",
+            default   : 0
+        },
+        insize         : {
+            type      : "number",
+            definition: "The number of characters to comprise a single indentation.",
+            default   : 4
+        },
+        jekyll         : {
+            type      : "boolean",
+            definition: "If YAML Jekyll HTML template comments are supported.",
+            default   : false
+        },
+        jsscope        : {
+            type      : "string",
+            definition: "An educational tool to generate HTML output of JavaScript code to identify sco" +
+                    "pe regions and declared references by color.",
+            values    : {
+                none  : "prevents use of this option",
+                report: "generates HTML output that renders in web browsers",
+                html  : "generates HTML output with escaped angle braces and ampersands for embedding a" +
+                        "s code, which is handy in code producing tools"
+            },
+            default   : "none"
+        },
+        jsx            : {
+            type      : "boolean",
+            definition: "An internal flag used to identify if a given code sample is React JSX code.",
+            default   : false
+        },
+        lang           : {
+            type      : "string",
+            definition: "The programming language of the source file.",
+            values    : [
+                "auto",
+                "markup",
+                "javascript",
+                "css",
+                "html",
+                "csv",
+                "text"
+            ],
+            default   : "auto"
+        },
+        langdefault    : {
+            type      : "string",
+            definition: "The fallback option if option 'lang' is set to 'auto' and a language cannot be" +
+                    " detected.",
+            values    : [
+                "markup",
+                "javascript",
+                "css",
+                "html",
+                "csv",
+                "text"
+            ],
+            default   : "text"
+        },
+        listoptions    : {
+            type      : "boolean",
+            definition: "A Node.js only option that writes current option settings to the console.",
+            default   : false
+        },
+        methodchain    : {
+            type      : "string",
+            definition: "Whether consecutive JavaScript methods should be chained onto a single line of" +
+                    " code instead of indented.",
+            values    : [
+                "chain", "indent", "none"
+            ],
+            default   : "indent"
+        },
+        miniwrap       : {
+            type      : "boolean",
+            definition: "Whether minified JavaScript should wrap after a specified character width.  Th" +
+                    "is option requires a value from option 'wrap'.",
+            default   : false
+        },
+        mode           : {
+            type      : "string",
+            definition: "The operation to be performed.",
+            values    : {
+                analysis: "returns a code examination report",
+                beautify: "beautifies code and returns a string",
+                diff    : "returns either command line list of differences or an HTML report",
+                minify  : "minifies code and returns a string",
+                parse   : "using option 'parseFormat' returns an object with shallow arrays, a multidimen" +
+                        "sional array, or an HTML report"
+            },
+            default   : "diff"
+        },
+        newline        : {
+            type      : "boolean",
+            definition: "Insert an empty line at the end of output.",
+            default   : false
+        },
+        neverflatten   : {
+            type      : "boolean",
+            definition: "If destructured lists in JavaScript should never be flattend.",
+            default   : false
+        },
+        nocaseindent   : {
+            type      : "boolean",
+            definition: "If a case statement should receive the same indentation as the containing swit" +
+                    "ch block.",
+            default   : false
+        },
+        nochainindent  : {
+            type      : "boolean",
+            definition: "If indentation should be prevent of JavaScript method chains broken onto multi" +
+                    "ple lines.",
+            default   : false
+        },
+        nodeasync      : {
+            type      : "boolean",
+            definition: "An internal option manage processing of multiple files simultanously",
+            default   : false
+        },
+        nodeerror      : {
+            type      : "boolean",
+            definition: "A Node.js only option if parse errors should be written to the console.",
+            default   : false
+        },
+        noleadzero     : {
+            type      : "boolean",
+            definition: "Whether leading 0s in CSS values immediately preceeding a decimal should be re" +
+                    "moved or prevented.",
+            default   : false
+        },
+        objsort        : {
+            type      : "string",
+            definition: "Sorts markup attributes and properties by key name in JavaScript and CSS.",
+            values    : [
+                "all", "css", "js", "markup", "none"
+            ],
+            default   : "none"
+        },
+        output         : {
+            type      : "string",
+            definition: "The path of the directory, if readmethod is value 'directory', or path and nam" +
+                    "e of the file to write the output.  The path will be created or overwritten.",
+            default   : ""
+        },
+        parseFormat    : {
+            type      : "string",
+            definition: "Determines the output format for 'parse' mode.",
+            values    : {
+                htmltable : "generates a human readable report in the format of an HTML table",
+                parallel  : "returns a series of parallel arrays",
+                sequential: "returns an array where each index is a child array containing the parsed token" +
+                        " and all descriptive data"
+            },
+            default   : "parallel"
+        },
+        parseSpace     : {
+            type      : "boolean",
+            definition: "Whether whitespace tokens should be included.",
+            default   : false
+        },
+        preserve       : {
+            type      : "number",
+            definition: "The maximum number of empty lines to retain.",
+            default   : 0
+        },
+        preserveComment: {
+            type      : "boolean",
+            definition: "Prevent comment reformatting due to option wrap.",
+            default   : false
+        },
+        qml            : {
+            type      : "boolean",
+            definition: "Enables QML syntax support in the jspretty library.",
+            default   : false
+        },
+        quote          : {
+            type      : "boolean",
+            definition: "If true and mode is 'diff' then all single quote characters will be replaced b" +
+                    "y double quote characters in both the source and diff file input so as to elim" +
+                    "inate some differences from the diff report HTML output.",
+            default   : false
+        },
+        quoteConvert   : {
+            type      : "string",
+            definition: "If the quotes of JavaScript strings or markup attributes should be converted t" +
+                    "o single quotes or double quotes.",
+            values    : [
+                "double", "single", "none"
+            ],
+            default   : "none"
+        },
+        readmethod     : {
+            type      : "string",
+            definition: "The readmethod determines how Node.js should receive input and output.",
+            values    : {
+                auto        : "changes to value subdirectory, file, or screen depending on source resolution",
+                screen      : "reads from screen and outputs to screen",
+                file        : "reads a file and outputs to a file.  file requires option 'output'",
+                filescreen  : "reads a file and writes to screen",
+                directory   : "process all files in the specified directory only",
+                subdirectory: "process all files in a directory and its subdirectories"
+            },
+            default   : "auto"
+        },
+        selectorlist   : {
+            type      : "boolean",
+            definition: "If comma separated CSS selectors should be retained on a single line of code.",
+            default   : false
+        },
+        semicolon      : {
+            type      : "boolean",
+            definition: "If true and mode is 'diff' and lang is 'javascript' all semicolon characters t" +
+                    "hat immediately preceed any white space containing a new line character will b" +
+                    "e removed so as to elimate some differences from the code comparison.",
+            default   : false
+        },
+        source         : {
+            type      : "string",
+            definition: "The source code or location for interpretation. This option is required for al" +
+                    "l modes.",
+            default   : ""
+        },
+        sourcelabel    : {
+            type      : "string",
+            definition: "This allows for a descriptive label of the source file code of the diff HTML o" +
+                    "utput.",
+            default   : "Source Sample"
+        },
+        space          : {
+            type      : "boolean",
+            definition: "Inserts a space following the function keyword for anonymous functions.",
+            default   : true
+        },
+        spaceclose     : {
+            type      : "boolean",
+            definition: "Markup self-closing tags end will end with ' />' instead of '/>'.",
+            default   : false
+        },
+        style          : {
+            type      : "string",
+            definition: "If mode is 'beautify' and lang is 'markup' or 'html' this will determine wheth" +
+                    "er the contents of script and style tags should always start at position 0 of " +
+                    "each line or if such content should be indented starting from the opening scri" +
+                    "pt or style tag.",
+            values    : [
+                "indent", "noindent"
+            ],
+            default   : "indent"
+        },
+        styleguide     : {
+            type      : "string",
+            definition: "Provides a collection of option presets to easily conform to popular JavaScrip" +
+                    "t style guides.",
+            values    : [
+                "airbnb",
+                "crockford",
+                "google",
+                "grunt",
+                "jquery",
+                "jslint",
+                "mediawiki",
+                "meteor",
+                "yandex",
+                "none"
+            ],
+            default   : "none"
+        },
+        summaryonly    : {
+            type      : "boolean",
+            definition: "Node only option to output only number of differences.",
+            default   : false
+        },
+        tagmerge       : {
+            type      : "boolean",
+            definition: "Allows immediately adjacement start and end markup tags of the same name to be" +
+                    " combined into a single self-closing tag.",
+            default   : false
+        },
+        tagsort        : {
+            type      : "boolean",
+            definition: "Sort child items of each respective markup parent element.",
+            default   : false
+        },
+        textpreserve   : {
+            type      : "boolean",
+            definition: "If text in the provided markup code should be preserved exactly as provided. T" +
+                    "his option eliminates beautification and wrapping of text content.",
+            default   : false
+        },
+        ternaryline    : {
+            type      : "boolean",
+            definition: "If ternary operators in JavaScript (? and :) should remain on the same line.",
+            default   : false
+        },
+        titanium       : {
+            type      : "boolean",
+            definition: "Forces the JavaScript parser to parse Titanium Style Sheets instead of JavaScr" +
+                    "ipt.",
+            default   : false
+        },
+        topcoms        : {
+            type      : "boolean",
+            definition: "If mode is 'minify' this determines whether comments above the first line of c" +
+                    "ode should be kept.",
+            default   : false
+        },
+        twig           : {
+            type      : "boolean",
+            definition: "If markuppretty is passing twig tag data to jspretty.",
+            default   : false
+        },
+        typescript     : {
+            type      : "boolean",
+            definition: "Identifies certain edge cases where TypeScript is in conflict with React JSX r" +
+                    "egarding type generics",
+            default   : false
+        },
+        unformatted    : {
+            type      : "boolean",
+            definition: "If markup tags should have their insides preserved.",
+            default   : false
+        },
+        varword        : {
+            type      : "string",
+            definition: "If consecutive JavaScript variables should be merged into a comma separated li" +
+                    "st or if variables in a list should be separated.",
+            values    : [
+                "each", "list", "none"
+            ],
+            default   : "none"
+        },
+        version        : {
+            type      : "boolean",
+            definition: "A Node.js only option to write the version information to the console.",
+            default   : false
+        },
+        vertical       : {
+            type      : "string",
+            definition: "If lists of assignments and properties should be vertically aligned.",
+            values    : [
+                "all", "css", "js", "none"
+            ],
+            default   : "none"
+        },
+        wrap           : {
+            type      : "number",
+            definition: "How many characters long text content in markup or strings in JavaScript can b" +
+                    "e before wrapping. A value of 0 turns this feature off. A value of -1 will con" +
+                    "catenate strings in JavaScript if separated by a '+' operator.",
+            default   : 0
+        }
+    };
+    options.functions.default       = function options_default() {
+        var keys     = Object.keys(options.functions.definitions),
+            populate = function options_default_populate(name) {
+                if (name !== "api" && name !== "diff" && name !== "output" && name !== "source" && name !== "nodeasync" && (options.functions.nodeArgs === undefined || options.functions.nodeArgs[name] === undefined)) {
+                    options[name] = options
+                        .functions
+                        .definitions[name]
+                        .default;
+                }
+            };
+        keys.forEach(populate);
+    };
+    options.functions.versionString = function options__versionString() {
+        var dstring = "",
+            mstring = 0,
+            month   = [
+                "January",
+                "February",
+                "March",
+                "April",
+                "May",
+                "June",
+                "July",
+                "August",
+                "September",
+                "October",
+                "November",
+                "December"
+            ];
+        if (global.prettydiff.edition === undefined) {
+            return "";
+        }
+        dstring = global
+            .prettydiff
+            .edition
+            .latest
+            .toString();
+        mstring = Number(dstring.slice(2, 4)) - 1;
+        return "\u001B[36mVersion\u001B[39m: " + global.prettydiff.edition.version + " " +
+                "\u001B[36mDated\u001B[39m: " + dstring.slice(4, 6) + " " + month[mstring] + " " +
+                "20" + dstring.slice(0, 2);
+    };
+    options.functions.consolePrint  = function options_consolePrint() {
+        var list      = Object.keys(options.functions.definitions),
+            a         = 0,
+            b         = 0,
+            longest   = 0,
+            len       = list.length,
+            def       = "",
+            name      = "",
+            type      = "",
+            vlist     = [],
+            names     = [],
+            vals      = [],
+            lf        = (options.crlf === true)
+                ? "\r\n"
+                : "\n",
+            limit     = (options.help === undefined)
+                ? 78
+                : options.help - 2,
+            namecolor = function options_colorPrint_namecolor(item) {
+                return "  * \"\u001B[32m" + item.replace("  * \"", "") + "\u001B[39m";
+            },
+            vertical  = function options_consolePrint_vertical(items) {
+                var mostest  = 0,
+                    x        = 0,
+                    y        = 0,
+                    leng     = items.length,
+                    newitems = [];
+                for (x = 0; x < leng; x = x + 1) {
+                    if (items[x].length > mostest) {
+                        mostest = items[x].length;
+                    }
+                }
+                for (x = 0; x < leng; x = x + 1) {
+                    y = items[x].length;
+                    newitems.push(items[x]);
+                    if (y < mostest) {
+                        do {
+                            y           = y + 1;
+                            newitems[x] = newitems[x] + " ";
+                        } while (y < mostest);
+                    }
+                }
+                return [newitems, mostest];
+            },
+            wrap      = function options_consolePrint_wrap(values) {
+                var start   = true,
+                    wrapper = [],
+                    wrappit = function options_consolePrint_wrap_wrappit() {
+                        var indent = (values === true && start === false)
+                                ? "     "
+                                : "  ",
+                            c      = limit - indent.length;
+                        name = name.replace(/^(\s+)/, "");
+                        if (name.length < c) {
+                            wrapper.push(indent + name);
+                            name = "";
+                            return;
+                        }
+                        if (name.charAt(c) !== " " || name.charAt(c - 1) === " ") {
+                            do {
+                                c = c - 1;
+                            } while (c > 0 && (name.charAt(c) !== " " || name.charAt(c - 1) === " "));
+                        }
+                        if (c === 0) {
+                            wrapper.push(indent + name);
+                            name = "";
+                            return;
+                        }
+                        wrapper.push(indent + name.slice(0, c));
+                        name = name.slice(c);
+                    };
+                do {
+                    wrappit();
+                    start = false;
+                } while (name.length > 0);
+                if (options.crlf === true) {
+                    return wrapper.join("\r\n");
+                }
+                return wrapper.join("\n");
+            },
+            output    = ["", "\u001B[1mOptions\u001B[22m"];
+        names   = vertical(list);
+        longest = names[1];
+        names   = names[0];
+        name    = "  Name";
+        b       = name.length;
+        if (b < longest) {
+            do {
+                b    = b + 1;
+                name = name + " ";
+            } while (b < longest);
+        }
+        name = name + "   - Type    - Default";
+        output.push("");
+        output.push(name);
+        b    = 0;
+        name = "";
+        do {
+            b    = b + 1;
+            name = name + "-";
+        } while (b < limit + 2);
+        output.push(name);
+        for (a = 0; a < len; a = a + 1) {
+            name = "* \u001B[32m" + names[a] + "\u001B[39m";
+            type = options
+                .functions
+                .definitions[list[a]]
+                .type;
+            if (type === "string") {
+                type = "\u001B[33m" + type + "\u001B[39m ";
+                def  = options
+                    .functions
+                    .definitions[list[a]]
+                    .default;
+                if (def === " ") {
+                    def = "(space)";
+                } else if (def === "") {
+                    def = "(empty string)";
+                } else {
+                    def = "\"" + def + "\"";
+                }
+            } else if (type === "number") {
+                type = "\u001B[36m" + type + "\u001B[39m ";
+                def  = options
+                    .functions
+                    .definitions[list[a]]
+                    .default
+                    .toString();
+            } else {
+                type = "\u001B[35m" + type + "\u001B[39m";
+                def  = options
+                    .functions
+                    .definitions[list[a]]
+                    .default
+                    .toString();
+            }
+            name = name + " - " + type + " - " + def;
+            output.push(name);
+            name = options
+                .functions
+                .definitions[list[a]]
+                .definition;
+            if (name.length < limit) {
+                output.push("  " + name);
+            } else {
+                output.push(wrap(false));
+            }
+            vlist = options
+                .functions
+                .definitions[list[a]]
+                .values;
+            if (vlist !== undefined) {
+                if (typeof vlist.length === "number") {
+                    name = "Accepted values: \"" + vlist
+                        .toString()
+                        .replace(/,/g, "\", \"") + "\"";
+                    name = "\u001B[31m" + wrap(false);
+                    name = name.replace(
+                        "Accepted values: \"",
+                        "Accepted values:\u001B[39m \"\u001B[32m"
+                    );
+                    name = name.replace(/,\u0020"/g, ", \"\u001B[32m");
+                    name = name.replace(/",/g, "\u001B[39m\",");
+                    output.push(name);
+                } else {
+                    output.push("  \u001B[31mAccepted values:\u001B[39m");
+                    vlist = Object.keys(options.functions.definitions[list[a]].values);
+                    vals  = vertical(vlist)[0];
+                    b     = 0;
+                    do {
+                        vals[b] = vals[b] + " ";
+                        name    = "  * \"" + vals[b].replace(" ", "\"") + " - " + options
+                            .functions
+                            .definitions[list[a]]
+                            .values[vlist[b]];
+                        name    = wrap(true);
+                        name    = name.replace(/\u0020\u0020\*\u0020"\w+/, namecolor);
+                        output.push(name);
+                        b = b + 1;
+                    } while (b < vlist.length);
+                }
+            }
+            output.push("");
+        }
+        if (options.api === "node") {
+            output.push("\u001B[1mUsage\u001B[22m");
+            output.push(
+                "\u001B[35mnode api/node-local.js\u001B[39m \u001B[32moption1:\u001B[39m\u001B[" +
+                "33m\"value\"\u001B[39m \u001B[32moption2:\u001B[39m\u001B[33m\"value\"\u001B[3" +
+                "9m ..."
+            );
+            output.push(
+                "\u001B[35mnode api/node-local.js\u001B[39m \u001B[32msource:\u001B[39m\u001B[3" +
+                "3m\"myApplication.js\"\u001B[39m \u001B[32mreadmethod:\u001B[39m\u001B[33m\"fi" +
+                "lescreen\"\u001B[39m \u001B[32mmode:\u001B[39m\u001B[33m\"beautify\"\u001B[39m"
+            );
+            output.push(
+                "\u001B[35mnode api/node-local.js\u001B[39m \u001B[32msource:\u001B[39m\u001B[3" +
+                "3m\"old_directory\"\u001B[39m \u001B[32mdiff:\u001B[39m\u001B[33m\"new_directo" +
+                "ry\"\u001B[39m \u001B[32mreadmethod:\u001B[39m\u001B[33m\"subdirectory\"\u001B" +
+                "[39m"
+            );
+            output.push(
+                "\u001B[35mnode api/node-local.js\u001B[39m \u001B[32mhelp\u001B[39m:80     to " +
+                "see this help message, the number value sets word wrap"
+            );
+            output.push(
+                "\u001B[35mnode api/node-local.js\u001B[39m \u001B[32mversion\u001B[39m     to " +
+                "see only the version line"
+            );
+            output.push(
+                "\u001B[35mnode api/node-local.js\u001B[39m \u001B[32mlist\u001B[39m        to " +
+                "see the current settings"
+            );
+            output.push("");
+            output.push(options.functions.versionString());
+            output.push("");
+            return output.join(lf);
+        }
+        output.push("");
+        output.push(options.functions.versionString());
+        output.push("");
+        return output
+            .join(lf)
+            .replace(/\u001b\[\d+m/g, "");
+    };
+    options.functions.pdcomment     = function options_pdcomment() {
+        var comment    = options.source,
+            type       = "source",
+            a          = 0,
+            b          = options.source.length,
+            strl       = 0,
+            strm       = "",
+            c          = -1,
+            build      = [],
+            comma      = -1,
+            g          = 0,
+            sourceChar = [],
+            quote      = "",
+            sind       = -1,
+            dind       = -1,
+            ss         = null,
+            sd         = null;
+        ss = options
+            .source
+            .match(/\/\*\s*prettydiff.com/);
+        sd = options
+            .diff
+            .match(/\/\*\s*prettydiff.com/);
+        if (ss === null) {
+            ss = options
+                .source
+                .match(/<\!--+\s*prettydiff.com/);
+            if (ss !== null) {
+                strm = ss[0];
+                strl = strm.length;
+                sind = options
+                    .source
+                    .indexOf(strm);
+                c    = sind + strl;
+            }
+        } else {
+            strm = ss[0];
+            strl = strm.length;
+            sind = options
+                .source
+                .indexOf(strm);
+            c    = sind + strl;
+        }
+        if (c < 0) {
+            if (sd === null) {
+                sd = options
+                    .diff
+                    .match(/<\!--+\s*prettydiff.com/);
+                if (sd !== null) {
+                    strm    = sd[0];
+                    strl    = strm.length;
+                    dind    = options
+                        .diff
+                        .indexOf(strm);
+                    c       = dind + strl;
+                    comment = options.diff;
+                    type    = "diff";
+                }
+            } else {
+                strm    = sd[0];
+                strl    = strm.length;
+                dind    = options
+                    .diff
+                    .indexOf(strm);
+                c       = dind + strl;
+                comment = options.diff;
+                type    = "diff";
+            }
+        }
+        if (c < 0) {
+            return;
+        }
+        if ((options.source.charAt(c - (strl + 1)) === "\"" && options.source.charAt(c) === "\"") || (sind < 0 && dind < 0)) {
+            return;
+        }
+        if (type === "source" && (/^(\s*\{\s*"token"\s*:\s*\[)/).test(options.source) === true && (/\],\s*"types"\s*:\s*\[/).test(options.source) === true) {
+            return;
+        }
+        if (type === "diff" && (/^(\s*\{\s*"token"\s*:\s*\[)/).test(options.diff) === true && (/\],\s*"types"\s*:\s*\[/).test(options.diff) === true) {
+            return;
+        }
+        for (c = c; c < b; c = c + 1) {
+            if (quote === "") {
+                if (comment.charAt(c) === "\"" || comment.charAt(c) === "'") {
+                    quote = comment.charAt(c);
+                    if (comment.charAt(c + 1) === " " && sourceChar[sourceChar.length - 1] === ":") {
+                        sourceChar.push("\\ ");
+                        c = c + 1;
+                    }
+                } else {
+                    if (comment.charAt(c) === "*" && comment.charAt(c + 1) === "/" && strm.slice(0, 2) === "/*") {
+                        break;
+                    }
+                    if (comment.charAt(c) === "-" && comment.charAt(c + 1) === "-" && comment.charAt(
+                        c + 2
+                    ) === ">" && strm.slice(0, 4) === "<!--") {
+                        break;
+                    }
+                    if (sourceChar[sourceChar.length - 1] !== ":" || (sourceChar[sourceChar.length - 1] === ":" && comment.charAt(c) !== " ")) {
+                        sourceChar.push(comment.charAt(c));
+                    }
+                }
+            } else if (comment.charAt(c) === quote) {
+                quote = "";
+            }
+        }
+        comment = sourceChar.join("");
+        b       = comment.length;
+        for (c = 0; c < b; c = c + 1) {
+            if ((typeof comment.charAt(c - 1) !== "string" || comment.charAt(c - 1) !== "\\") && (comment.charAt(c) === "\"" || comment.charAt(c) === "'")) {
+                if (quote === "") {
+                    quote = comment.charAt(c);
+                } else {
+                    quote = "";
+                }
+            }
+            if (quote === "") {
+                if (comment.charAt(c) === ",") {
+                    g     = comma + 1;
+                    comma = c;
+                    if ((/(\:\\\s+)$/).test(comment.slice(g, comma)) === true) {
+                        build.push(comment.slice(g, comma).replace(/^(\s*)/, "").replace(/:\\/, ":"));
+                    } else {
+                        build.push(comment.slice(g, comma).replace(/^(\s*)/, "").replace(/(\s*)$/, ""));
+                    }
+                }
+            }
+        }
+        g     = comma + 1;
+        comma = comment.length;
+        if ((/(\:\\\s+)$/).test(comment.slice(g, comma)) === true) {
+            build.push(comment.slice(g, comma).replace(/^(\s*)/, "").replace(/:\\/, ":"));
+        } else {
+            build.push(comment.slice(g, comma).replace(/^(\s*)/, "").replace(/(\s*)$/, ""));
+        }
+        quote      = "";
+        b          = build.length;
+        sourceChar = [];
+        for (c = 0; c < b; c = c + 1) {
+            a = build[c].length;
+            for (g = 0; g < a; g = g + 1) {
+                if (build[c].indexOf(":") === -1) {
+                    build[c] = "";
+                    break;
+                }
+                sourceChar = [];
+                if ((typeof build[c].charAt(g - 1) !== "string" || build[c].charAt(g - 1) !== "\\") && (build[c].charAt(g) === "\"" || build[c].charAt(g) === "'")) {
+                    if (quote === "") {
+                        quote = build[c].charAt(g);
+                    } else {
+                        quote = "";
+                    }
+                }
+                if (quote === "") {
+                    if (build[c].charAt(g) === ":") {
+                        sourceChar.push(build[c].substring(0, g).replace(/(\s*)$/, ""));
+                        sourceChar.push(build[c].substring(g + 1));
+                        if (sourceChar[1].charAt(0) === sourceChar[1].charAt(sourceChar[1].length - 1) && sourceChar[1].charAt(sourceChar[1].length - 2) !== "\\" && (sourceChar[1].charAt(0) === "\"" || sourceChar[1].charAt(0) === "'")) {
+                            sourceChar[1] = sourceChar[1].substring(1, sourceChar[1].length - 1);
+                        }
+                        build[c] = sourceChar;
+                        break;
+                    }
+                }
+            }
+        }
+        for (c = 0; c < b; c = c + 1) {
+            if (typeof build[c][1] === "string") {
+                build[c][0] = build[c][0].replace("api.", "");
+                if (build[c][0] === "brace_style") {
+                    if (build[c][1] === "collapse" || build[c][1] === "collapse-preserve-inline" || build[c][1] === "expand" || build[c][1] === "none") {
+                        options.brace_style = build[c][1];
+                    }
+                }
+                if (build[c][0] === "braces" || build[c][0] === "indent") {
+                    if (build[c][1] === "knr" || build[c][1] === "allman") {
+                        options.braces = build[c][1];
+                    }
+                } else if (build[c][0] === "color") {
+                    if (typeof b[c][1] === "string" && b[c][1] !== "") {
+                        options.color = b[c][1];
+                    }
+                } else if (build[c][0] === "comments") {
+                    if (build[c][1] === "indent" || build[c][1] === "noindent") {
+                        options.comments = "noindent";
+                    }
+                } else if (build[c][0] === "diffview") {
+                    if (build[c][1] === "sidebyside" || build[c][1] === "inline") {
+                        options.diffview = build[c][1];
+                    }
+                } else if (build[c][0] === "endcomma") {
+                    if (build[c][1] === "true" || build[c][1] === "always") {
+                        options.endcomma = "always";
+                    } else if (build[c][1] === "false" || build[c][1] === "never") {
+                        options.endcomma = "never";
+                    } else if (build[c][1] === "multiline") {
+                        options.endcomma = "multiline";
+                    }
+                } else if (build[c][0] === "formatArray" || build[c][0] === "formatObject") {
+                    if (build[c][1] === "default" || build[c][1] === "indent" || build[c][1] === "inline") {
+                        options[build[c][0]] = build[c][1];
+                    }
+                } else if (build[c][0] === "jsscope") {
+                    if (build[c][1] === "html" || build[c][1] === "none" || build[c][1] === "report") {
+                        options.jsscope = build[c][1];
+                    }
+                } else if (build[c][0] === "lang" || build[c][0] === "langdefault") {
+                    options[build[c][0]] = global
+                        .prettydiff
+                        .language
+                        .setlangmode(build[c][1]);
+                } else if (build[c][0] === "mode") {
+                    if (build[c][1] === "beautify" || build[c][1] === "minify" || build[c][1] === "diff" || build[c][1] === "parse" || build[c][1] === "analysis") {
+                        options.mode = build[c][1];
+                    }
+                } else if (build[c][0] === "objsort") {
+                    if (build[c][1] === "all" || build[c][1] === "js" || build[c][1] === "css" || build[c][1] === "markup" || build[c][1] === "none" || build[c][1] === "true" || build[c][1] === "false") {
+                        options.objsort = build[c][1];
+                    }
+                } else if (build[c][0] === "parseFormat") {
+                    if (build[c][1] === "htmltable" || build[c][1] === "parallel" || build[c][1] === "sequential") {
+                        options.parseFormat = build[c][1];
+                    }
+                } else if (build[c][0] === "quoteConvert") {
+                    if (build[c][1] === "single" || build[c][1] === "double" || build[c][1] === "none") {
+                        options.quoteConvert = build[c][1];
+                    }
+                } else if (build[c][0] === "style") {
+                    if (build[c][1] === "indent" || build[c][1] === "noindent") {
+                        options.style = build[c][1];
+                    }
+                } else if (build[c][0] === "typescript" && build[c][1] === "true") {
+                    options.typescript = true;
+                    options.lang       = "typescript";
+                } else if (build[c][0] === "varword") {
+                    if (build[c][1] === "each" || build[c][1] === "list" || build[c][1] === "none") {
+                        options.varword = build[c][1];
+                    }
+                } else if (build[c][0] === "vertical") {
+                    if (build[c][1] === "all" || build[c][1] === "css" || build[c][1] === "js" || build[c][1] === "none") {
+                        options.vertical = build[c][1];
+                    }
+                } else if (options[build[c][0]] !== undefined && options[build[c][1]] !== "") {
+                    if (build[c][1] === "true") {
+                        options[build[c][0]] = true;
+                    } else if (build[c][1] === "false") {
+                        options[build[c][0]] = false;
+                    } else if (isNaN(build[c][1]) === false && (/\s+/).test(build[c][1]) === false) {
+                        options[build[c][0]] = Number(build[c][1]);
+                    } else {
+                        if (options.functions.definitions[build[c][0]].type === "string") {
+                            options[build[c][0]] = build[c][1];
+                        } else {
+                            options[build[c][0]] = options
+                                .functions
+                                .definitions[build[c][0]]
+                                .default;
+                        }
+                    }
+                }
+            }
+        }
+    };
+    options.functions.validate      = function options_validate(api) {
+        var braceEscape = function diffview__options_braceEscape(input) {
+            return input
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;");
+        };
+        if (options.api !== "dom") {
+            options
+                .functions
+                .default();
+        }
+        // apacheVelocity - provides support for Apache Velocity markup templates
+        options.apacheVelocity  = (
+            api.apacheVelocity === true || api.apacheVelocity === "true"
+        );
+        // determines api source as necessary to make a decision about whether to supply
+        // externally needed JS functions to reports
+        options.api             = (api.api === undefined || api.api.length === 0)
+            ? "node"
+            : api.api;
+        // attributetoken - whether attributes should be represented as token items in
+        // the parse table or whether they should be a data properties of their element
+        options.attributetoken  = (
+            api.attributetoken === true || api.attributetoken === "true"
+        );
+        // brace-style - provided to emulate JSBeautify's brace-style option
+        options.brace_style     = (
+            api.brace_style === "collapse" || api.brace_style === "collapse-preserve-inline" || api.brace_style === "expand"
+        )
+            ? api.brace_style
+            : "none";
+        // braceline - should a new line pad the interior of blocks (curly braces) in
+        // JavaScript
+        options.braceline       = (api.braceline === true || api.braceline === "true");
+        //bracepadding - should curly braces be padded with a space in JavaScript?
+        options.bracepadding    = (
+            api.bracepadding === true || api.bracepadding === "true"
+        );
+        // indent - should JSPretty format JavaScript in the normal KNR style or push
+        // curly braces onto a separate line like the "allman" style
+        options.braces          = (
+            api.braces === true || api.braces === "true" || api.braces === "allman"
+        )
+            ? "allman"
+            : "knr";
+        //color scheme of generated HTML artifacts
+        options.color           = (api.color === "canvas" || api.color === "shadow")
+            ? api.color
+            : "white";
+        //comments - if comments should receive indentation or not
+        options.comments        = (api.comments === "noindent")
+            ? "noindent"
+            : ((api.comments === "nocomment")
+                ? "nocomment"
+                : "indent");
+        //commline - If in markup a newline should be forced above comments
+        options.commline        = (api.commline === true || api.commline === "true");
+        // compressedcss - If the beautified CSS should contain minified properties
+        options.compressedcss   = (
+            api.compressedcss === true || api.compressedcss === "true"
+        );
+        // conditional - should IE conditional comments be preserved during markup
+        // minification
+        options.conditional     = (
+            api.conditional === true || api.conditional === "true" || api.html === true
+        );
+        //content - should content be normalized during a diff operation
+        options.content         = (api.content === true || api.content === "true");
+        // context - should the diff report only include the differences, if so then
+        // buffered by how many lines of code
+        options.context         = (
+            isNaN(api.context) === true || api.context === "" || Number(api.context) < 0
+        )
+            ? -1
+            : Number(api.context);
+        //correct - should JSPretty make some corrections for sloppy JS
+        options.correct         = (api.correct === true || api.correct === "true");
+        //crlf - if output should use \r\n (Windows compatible) for line termination
+        options.crlf            = (api.crlf === true || api.crlf === "true");
+        //cssinsertlines = if a new line should be forced between each css block
+        options.cssinsertlines = (
+            api.cssinsertlines === true || api.cssinsertlines === "true"
+        );
+        //csvchar - what character should be used as a separator
+        options.csvchar         = (typeof api.csvchar === "string" && api.csvchar.length > 0)
+            ? api.csvchar
+            : ",";
+        //diff - source code to compare with
+        options.diff            = (
+            typeof api.diff === "string" && api.diff.length > 0 && (/^(\s+)$/).test(api.diff) === false
+        )
+            ? api.diff
+            : "";
+        // diffcli - if operating from Node.js and set to true diff output will be
+        // printed to stdout just like git diff
+        options.diffcli         = (api.diffcli === true || api.diffcli === "true");
+        //diffcomments - should comments be included in the diff operation
+        options.diffcomments    = (
+            api.diffcomments === true || api.diffcomments === "true"
+        );
+        //difflabel - a text label to describe the diff code
+        options.difflabel       = (
+            typeof api.difflabel === "string" && api.difflabel.length > 0
+        )
+            ? braceEscape(api.difflabel)
+            : "New Sample";
+        // diffspaceignore - If white space differences should be ignored by the diff
+        // tool
+        options.diffspaceignore = (
+            api.diffspaceignore === true || api.diffspaceignore === "true"
+        );
+        // diffview - should the diff report be a single column showing both sources
+        // simultaneously "inline" or showing the sources in separate columns
+        // "sidebyside"
+        options.diffview        = (api.diffview === "inline")
+            ? "inline"
+            : "sidebyside";
+        //dustjs - support for this specific templating scheme
+        options.dustjs          = (api.dustjs === true || api.dustjs === "true");
+        //elseline - for the 'else' keyword onto a new line in JavaScript
+        options.elseline        = (api.elseline === true || api.elseline === "true");
+        // endcomma - if a trailing comma should be injected at the end of arrays and
+        // object literals in JavaScript
+        options.endcomma        = (
+            api.endcomma === true || api.endcomma === "true" || api.endcomma === "always"
+        )
+            ? "always"
+            : (api.endcomma === "multiline")
+                ? "multiline"
+                : "never";
+        // endquietly - a node only option to prevent writing anything to console as
+        // stdout
+        options.endquietly      = (api.endquietly === "log" || api.endquietly === "quiet")
+            ? api.endquietly
+            : "";
+        // force_attribute - forces indentation of all markup attriubtes
+        options.force_attribute = (
+            api.force_attribute === true || api.force_attribute === "true"
+        );
+        // force_indent - should markup beautification always force indentation even if
+        // disruptive
+        options.force_indent    = (
+            api.force_indent === true || api.force_indent === "true"
+        );
+        // formatArray - defines whether JavaScript array keys should be indented or
+        // kept on a single line
+        options.formatArray     = (
+            api.formatArray === "indent" || api.formatArray === "inline"
+        )
+            ? api.formatArray
+            : "default";
+        // formatObject - defines whether JavaScript object properties should be
+        // indented or kept on a single line
+        options.formatObject    = (
+            api.formatObject === "indent" || api.formatObject === "inline"
+        )
+            ? api.formatObject
+            : "default";
+        // functionname - if a space should occur between a function name and its
+        // arguments paren
+        options.functionname    = (
+            api.functionname === true || api.functionname === "true"
+        );
+        options.help            = (isNaN(api.help) === true || api.help === "")
+            ? 80
+            : Number(api.help);
+        // html - should markup be presumed to be HTML with all the aloppiness HTML
+        // allows
+        options.html            = (
+            api.html === true || api.html === "true" || api.html === "html-yes"
+        );
+        //inchar - what character(s) should be used to create a single identation
+        options.inchar          = (typeof api.inchar === "string" && api.inchar.length > 0)
+            ? api
+                .inchar
+                .replace(/\\t/g, "\u0009")
+                .replace(/\\n/g, "\u000a")
+                .replace(/\\r/g, "\u000d")
+                .replace(/\\f/g, "\u000c")
+                .replace(/\\b/g, "\u0008")
+            : " ";
+        // inlevel - should indentation in JSPretty be buffered with additional
+        // indentation?  Useful when supplying code to sites accepting markdown
+        options.inlevel         = (
+            isNaN(api.inlevel) === true || api.inlevel === "" || Number(api.inlevel) < 1
+        )
+            ? 0
+            : Number(api.inlevel);
+        // insize - how many characters from api.inchar should constitute a single
+        // indentation
+        options.insize          = (isNaN(api.insize) === true || api.insize === "")
+            ? 4
+            : Number(api.insize);
+        // jekyll - If the delimiter "---" should be used to create comments in markup.
+        options.jekyll          = (api.jekyll === true || api.jekyll === "true");
+        // jsscope - do you want to enable the jsscope feature of JSPretty?  This
+        // feature will output formatted HTML instead of text code showing which
+        // variables are declared at which functional depth
+        options.jsscope         = (
+            api.jsscope === true || api.jsscope === "true" || api.jsscope === "report"
+        )
+            ? "report"
+            : (api.jsscope === "html")
+                ? "html"
+                : "none";
+        // jsx - an internal option that is tripped to true when JSX code is
+        // encountered.  This option allows the markuppretty and jspretty parsers know
+        // to recursively hand off to each other.
+        options.jsx             = false;
+        //lang - which programming language will we be analyzing
+        options.lang            = (typeof api.lang === "string" && api.lang !== "auto")
+            ? global
+                .prettydiff
+                .language
+                .setlangmode(api.lang.toLowerCase())
+            : "auto";
+        // langdefault - what language should lang value "auto" resort to when it cannot
+        // determine the language
+        options.langdefault     = (typeof api.langdefault === "string")
+            ? global
+                .prettydiff
+                .language
+                .setlangmode(api.langdefault.toLowerCase())
+            : "text";
+        // listoptions - a node only option to output the current options object to the
+        // console
+        options.listoptions     = (
+            api.listoptions === true || api.listoptions === "true" || api.listoptions === "l" || api.listoptions === "list"
+        );
+        // methodchain - if JavaScript method chains should be strung onto a single line
+        // instead of indented
+        options.methodchain     = (
+            api.methodchain === true || api.methodchain === "true" || api.methodchain === "chain"
+        )
+            ? "chain"
+            : (api.methodchain === "none")
+                ? "none"
+                : "indent";
+        // miniwrap - when language is JavaScript and mode is 'minify' if option 'jwrap'
+        // should be applied to all code
+        options.miniwrap        = (api.miniwrap === true || api.miniwrap === "true");
+        //mode - is this a minify, beautify, or diff operation
+        options.mode            = (
+            api.mode === "minify" || api.mode === "beautify" || api.mode === "parse" || api.mode === "analysis"
+        )
+            ? api.mode
+            : "diff";
+        //newline - Insert an empty line at the end of output.
+        options.newline         = (
+            api.newline === true || api.newline === "true"
+        );
+        //neverflatten - prevent flattening of destructured lists in JavaScript
+        options.neverflatten    = (
+            api.neverflatten === true || api.neverflatten === "true"
+        );
+        //nocaseindent - if a 'case' should be indented to its parent 'switch'
+        options.nocaseindent    = (
+            api.nocaseindent === true || api.nocaseindent === "true"
+        );
+        // nochainindent - prevent indentation when JavaScript chains of methods are
+        // broken onto multiple lines
+        options.nochainindent   = (
+            api.nochainindent === true || api.nochainindent === "true"
+        );
+        // nodeasync - meta data has to be passed in the output for bulk async
+        // operations otherwise there is cross-talk, which means prettydiff has to
+        // return an array of [data, meta] instead of a single string
+        options.nodeasync       = (api.nodeasync === true || api.nodeasync === "true");
+        // nodeerror - nodeonly rule about whether parse errors should be logged to the
+        // console
+        options.nodeerror       = (api.nodeerror === true || api.nodeerror === "true");
+        // noleadzero - in CSS removes and prevents a run of 0s from appearing
+        // immediately before a value's decimal.
+        options.noleadzero      = (api.noleadzero === true || api.noleadzero === "true");
+        //objsort will alphabetize object keys in JavaScript
+        options.objsort         = (
+            api.objsort === "all" || api.objsort === "js" || api.objsort === "css" || api.objsort === "markup" || api.objsort === true || api.objsort === "true"
+        )
+            ? api.objsort
+            : "none";
+        // output - a node only option of where to write the output into the file system
+        options.output          = (
+            typeof api.output === "string" && api.output.length > 0 && (/^(\s+)$/).test(api.output) === false
+        )
+            ? api.output
+            : "";
+        //parseFormat - determine how the parse tree should be organized and formatted
+        options.parseFormat     = (
+            api.parseFormat === "sequential" || api.parseFormat === "htmltable"
+        )
+            ? api.parseFormat
+            : "parallel";
+        // parseSpace - whether whitespace tokens between tags should be included in the
+        // parse tree output
+        options.parseSpace      = (api.parseSpace === true || api.parseSpace === "true");
+        //preserve - should empty lines be preserved in beautify operations of JSPretty?
+        options.preserve        = (function core__optionPreserve() {
+            if (api.preserve === 1 || api.preserve === undefined || api.preserve === true || api.preserve === "all" || api.preserve === "js" || api.preserve === "css") {
+                return 1;
+            }
+            if (api.preserve === false || api.preserve === "" || isNaN(api.preserve) === true || Number(api.preserve) < 1 || api.preserve === "none") {
+                return 0;
+            }
+            return Number(api.preserve);
+        }());
+        // preserveComment - prevent comment reformatting due to option wrap
+        options.preserveComment = (api.preserveComment === true || api.preserveComment === "true");
+        // qml - if the language is qml (beautified as JavaScript that looks like CSS)
+        options.qml             = (api.qml === true || api.qml === "true");
+        // quoteConvert - convert " to ' (or ' to ") of string literals or markup
+        // attributes
+        options.quoteConvert    = (
+            api.quoteConvert === "single" || api.quoteConvert === "double"
+        )
+            ? api.quoteConvert
+            : "none";
+        // readmethod - a node only option to determine scope of operations (how to
+        // proceeed with source and diff options as text or file system properties)
+        options.readmethod      = (
+            api.readmethod === "subdirectory" || api.readmethod === "directory" || api.readmethod === "file" || api.readmethod === "filescreen" || api.readmethod === "screen"
+        )
+            ? api.readmethod
+            : "auto";
+        //selectorlist - should comma separated CSS selector lists be on one line
+        options.selectorlist    = (
+            api.selectorlist === true || api.selectorlist === "true"
+        );
+        // semicolon - should trailing semicolons be removed during a diff operation to
+        // reduce the number of false positive comparisons
+        options.semicolon       = (api.semicolon === true || api.semicolon === "true");
+        // source - the source code in minify and beautify operations or "base" code in
+        // operations
+        options.source          = (
+            typeof api.source === "string" && api.source.length > 0 && (/^(\s+)$/).test(api.source) === false
+        )
+            ? api.source
+            : "";
+        //sourcelabel - a text label to describe the api.source code for the diff report
+        options.sourcelabel     = (
+            typeof api.sourcelabel === "string" && api.sourcelabel.length > 0
+        )
+            ? braceEscape(api.sourcelabel)
+            : "Base Sample";
+        // space - should JSPretty include a space between a function keyword and the
+        // next adjacent opening parenthesis character in beautification operations
+        options.space           = (api.space !== false && api.space !== "false");
+        //spaceclose - If markup self-closing tags should end with " />" instead of "/>"
+        options.spaceclose      = (api.spaceclose === true || api.spaceclose === "true");
+        // style - should JavaScript and CSS code receive indentation if embedded inline
+        // in markup
+        options.style           = (api.style === "noindent")
+            ? "noindent"
+            : "indent";
+        // styleguide - preset of beautification options to bring a JavaScript sample
+        // closer to conformance of a given style guide
+        options.styleguide      = (typeof api.styleguide === "string")
+            ? api
+                .styleguide
+                .toLowerCase()
+                .replace(/\s+/g, "")
+            : "none";
+        // summaryonly - node only option to output only the diff summary
+        options.summaryonly     = (api.summaryonly === true || api.summaryonly === "true");
+        // tagmerge - Allows combining immediately adjacent start and end tags of the
+        // same name into a single self-closing tag:  <a href="home"></a> into
+        // <a//href="home"/>
+        options.tagmerge = (api.tagmerge === true || api.tagmerge === "true");
+        //sort markup child nodes alphabetically
+        options.tagsort         = (api.tagsort === true || api.tagsort === "true");
+        // textpreserve - Force the markup beautifier to retain text (white space and
+        // all) exactly as provided.
+        options.ternaryline     = (api.ternaryline === true || api.ternaryline === "true");
+        options.textpreserve    = (
+            api.textpreserve === true || api.textpreserve === "true"
+        );
+        // titanium - TSS document support via option, because this is a uniquely
+        // modified form of JSON
+        options.titanium        = (api.titanium === true || api.titanium === "true");
+        // topcoms - should comments at the top of a JavaScript or CSS source be
+        // preserved during minify operations
+        options.topcoms         = (api.topcoms === true || api.topcoms === "true");
+        // twig - if markuppretty is passing twig tag data to jspretty
+        options.twig            = (api.twig === true || api.twig === "true");
+        options.typescript      = (api.typescript === true || api.typescript === "true");
+        // unformatted - if the internals of markup tags should be preserved
+        options.unformatted     = (api.unformatted === true || api.unformatted === "true");
+        // varword - should consecutive variables be merged into a comma separated list
+        // or the opposite
+        options.varword         = (api.varword === "each" || api.varword === "list")
+            ? api.varword
+            : "none";
+        // version - a node only option to output the version number to command line
+        options.version         = (
+            api.version === true || api.version === "true" || api.version === "version" || api.version === "v"
+        );
+        // vertical - whether or not to vertically align lists of assigns in CSS and
+        // JavaScript
+        options.vertical        = (
+            api.vertical === "all" || api.vertical === "css" || api.vertical === "js"
+        )
+            ? api.vertical
+            : "none";
+        // wrap - in markup beautification should text content wrap after the first
+        // complete word up to a certain character length
+        options.wrap            = (
+            isNaN(api.wrap) === true || api.wrap === "" || options.textpreserve === true
+        )
+            ? 0
+            : Number(api.wrap);
+        options.autoval         = ["", "", ""];
+        if (options.lang === "auto") {
+            options.autoval = global
+                .prettydiff
+                .language
+                .auto(options.source, options.langdefault);
+            options.lang    = options.autoval[1];
+        } else if (options.lang === "qml") {
+            options.qml  = true;
+            options.lang = "javascript";
+        } else if (options.lang === "velocity") {
+            options.apacheVelocity = true;
+            options.lang           = "markup";
+        } else if (options.api === "dom") {
+            options.autoval = [options.lang, options.lang, options.lang];
+        } else {
+            options.lang = global
+                .prettydiff
+                .language
+                .setlangmode(options.lang);
+        }
+        if (options.lang === "typescript") {
+            options.lang       = "javascript";
+            options.typescript = true;
+        }
+        if (options.apacheVelocity === true) {
+            if (options.mode === "minify") {
+                options.apacheVelocity = false;
+            } else {
+                options.lang = "markup";
+            }
+        }
+        if (options.qml === true) {
+            if (options.mode === "minify") {
+                options.qml = false;
+            } else {
+                options.lang = "javascript";
+            }
+        }
+        if (api.alphasort === true || api.alphasort === "true" || api.objsort === true || api.objsort === "true") {
+            options.objsort = "all";
+        }
+        if (api.indent === "allman") {
+            options.braces = "allman";
+        }
+        if (api.methodchain === true || api.methodchain === "true") {
+            options.methodchain = "chain";
+        } else if (api.methodchain === false || api.methodchain === "false") {
+            options.methodchain = "indent";
+        }
+        if (api.vertical === true || api.vertical === "true") {
+            options.vertical = "all";
+        } else if (api.vertical === "cssonly") {
+            options.vertical = "css";
+        } else if (api.vertical === "jsonly") {
+            options.vertical = "js";
+        }
+        if (options.autoval[0] === "dustjs") {
+            options.dustjs = true;
+        }
+        if (options.lang === "html") {
+            options.html = true;
+            options.lang = "markup";
+        } else if (options.lang === "tss" || options.lang === "titanium") {
+            options.titanium = true;
+            options.lang     = "javscript";
+        }
+        if (options.qml === true) {
+            options.correct = false;
+            options.jsx     = false;
+        }
+        if (options.mode !== "beautify" && options.mode !== "diff" && options.endcomma === "multiline") {
+            options.endcomma = "never";
+        }
+        if (options.mode === "minify") {
+            if (options.wrap < 1) {
+                options.miniwrap = false;
+            } else if (options.miniwrap === false) {
+                options.wrap = -1;
+            }
+            options.correct = true;
+        } else if (options.jsscope !== "none") {
+            if (options.mode !== "beautify") {
+                options.jsscope = "none";
+            } else {
+                // wrap is disabled for jsscope because it can break HTML character entities in
+                // strings, which is fine in JS, but breaks things when rendered in the browser.
+                options.wrap = 0;
+            }
+        }
+
+        // old diff api
+        if (typeof options.baseTextLines === "string") {
+            options.source = options
+                .baseTextLines
+                .replace(options.functions.binaryCheck, "")
+                .replace(/\r\n?/g, "\n");
+        }
+        if (typeof options.baseTextName === "string") {
+            options.sourcelabel = braceEscape(options.baseTextName);
+        }
+        if (typeof options.newTextLines === "string") {
+            options.diff = options
+                .newTextLines
+                .replace(options.functions.binaryCheck, "")
+                .replace(/\r\n?/g, "\n");
+        }
+        if (typeof options.newTextName === "string") {
+            options.difflabel = braceEscape(options.newTextName);
+        }
+        if ((/^([0-9]+)$/).test(options.contextSize) === true) {
+            options.context = Number(options.contextSize);
+        }
+        if (typeof options.tchar === "string") {
+            options.inchar = options.tchar;
+        }
+        if ((/^([0-9]+)$/).test(options.tsize) === true) {
+            options.insize = Number(options.tsize);
+        }
+        //end old diff api
+
+        options
+            .functions
+            .pdcomment();
+        return options;
+    };
+    options.functions.domops        = function options_domops(id, value, commentString) {
+        var a    = 0,
+            data = [];
+        if (id === "adustno" || id === "bdustno" || id === "ddustno" || id === "mdustno" || id === "pdustno") {
+            data = ["dustjs", "false"];
+        } else if (id === "adustyes" || id === "bdustyes" || id === "ddustyes" || id === "mdustyes" || id === "pdustyes") {
+            data = ["dustjs", "true"];
+        } else if (id === "ahtml-no" || id === "htmld-no" || id === "html-no" || id === "htmlm-no" || id === "phtml-no") {
+            data = ["html", "false"];
+        } else if (id === "ahtml-no" || id === "htmld-yes" || id === "html-yes" || id === "htmlm-yes" || id === "phtml-yes") {
+            data = ["html", "true"];
+        } else if (id === "ajekyll-no" || id === "bjekyll-no" || id === "djekyll-no" || id === "mjekyll-no" || id === "pjekyll-no") {
+            data = ["jekyll", "false"];
+        } else if (id === "ajekyll-yes" || id === "bjekyll-yes" || id === "djekyll-yes" || id === "mjekyll-yes" || id === "pjekyll-yes") {
+            data = ["jekyll", "true"];
+        } else if (id === "attributetoken-no") {
+            data = ["attributetoken", "false"];
+        } else if (id === "attributetoken-yes") {
+            data = ["attributetoken", "true"];
+        } else if (id === "baselabel") {
+            data = ["sourcelabel", value];
+        } else if (id === "bbracestyle-collapse" || id === "dbracestyle-collapse") {
+            data = ["brace_style", "collapse"];
+        } else if (id === "bbracestyle-expand" || id === "dbracestyle-expand") {
+            data = ["brace_style", "expand"];
+        } else if (id === "bbracestyle-inline" || id === "dbracestyle-inline") {
+            data = ["brace_style", "collapse-preserve-inline"];
+        } else if (id === "bbracestyle-none" || id === "dbracestyle-none") {
+            data = ["brace_style", "none"];
+        } else if (id === "bbraceline-no" || id === "dbraceline-no") {
+            data = ["braceline", "false"];
+        } else if (id === "bbraceline-yes" || id === "dbraceline-yes") {
+            data = ["braceline", "true"];
+        } else if (id === "bbracepadding-no" || id === "dbracepadding-no") {
+            data = ["bracepadding", "false"];
+        } else if (id === "bbracepadding-yes" || id === "dbracepadding-yes") {
+            data = ["bracepadding", "true"];
+        } else if (id === "bcommline-no") {
+            data = ["commline", "false"];
+        } else if (id === "bcommline-yes") {
+            data = ["commline", "true"];
+        } else if (id === "bcompressedcss-no" || id === "dcompressedcss-no") {
+            data = ["compressedcss", "false"];
+        } else if (id === "bcompressedcss-yes" || id === "dcompressedcss-yes") {
+            data = ["compressedcss", "true"];
+        } else if (id === "beau-wrap" || id === "diff-wrap" || id === "mini-wrap") {
+            data = ["wrap", value];
+        } else if (id === "bendcomma-always" || id === "dendcomma-always") {
+            data = ["endcomma", "always"];
+        } else if (id === "bendcomma-multiline" || id === "dendcomma-multiline") {
+            data = ["endcomma", "multiline"];
+        } else if (id === "bendcomma-never" || id === "dendcomma-never") {
+            data = ["endcomma", "never"];
+        } else if (id === "bforce_attribute-no" || id === "dforce_attribute-no") {
+            data = ["force_attribute", "false"];
+        } else if (id === "bforce_attribute-yes" || id === "dforce_attribute-yes") {
+            data = ["force_attribute", "true"];
+        } else if (id === "bforce_indent-no" || id === "dforce_indent-no") {
+            data = ["force_indent", "false"];
+        } else if (id === "bforce_indent-yes" || id === "dforce_indent-yes") {
+            data = ["force_indent", "true"];
+        } else if (id === "bformatarray-default" || id === "dformatarray-default") {
+            data = ["formatArray", "default"];
+        } else if (id === "bformatarray-indent" || id === "dformatarray-indent") {
+            data = ["formatArray", "indent"];
+        } else if (id === "bformatarray-inline" || id === "dformatarray-inline") {
+            data = ["formatArray", "inline"];
+        } else if (id === "bformatobject-default" || id === "dformatobject-default") {
+            data = ["formatObject", "default"];
+        } else if (id === "bformatobject-indent" || id === "dformatobject-indent") {
+            data = ["formatObject", "indent"];
+        } else if (id === "bformatobject-inline" || id === "dformatobject-inline") {
+            data = ["formatObject", "inline"];
+        } else if (id === "bfunctionname-no" || id === "dfunctionname-no") {
+            data = ["functionname", "false"];
+        } else if (id === "bfunctionname-yes" || id === "dfunctionname-yes") {
+            data = ["functionname", "true"];
+        } else if (id === "bpreserve" || id === "dpreserve") {
+            data = ["preserve", value];
+        } else if (id === "bpreserveComment-false" || id === "dpreserveComment-false") {
+            data = ["preserveComment", "false"];
+        } else if (id === "bpreserveComment-true" || id === "dpreserveComment-true") {
+            data = ["preserveComment", "true"];
+        } else if (id === "bmethodchain-chain" || id === "dmethodchain-chain") {
+            data = ["methodchain", "chain"];
+        } else if (id === "bmethodchain-indent" || id === "dmethodchain-indent") {
+            data = ["methodchain", "indent"];
+        } else if (id === "bmethodchain-none" || id === "dmethodchain-none") {
+            data = ["methodchain", "none"];
+        } else if (id === "bnocaseindent-no" || id === "dnocaseindent-no") {
+            data = ["nocaseindent", "false"];
+        } else if (id === "bnocaseindent-yes" || id === "dnocaseindent-yes") {
+            data = ["nocaseindent", "true"];
+        } else if (id === "bnochainindent-no" || id === "dnochainindent-no") {
+            data = ["nochainindent", "false"];
+        } else if (id === "bnochainindent-yes" || id === "dnochainindent-yes") {
+            data = ["nochainindent", "true"];
+        } else if (id === "bnoleadzero-no") {
+            data = ["noleadzero", "false"];
+        } else if (id === "bnoleadzero-yes") {
+            data = ["noleadzero", "true"];
+        } else if (id === "bobjsort-all" || id === "dobjsort-all" || id === "mobjsort-all" || id === "pobjsort-all") {
+            data = ["objsort", "all"];
+        } else if (id === "bobjsort-cssonly" || id === "dobjsort-cssonly" || id === "mobjsort-cssonly" || id === "pobjsort-cssonly") {
+            data = ["objsort", "css"];
+        } else if (id === "bobjsort-jsonly" || id === "dobjsort-jsonly" || id === "mobjsort-jsonly" || id === "pobjsort-jsonly") {
+            data = ["objsort", "js"];
+        } else if (id === "bobjsort-markuponly" || id === "dobjsort-markuponly" || id === "mobjsort-markuponly" || id === "pobjsort-markuponly") {
+            data = ["objsort", "markup"];
+        } else if (id === "bobjsort-none" || id === "dobjsort-none" || id === "mobjsort-none" || id === "pobjsort-none") {
+            data = ["objsort", "none"];
+        } else if (id === "bquoteconvert-double" || id === "mquoteconvert-double") {
+            data = ["quoteConvert", "double"];
+        } else if (id === "bquoteconvert-none" || id === "mquoteconvert-none") {
+            data = ["quoteConvert", "none"];
+        } else if (id === "bquoteconvert-single" || id === "mquoteconvert-single") {
+            data = ["quoteConvert", "single"];
+        } else if (id === "bselectorlist-no" || id === "dselectorlist-no") {
+            data = ["selectorlist", "false"];
+        } else if (id === "bselectorlist-yes" || id === "dselectorlist-yes") {
+            data = ["selectorlist", "true"];
+        } else if (id === "bspaceclose-no") {
+            data = ["spaceclose", "false"];
+        } else if (id === "bspaceclose-yes") {
+            data = ["spaceclose", "true"];
+        } else if (id === "bstyleguide") {
+            if (value === "") {
+                data = ["styleguide", ""];
+            } else {
+                data = ["styleguide", value];
+            }
+        } else if (id === "btagmerge-no" || id === "dtagmerge-no" || id === "mtagmerge-no" || id === "ptagmerge-no") {
+            data = ["tagmerge", "false"];
+        } else if (id === "btagmerge-yes" || id === "dtagmerge-yes" || id === "mtagmerge-yes" || id === "ptagmerge-yes") {
+            data = ["tagmerge", "true"];
+        } else if (id === "btagsort-no" || id === "dtagsort-no" || id === "mtagsort-no" || id === "ptagsort-no") {
+            data = ["tagsort", "false"];
+        } else if (id === "btagsort-yes" || id === "dtagsort-yes" || id === "mtagsort-yes" || id === "ptagsort-yes") {
+            data = ["tagsort", "true"];
+        } else if (id === "bternaryline-no" || id === "dternaryline-no") {
+            data = ["ternaryline", "false"];
+        } else if (id === "bternaryline-yes" || id === "dternaryline-yes") {
+            data = ["ternaryline", "true"];
+        } else if (id === "btextpreserveno" || id === "dtextpreserveno" || id === "mtextpreserveno" || id === "ptextpreserveno") {
+            data = ["textpreserve", "false"];
+        } else if (id === "btextpreserveyes" || id === "dtextpreserveyes" || id === "mtextpreserveyes" || id === "ptextpreserveyes") {
+            data = ["textpreserve", "true"];
+        } else if (id === "bunformatted-no" || id === "dunformatted-no" || id === "munformatted-no" || id === "punformatted-no") {
+            data = ["unformatted", "false"];
+        } else if (id === "bunformatted-yes" || id === "dunformatted-yes" || id === "munformatted-yes" || id === "punformatted-yes") {
+            data = ["unformatted", "true"];
+        } else if (id === "bvarword-each" || id === "dvarword-each" || id === "mvarword-each" || id === "pvarword-each") {
+            data = ["varword", "each"];
+        } else if (id === "bvarword-list" || id === "dvarword-list" || id === "mvarword-list" || id === "pvarword-list") {
+            data = ["varword", "list"];
+        } else if (id === "bvarword-none" || id === "dvarword-none" || id === "mvarword-none" || id === "pvarword-none") {
+            data = ["varword", "none"];
+        } else if (id === "conditionald-no" || id === "conditionalm-no") {
+            data = ["conditional", "false"];
+        } else if (id === "conditionald-yes" || id === "conditionalm-yes") {
+            data = ["conditional", "true"];
+        } else if (id === "contextSize") {
+            data = ["context", value];
+        } else if (id === "csvchar") {
+            data = ["csvchar", value];
+        } else if (id === "cssinsertlines-no") {
+            data = ["cssinsertlines", "false"];
+        } else if (id === "cssinsertlines-yes") {
+            data = ["cssinsertlines", "true"];
+        } else if (id === "diff-char" || id === "beau-char") {
+            data = ["inchar", value];
+        } else if (id === "diff-line" || id === "beau-line") {
+            data = ["inchar", "\n"];
+        } else if (id === "diff-quan" || id === "beau-quan" || id === "minn-quan") {
+            data = ["insize", value];
+        } else if (id === "diff-space" || id === "beau-space") {
+            data = ["inchar", " "];
+        } else if (id === "diff-tab" || id === "beau-tab") {
+            data = ["inchar", "\t"];
+        } else if (id === "diffcontent") {
+            data = ["content", "true"];
+        } else if (id === "diffcontenty") {
+            data = ["content", "false"];
+        } else if (id === "diffcli-false") {
+            data = ["diffcli", "false"];
+        } else if (id === "diffcli-true") {
+            data = ["diffcli", "true"];
+        } else if (id === "diffcommentsn") {
+            data = ["diffcomments", "false"];
+        } else if (id === "diffcommentsy") {
+            data = ["diffcomments", "true"];
+        } else if (id === "difflabel") {
+            data = ["difflabel", value];
+        } else if (id === "diffscolon") {
+            data = ["semicolon", "true"];
+        } else if (id === "diffscolony") {
+            data = ["semicolon", "false"];
+        } else if (id === "diffspaceignoren") {
+            data = ["diffspaceignore", "false"];
+        } else if (id === "diffspaceignorey") {
+            data = ["diffspaceignore", "true"];
+        } else if (id === "incomment-no") {
+            data = ["comments", "noindent"];
+        } else if (id === "incomment-yes") {
+            data = ["comments", "indent"];
+        } else if (id === "inline") {
+            data = ["diffview", "inline"];
+        } else if (id === "inlevel") {
+            data = ["inlevel", value];
+        } else if (id === "inscriptd-no" || id === "inscript-no") {
+            data = ["style", "noindent"];
+        } else if (id === "inscriptd-yes" || id === "inscript-yes") {
+            data = ["style", "indent"];
+        } else if (id === "jscorrect-no" || id === "mjscorrect-no") {
+            data = ["correct", "false"];
+        } else if (id === "jscorrect-yes" || id === "mjscorrect-yes") {
+            data = ["correct", "true"];
+        } else if (id === "jselseline-no") {
+            data = ["elseline", "false"];
+        } else if (id === "jselseline-yes") {
+            data = ["elseline", "true"];
+        } else if (id === "jsindentd-all" || id === "jsindent-all") {
+            data = ["indent", "allman"];
+        } else if (id === "jsindentd-knr" || id === "jsindent-knr") {
+            data = ["indent", "knr"];
+        } else if (id === "jsscope-html") {
+            data = ["jsscope", "true"];
+        } else if (id === "jsscope-no") {
+            data = ["jsscope", "none"];
+        } else if (id === "jsscope-yes") {
+            data = ["jsscope", "html"];
+        } else if (id === "jsscope-html") {
+            data = ["jsscope", "report"];
+        } else if (id === "jsspaced-no" || id === "jsspace-no") {
+            data = ["jsspace", "false"];
+        } else if (id === "jsspaced-yes" || id === "jsspace-yes") {
+            data = ["jsspace", "true"];
+        } else if (id === "language") {
+            data = ["lang", value];
+        } else if (id === "lang-default") {
+            data = ["langdefault", value];
+        } else if (id === "langauge") {
+            data = ["lang", value];
+        } else if (id === "lterminator-crlf") {
+            data = ["crlf", "true"];
+        } else if (id === "lterminator-lf") {
+            data = ["crlf", "false"];
+        } else if (id === "miniwrapm-no") {
+            data = ["miniwrap", "false"];
+        } else if (id === "miniwrapm-yes") {
+            data = ["miniwrap", "true"];
+        } else if (id === "modeanalysis") {
+            data = ["mode", "analysis"];
+        } else if (id === "modebeautify") {
+            data = ["mode", "beautify"];
+        } else if (id === "modediff") {
+            data = ["mode", "diff"];
+        } else if (id === "modeminify") {
+            data = ["mode", "minify"];
+        } else if (id === "modeparse") {
+            data = ["mode", "parse"];
+        } else if (id === "newline-no") {
+            data = ["newline", "false"];
+        } else if (id === "newline-yes") {
+            data = ["newline", "true"];
+        } else if (id === "parseFormat-htmltable") {
+            data = ["parseFormat", "htmltable"];
+        } else if (id === "parseFormat-parallel") {
+            data = ["parseFormat", "parallel"];
+        } else if (id === "parseFormat-sequential") {
+            data = ["parseFormat", "sequential"];
+        } else if (id === "parsespace-no") {
+            data = ["parseSpace", "false"];
+        } else if (id === "parsespace-yes") {
+            data = ["parseSpace", "true"];
+        } else if (id === "sidebyside") {
+            data = ["diffview", "sidebyside"];
+        } else if (id === "topcoms-yes") {
+            data = ["topcoms", "true"];
+        } else if (id === "topcoms-no") {
+            data = ["topcoms", "false"];
+        } else if (id === "vertical-all") {
+            data = ["vertical", "all"];
+        } else if (id === "vertical-cssonly") {
+            data = ["vertical", "css"];
+        } else if (id === "vertical-jsonly") {
+            data = ["vertical", "js"];
+        } else if (id === "vertical-none") {
+            data = ["vertical", "none"];
+        }
+        if (data.length === 0) {
+            return commentString;
+        }
+        if (data[1] !== "true" && data[1] !== "false") {
+            data[1] = "\"" + data[1] + "\"";
+        }
+        for (a = commentString.length - 1; a > -1; a = a - 1) {
+            if (commentString[a].indexOf(data[0]) > -1) {
+                commentString[a] = data.join(": ");
+                break;
+            }
+        }
+        if (a < 0) {
+            commentString.push(data.join(": "));
+            commentString.sort();
+        }
+        return commentString;
+    };
+    options.functions.node          = function options_node(a) {
+        var b        = 0,
+            c        = a.length,
+            d        = [],
+            e        = [],
+            f        = 0,
+            opts     = {},
+            help     = false,
+            langauto = true;
+        for (b = 0; b < c; b = b + 1) {
+            e = [];
+            f = a[b].indexOf(":");
+            e.push(a[b].substring(0, f).replace(/(\s+)$/, ""));
+            e.push(a[b].substring(f + 1).replace(/^(\s+)/, ""));
+            d.push(e);
+        }
+        c = d.length;
+        for (b = 0; b < c; b = b + 1) {
+            if (d[b].length === 2) {
+                opts[d[b][0]] = d[b][1];
+                if (d[b][0] === "lang" && d[b][1] !== "auto") {
+                    langauto = false;
+                }
+            } else {
+                if (d[b] === "help" || d[b][0] === "help" || d[b][0] === "man" || d[b][0] === "manual") {
+                    help = true;
+                } else if (d[b] === "v" || d[b] === "version" || d[b][0] === "v" || d[b][0] === "version") {
+                    options.version = true;
+                } else if (d[b] === "l" || d[b] === "list" || d[b][0] === "l" || d[b][0] === "list") {
+                    options.listoptions = true;
+                }
+            }
+        }
+        if (Object.keys(opts).length < 2) {
+            help = true;
+        }
+        options.functions.nodeArgs = opts;
+        options
+            .functions
+            .validate(opts);
+        return [help, langauto];
+    };
+    options.functions.binaryCheck   = (
+        /\u0000|\u0001|\u0002|\u0003|\u0004|\u0005|\u0006|\u0007|\u000b|\u000e|\u000f|\u0010|\u0011|\u0012|\u0013|\u0014|\u0015|\u0016|\u0017|\u0018|\u0019|\u001a|\u001c|\u001d|\u001e|\u001f|\u007f|\u0080|\u0081|\u0082|\u0083|\u0084|\u0085|\u0086|\u0087|\u0088|\u0089|\u008a|\u008b|\u008c|\u008d|\u008e|\u008f|\u0090|\u0091|\u0092|\u0093|\u0094|\u0095|\u0096|\u0097|\u0098|\u0099|\u009a|\u009b|\u009c|\u009d|\u009e|\u009f/g
+    );
+    if ((typeof define === "object" || typeof define === "function") && (typeof ace !== "object" || ace.prettydiffid === undefined)) {
+        //requirejs support
+        define(function options_requirejs() {
+            return global.prettydiff.options;
+        });
+    } else if (typeof module === "object" && typeof module.parent === "object") {
+        //commonjs and nodejs support
+        module.exports = global.prettydiff.options;
+        if (typeof require === "function" && (typeof ace !== "object" || ace.prettydiffid === undefined)) {
+            (function glib_options() {
+                var localPath = (
+                    typeof process === "object" && typeof process.cwd === "function" && (process.cwd() === "/" || (/^([a-z]:\\)$/).test(process.cwd()) === true) && typeof __dirname === "string"
+                )
+                    ? __dirname
+                    : ".";
+                if (global.prettydiff.language === undefined) {
+                    global.prettydiff.language = require(
+                        localPath + "/lib/language.js"
+                    );
+                }
+            }());
+        }
+    } 
+}());

--- a/node_modules/prettydiff/lib/safeSort.js
+++ b/node_modules/prettydiff/lib/safeSort.js
@@ -1,0 +1,190 @@
+/*prettydiff.com api.topcoms:true,api.insize:4,api.inchar:" ",api.vertical:true */
+/*global ace, define, global, module*/
+/***********************************************************************
+ safeSort is written by Austin Cheney on 23 Apr 2015.
+
+ Please see the license.txt file associated with the Pretty Diff
+ application for license information.
+ **********************************************************************/
+(function safeSort_init() {
+    "use strict";
+    var safeSort = function safeSort_(array, operation, recursive) {
+        var arTest  = function safeSort_arTest(item) {
+                if (typeof item !== "object" || item.length === undefined || item.length < 2) {
+                    return false;
+                }
+                return true;
+            },
+            extref  = function safeSort__extref() {
+                //worthless function for backwards compatibility with older versions of V8 node.
+                return;
+            },
+            normal  = function safeSort__normal(item) {
+                var done    = [item[0]],
+                    storeb  = item,
+                    child   = function safeSort__normal_child() {
+                        var a   = 0,
+                            len = storeb.length;
+                        for (a = 0; a < len; a = a + 1) {
+                            if (arTest(storeb[a]) === true) {
+                                storeb[a] = safeSort__normal(storeb[a]);
+                            }
+                        }
+                    },
+                    recurse = function safeSort__normal_recurse(x) {
+                        var a      = 0,
+                            storea = [],
+                            len    = storeb.length;
+                        for (a = 0; a < len; a = a + 1) {
+                            if (storeb[a] !== x) {
+                                storea.push(storeb[a]);
+                            }
+                        }
+                        storeb = storea;
+                        if (storea.length > 0) {
+                            done.push(storea[0]);
+                            extref(storea[0]);
+                        } else {
+                            if (recursive === true) {
+                                child();
+                            }
+                            item = storeb;
+                        }
+                    };
+                extref = recurse;
+                recurse(array[0]);
+            },
+            descend = function safeSort__descend(item) {
+                var c       = 0,
+                    storeb  = item,
+                    len     = item.length,
+                    child   = function safeSort__descend_child() {
+                        var a    = 0,
+                            lenc = storeb.length;
+                        for (a = 0; a < lenc; a = a + 1) {
+                            if (arTest(storeb[a]) === true) {
+                                storeb[a] = safeSort__descend(storeb[a]);
+                            }
+                        }
+                    },
+                    recurse = function safeSort__descend_recurse() {
+                        var a      = 0,
+                            b      = 0,
+                            d      = 0,
+                            e      = 0,
+                            ind    = [],
+                            key    = storeb[c],
+                            tstore = "",
+                            tkey   = typeof key;
+                        for (a = c; a < len; a = a + 1) {
+                            tstore = typeof storeb[a];
+                            if (storeb[a] > key || (tstore > tkey)) {
+                                key = storeb[a];
+                                ind = [a];
+                            } else if (storeb[a] === key) {
+                                ind.push(a);
+                            }
+                        }
+                        d = ind.length;
+                        b = d + c;
+                        for (a = c; a < b; a = a + 1) {
+                            storeb[ind[e]] = storeb[a];
+                            storeb[a]      = key;
+                            e              = e + 1;
+                        }
+                        c = c + d;
+                        if (c < len) {
+                            extref();
+                        } else {
+                            if (recursive === true) {
+                                child();
+                            }
+                            item = storeb;
+                        }
+                    };
+                extref = recurse;
+                recurse();
+                return item;
+            },
+            ascend  = function safeSort__ascend(item) {
+                var c       = 0,
+                    storeb  = item,
+                    len     = item.length,
+                    child   = function safeSort__ascend_child() {
+                        var a    = 0,
+                            lenc = storeb.length;
+                        for (a = 0; a < lenc; a = a + 1) {
+                            if (arTest(storeb[a]) === true) {
+                                storeb[a] = safeSort__ascend(storeb[a]);
+                            }
+                        }
+                    },
+                    recurse = function safeSort__ascend_recurse() {
+                        var a      = 0,
+                            b      = 0,
+                            d      = 0,
+                            e      = 0,
+                            ind    = [],
+                            key    = storeb[c],
+                            tstore = "",
+                            tkey   = typeof key;
+                        for (a = c; a < len; a = a + 1) {
+                            tstore = typeof storeb[a];
+                            if (storeb[a] < key || tstore < tkey) {
+                                key = storeb[a];
+                                ind = [a];
+                            } else if (storeb[a] === key) {
+                                ind.push(a);
+                            }
+                        }
+                        d = ind.length;
+                        b = d + c;
+                        for (a = c; a < b; a = a + 1) {
+                            storeb[ind[e]] = storeb[a];
+                            storeb[a]      = key;
+                            e              = e + 1;
+                        }
+                        c = c + d;
+                        if (c < len) {
+                            extref();
+                        } else {
+                            if (recursive === true) {
+                                child();
+                            }
+                            item = storeb;
+                        }
+                    };
+                extref = recurse;
+                recurse();
+                return item;
+            };
+        if (arTest(array) === false) {
+            return array;
+        }
+        if (recursive === "true") {
+            recursive = true;
+        } else if (recursive !== true) {
+            recursive = false;
+        }
+        if (operation === "normal") {
+            return normal(array);
+        }
+        if (operation === "descend") {
+            return descend(array);
+        }
+        return ascend(array);
+    };
+    if ((typeof define === "object" || typeof define === "function") && (typeof ace !== "object" || ace.prettydiffid === undefined)) {
+        //requirejs support
+        define(function safeSort_requirejs() {
+            return function safeSort_requirejs_wrapper(x, y, z) {
+                return safeSort(x, y, z);
+            };
+        });
+    } else if (typeof module === "object" && typeof module.parent === "object") {
+        //commonjs and nodejs support
+        module.exports = safeSort;
+    } else {
+        global.prettydiff.safeSort = safeSort;
+    }
+}());

--- a/node_modules/prettydiff/license.txt
+++ b/node_modules/prettydiff/license.txt
@@ -1,0 +1,149 @@
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work
+of authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without
+fear of later claims of infringement build upon, modify, incorporate in
+other works, reuse and redistribute as freely as possible in any form
+whatsoever and for any purposes, including without limitation commercial
+purposes. These owners may contribute to the Commons to promote the
+ideal of a free culture and the further production of creative, cultural
+and scientific works, or to gain reputation or greater distribution for
+their Work in part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or
+she is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under
+its terms, with knowledge of his or her Copyright and Related Rights in
+the Work and the meaning and intended legal effect of CC0 on those
+rights.
+
+1. Copyright and Related Rights.
+
+   A Work made available under CC0 may be protected by copyright and
+   related or neighboring rights ("Copyright and Related Rights").
+   Copyright and Related Rights include, but are not limited to, the
+   following:
+
+    i. the right to reproduce, adapt, distribute, perform, display,
+    communicate, and translate a Work;
+    
+    ii. moral rights retained by the original author(s) and/or
+    performer(s);
+
+    iii. publicity and privacy rights pertaining to a person's image or
+    likeness depicted in a Work;
+
+    iv. rights protecting against unfair competition in regards to a
+    Work, subject to the limitations in paragraph 4(a), below;
+
+    v. rights protecting the extraction, dissemination, use and reuse of
+    data in a Work;
+
+    vi. database rights (such as those arising under Directive 96/9/EC
+    of the European Parliament and of the Council of 11 March 1996 on
+    the legal protection of databases, and under any national
+    implementation thereof, including any amended or successor version
+    of such directive); and
+
+    vii. other similar, equivalent or corresponding rights throughout
+    the world based on applicable law or treaty, and any national
+    implementations thereof.
+
+2. Waiver.
+
+   To the greatest extent permitted by, but not in contravention of,
+   applicable law, Affirmer hereby overtly, fully, permanently,
+   irrevocably and unconditionally waives, abandons, and surrenders all
+   of Affirmer's Copyright and Related Rights and associated claims and
+   causes of action, whether now known or unknown (including existing as
+   well as future claims and causes of action), in the Work (i) in all
+   territories worldwide, (ii) for the maximum duration provided by
+   applicable law or treaty (including future time extensions), (iii) in
+   any current or future medium and for any number of copies, and (iv)
+   for any purpose whatsoever, including without limitation commercial,
+   advertising or promotional purposes (the "Waiver"). Affirmer makes
+   the Waiver for the benefit of each member of the public at large and
+   to the detriment of Affirmer's heirs and successors, fully intending
+   that such Waiver shall not be subject to revocation, rescission,
+   cancellation, termination, or any other legal or equitable action to
+   disrupt the quiet enjoyment of the Work by the public as contemplated
+   by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback.
+
+   Should any part of the Waiver for any reason be judged legally
+   invalid or ineffective under applicable law, then the Waiver shall be
+   preserved to the maximum extent permitted taking into account
+   Affirmer's express Statement of Purpose. In addition, to the extent
+   the Waiver is so judged Affirmer hereby grants to each affected
+   person a royalty-free, non transferable, non sublicensable, non
+   exclusive, irrevocable and unconditional license to exercise
+   Affirmer's Copyright and Related Rights in the Work
+   
+   (i) in all territories worldwide,
+
+   (ii) for the maximum duration provided by applicable law or treaty
+   (including future time extensions),
+
+   (iii) in any current or future medium and for any number of copies,
+   and
+
+   (iv) for any purpose whatsoever, including without limitation
+   commercial, advertising or promotional purposes (the "License").
+
+   The License shall be deemed effective as of the date CC0 was applied
+   by Affirmer to the Work. Should any part of the License for any
+   reason be judged legally invalid or ineffective under applicable law,
+   such partial invalidity or ineffectiveness shall not invalidate the
+   remainder of the License, and in such case Affirmer hereby affirms
+   that he or she will not
+
+   (i) exercise any of his or her remaining Copyright and Related Rights
+   in the Work or
+
+   (ii) assert any associated claims and causes of action with respect
+   to the Work, in either case contrary to Affirmer's express Statement
+   of Purpose.
+
+4. Limitations and Disclaimers.
+
+    a. No trademark or patent rights held by Affirmer are waived,
+    abandoned, surrendered, licensed or otherwise affected by this
+    document.
+
+    b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy,
+    or the present or absence of errors, whether or not discoverable,
+    all to the greatest extent permissible under applicable law.
+
+    c. Affirmer disclaims responsibility for clearing rights of other
+    persons that may apply to the Work or any use thereof, including
+    without limitation any person's Copyright and Related Rights in the
+    Work. Further, Affirmer disclaims responsibility for obtaining any
+    necessary consents, permissions or other rights required for any use
+    of the Work.
+
+    d. Affirmer understands and acknowledges that Creative Commons is
+    not a party to this document and has no duty or obligation with
+    respect to this CC0 or use of the Work.
+
+------------------------------------------------------------------------
+
+Rights holder Austin Cheney and Pretty Diff
+
+Pretty Diff project, as of version 2.1.17 and all following versions
+unless otherwise changed, is licensed with a Creative Commons 1.0
+Universal license (CC0).
+
+https://creativecommons.org/publicdomain/zero/1.0/legalcode

--- a/node_modules/prettydiff/package.json
+++ b/node_modules/prettydiff/package.json
@@ -1,0 +1,73 @@
+{
+    "author"              : {
+        "email": "info@prettydiff.com",
+        "name" : "Austin Cheney",
+        "url"  : "http://prettydiff.com/"
+    },
+    "bin"                 : "./bin/prettydiff",
+    "bugs"                : {
+        "email": "info@prettydiff.com",
+        "url"  : "https://github.com/prettydiff/prettydiff/issues"
+    },
+    "description"         : "Language aware code comparison tool for several web based languages. It also beautifies, minifies, and a few other things.",
+    "homepage"            : "http://prettydiff.com/",
+    "keywords"            : [
+        "diff",
+        "prettydiff",
+        "pretty diff",
+        "pretty print",
+        "pretty-print",
+        "beautify",
+        "minify",
+        "xml",
+        "html",
+        "css",
+        "jsx",
+        "es6",
+        "javascript"
+    ],
+    "license"             : "CC0",
+    "main"                : "prettydiff.js",
+    "maintainers"         : [
+        {
+            "email": "info@prettydiff.com",
+            "name" : "austincheney"
+        }
+    ],
+    "name"                : "prettydiff",
+    "publication_variants": {
+        "browser"     : {
+            "exclusions": ["api/node-local.js", "changelog.md", "favicon.ico", "jslint", "test"]
+        },
+        "browserNoAce": {
+            "exclusions": [
+                "ace",
+                "api/node-local.js",
+                "changelog.md",
+                "favicon.ico",
+                "jslint",
+                "test"
+            ]
+        },
+        "cli"         : {
+            "exclusions": [
+                "ace",
+                "api/dom.js",
+                "changelog.md",
+                "css",
+                "documentation.xhtml",
+                "favicon.ico",
+                "guide",
+                "index.xhtml",
+                "jslint",
+                "test"
+            ]
+        }
+    },
+    "repository"          : {
+        "type": "git",
+        "url" : "https://github.com/prettydiff/prettydiff"
+    },
+    "test"                : "node test/lint.js",
+    "version"             : "2.2.1"
+}

--- a/node_modules/prettydiff/prettydiff.js
+++ b/node_modules/prettydiff/prettydiff.js
@@ -1,0 +1,473 @@
+/*prettydiff.com topcoms: true, insize: 4, inchar: " ", vertical: true */
+/*jshint laxbreak: true*/
+/*global __dirname, ace, console, define, global, module, options, performance, process, require */
+/*
+
+ Execute in a NodeJS app:
+
+    var prettydiff = require("prettydiff"),
+        args       = {
+            source: "asdf",
+            diff  : "asdd",
+            lang  : "text"
+        },
+        output     = prettydiff(args);
+
+ Execute on command line with NodeJS:
+
+    node api/node-local.js source:"c:\mydirectory\myfile.js" readmethod:"file" diff:"c:\myotherfile.js"
+
+ Execute from JavaScript:
+    var global = {},
+        args   = {
+            source: "asdf",
+            diff  : "asdd",
+            lang  : "text"
+        },
+        output = prettydiff(args);
+
+ Manage with biddle
+     biddle install http://prettydiff.com/downloads/prettydiff/prettydiff_latest.zip
+     biddle global prettydiff
+     prettydiff source:"c:\mydirectory\myfile.js" readmethod:"file" diff:"c:\myotherfile.js"
+
+ Please see the license.txt file associated with the Pretty Diff
+ application for license information.
+
+ Special thanks to:
+
+ * Harry Whitfield for the numerous test cases provided against
+ JSPretty.  http://g6auc.me.uk/
+
+ * Andreas Greuel for contributing samples to test diffview.js
+ https://plus.google.com/105958105635636993368/posts
+
+ */
+(function prettydiff_init() {
+    "use strict";
+    var prettydiff = function prettydiff_(api) {
+        var startTime = (typeof performance === "object")
+                ? performance.now()
+                : 0,
+            core      = function core_(api) {
+                var spacetest    = (/^\s+$/g),
+                    apioutput    = "",
+                    apidiffout   = "",
+                    metaerror    = "",
+                    finalFile    = global.prettydiff.finalFile,
+                    options      = global
+                        .prettydiff
+                        .options
+                        .functions
+                        .validate(api),
+                    jspretty     = function core__jspretty() {
+                        var jsout = global
+                            .prettydiff
+                            .jspretty(options);
+                        if (options.nodeasync === true) {
+                            metaerror = jsout[1];
+                            return jsout[0];
+                        }
+                        metaerror = global.prettydiff.meta.error;
+                        return jsout;
+                    },
+                    markuppretty = function core__markuppretty() {
+                        var markout = global
+                            .prettydiff
+                            .markuppretty(options);
+                        if (options.nodeasync === true) {
+                            metaerror = markout[1];
+                            if (options.mode === "beautify" && options.inchar !== "\t") {
+                                markout[0] = markout[0].replace(/\r?\n[\t]*\u0020\/>/g, "");
+                            } else if (options.mode === "diff") {
+                                markout[0] = markout[0].replace(/\r?\n[\t]*\u0020\/>/g, "");
+                            }
+                            return markout[0];
+                        }
+                        metaerror = global.prettydiff.meta.error;
+                        if (options.mode === "beautify" && options.inchar !== "\t") {
+                            markout = markout.replace(/\r?\n[\t]*\u0020\/>/g, "");
+                        } else if (options.mode === "diff") {
+                            markout = markout.replace(/\r?\n[\t]*\u0020\/>/g, "");
+                        }
+                        return markout;
+                    },
+                    csspretty    = function core__markupcss() {
+                        var cssout = global
+                            .prettydiff
+                            .csspretty(options);
+                        if (options.nodeasync === true) {
+                            metaerror = cssout[1];
+                            return cssout[0];
+                        }
+                        metaerror = global.prettydiff.meta.error;
+                        return cssout;
+                    },
+                    proctime     = function core__proctime() {
+                        var minuteString = "",
+                            hourString   = "",
+                            minutes      = 0,
+                            hours        = 0,
+                            elapsed      = (typeof performance === "object")
+                                ? (performance.now() - startTime) / 1000
+                                : 0,
+                            secondString = elapsed.toFixed(6),
+                            plural       = function core__proctime_plural(x, y) {
+                                var a = x + y;
+                                if (x !== 1) {
+                                    a = a + "s";
+                                }
+                                if (y !== " second") {
+                                    a = a + " ";
+                                }
+                                return a;
+                            },
+                            minute       = function core__proctime_minute() {
+                                minutes      = parseInt((elapsed / 60), 10);
+                                minuteString = plural(minutes, " minute");
+                                minutes      = elapsed - (minutes * 60);
+                                secondString = (minutes === 1)
+                                    ? "1 second"
+                                    : minutes.toFixed(3) + " seconds";
+                            };
+                        if (elapsed >= 60 && elapsed < 3600) {
+                            minute();
+                        } else if (elapsed >= 3600) {
+                            hours      = parseInt((elapsed / 3600), 10);
+                            hourString = hours.toString();
+                            elapsed    = elapsed - (hours * 3600);
+                            hourString = plural(hours, " hour");
+                            minute();
+                        } else {
+                            secondString = plural(secondString, " second");
+                        }
+                        return hourString + minuteString + secondString;
+                    },
+                    output       = function core__output(finalProduct, difftotal, difflines) {
+                        var meta         = {
+                                difflines: 0,
+                                difftotal: 0,
+                                error    : "",
+                                insize   : 0,
+                                lang     : [
+                                    "", "", ""
+                                ],
+                                outsize  : 0,
+                                time     : ""
+                            };
+                        meta.lang   = options.autoval;
+                        meta.time   = proctime();
+                        meta.insize = (options.mode === "diff")
+                            ? options.source.length + options.diff.length
+                            : options.source.length;
+                        if (options.mode === "parse" && options.lang !== "text" && typeof finalProduct === "object" && (options.autoval[0] !== "" || options.lang !== "auto")) {
+                            if (options.parseFormat === "sequential" || options.parseFormat === "htmltable") {
+                                meta.outsize = finalProduct.data.length;
+                            } else {
+                                meta.outsize = finalProduct.data.token.length;
+                            }
+                        } else {
+                            meta.outsize = finalProduct.length;
+                        }
+                        if (options.autoval[0] === "text" && options.mode !== "diff") {
+                            if (options.autoval[2] === "unknown") {
+                                meta.error = "Language is set to auto, but could not be detected. File not parsed.";
+                            } else {
+                                meta.error = "Language is set to text, but plain text is only supported in diff mode. File n" +
+                                        "ot parsed.";
+                            }
+                        }
+                        if (difftotal !== undefined) {
+                            meta.difftotal = difftotal;
+                        }
+                        if (difflines !== undefined) {
+                            meta.difflines = difflines;
+                        }
+                        meta.error = metaerror;
+                        if (options.nodeasync === true) {
+                            return [finalProduct, meta];
+                        }
+                        global.prettydiff.meta = meta;
+                        return finalProduct;
+                    };
+                if (options.source === "" && (options.mode === "beautify" || options.mode === "minify" || options.mode === "analysis" || (options.mode === "diff" && options.diffcli === false) || (options.mode === "parse" && options.parseFormat === "htmltable"))) {
+                    metaerror = "options.source is empty!";
+                    console.log(metaerror);
+                    return output("", 0, 0);
+                }
+                if (options.mode === "diff" && options.diffcli === false) {
+                    if (options.diff === "") {
+                        metaerror = "options.mode is 'diff' and options.diff is empty!";
+                        console.log(metaerror);
+                        return output("", 0, 0);
+                    }
+                    if (options.lang === "csv") {
+                        options.lang = "text";
+                    }
+                }
+                if (options.autoval[0] === "text" && options.mode !== "diff") {
+                    metaerror = "Language is either text or undetermined, but text is only allowed for the 'dif" +
+                            "f' mode!";
+                    return output(options.source, 0, 0);
+                }
+                finalFile.order[7] = options.color;
+                if (options.mode === "diff") {
+                    options.vertical = false;
+                    options.jsscope  = "none";
+                    options.preserve = 0;
+                    if (options.diffcomments === false) {
+                        options.comments = "nocomment";
+                    }
+                    if (options.lang === "css") {
+                        apioutput      = csspretty();
+                        options.source = options.diff;
+                        apidiffout     = csspretty();
+                    } else if (options.lang === "csv") {
+                        apioutput  = global
+                            .prettydiff
+                            .csvpretty(options);
+                        apidiffout = global
+                            .prettydiff
+                            .csvpretty(options);
+                    } else if (options.lang === "markup") {
+                        apioutput      = markuppretty();
+                        options.source = options.diff;
+                        apidiffout     = markuppretty();
+                    } else if (options.lang === "text") {
+                        apioutput  = options.source;
+                        apidiffout = options.diff;
+                    } else {
+                        apioutput      = jspretty();
+                        options.source = options.diff;
+                        apidiffout     = jspretty();
+                    }
+                    if (options.quote === true) {
+                        apioutput  = apioutput.replace(/'/g, "\"");
+                        apidiffout = apidiffout.replace(/'/g, "\"");
+                    }
+                    if (options.semicolon === true) {
+                        apioutput  = apioutput
+                            .replace(/;\r\n/g, "\r\n")
+                            .replace(/;\n/g, "\n");
+                        apidiffout = apidiffout
+                            .replace(/;\r\n/g, "\r\n")
+                            .replace(/;\n/g, "\n");
+                    }
+                    if (options.sourcelabel === "" || spacetest.test(options.sourcelabel)) {
+                        options.sourcelabel = "Base Text";
+                    }
+                    if (options.difflabel === "" || spacetest.test(options.difflabel)) {
+                        options.difflabel = "New Text";
+                    }
+                    if (options.jsx === true) {
+                        options.autoval = ["jsx", "javascript", "React JSX"];
+                    }
+                    return (function core__diff() {
+                        var a = "";
+                        options.diff   = apidiffout;
+                        options.source = apioutput;
+                        if (options.diffcli === true) {
+                            a = global.prettydiff.diffview(options);
+                            return output(a[0], a[1], a[2]);
+                        }
+                        if (apioutput === "Error: This does not appear to be JavaScript." || apidiffout === "Error: This does not appear to be JavaScript.") {
+                            return output(
+                                "<p><strong>Error:</strong> Please try using the option labeled <em>Plain Text " +
+                                "(diff only)</em>. <span style='display:block'>The input does not appear to be " +
+                                "markup, CSS, or JavaScript.</span></p>", 0, 0
+                            );
+                        }
+                        if (options.lang === "text") {
+                            options.inchar = "";
+                        }
+                        a = global
+                            .prettydiff
+                            .diffview(options);
+                        if (options.jsx === true) {
+                            options.autoval = ["jsx", "javascript", "React JSX"];
+                        }
+                        if (options.api === "") {
+                            finalFile.order[10] = a[0];
+                            finalFile.order[12] = finalFile.script.diff;
+                            return output(finalFile.order.join(""), a[1], a[2]);
+                        }
+                        return output(a[0], a[1], a[2]);
+                    }());
+                } else {
+                    if (options.mode === "analysis") {
+                        options.accessibility = true;
+                    }
+                    if (options.lang === "css") {
+                        apioutput = csspretty();
+                    } else if (options.lang === "csv") {
+                        apioutput = global
+                            .prettydiff
+                            .csvpretty(options);
+                    } else if (options.lang === "markup") {
+                        apioutput = markuppretty();
+                    } else if (options.lang === "text") {
+                        apioutput  = options.source;
+                        apidiffout = "";
+                    } else {
+                        apioutput = jspretty();
+                    }
+                    if (options.api === "") {
+                        if (options.mode === "analysis" || (options.mode === "parse" && options.parseFormat === "htmltable")) {
+                            finalFile.order[10] = apidiffout;
+                            apioutput           = finalFile
+                                .order
+                                .join("");
+                        } else if (options.mode === "beautify" && options.jsscope !== "none" && (options.lang === "javascript" || options.lang === "json")) {
+                            finalFile.order[10] = apidiffout;
+                            finalFile.order[12] = finalFile.script.beautify;
+                            apioutput           = finalFile
+                                .order
+                                .join("");
+                        }
+                    }
+                    if (options.jsx === true) {
+                        options.autoval = ["jsx", "javascript", "React JSX"];
+                    }
+                    return output(apioutput, 0, 0);
+                }
+            };
+        return core(api);
+    };
+
+    if (typeof global.prettydiff !== "object") {
+        global.prettydiff = {};
+    }
+    if (typeof global.prettydiff.meta !== "object") {
+        // schema for global.prettydiff.meta lang - array, language detection time -
+        // string, proctime (total execution time minus visual rendering) insize -
+        // number, input size outsize - number, output size difftotal - number,
+        // difference count difflines - number, difference lines
+        global.prettydiff.meta = {
+            difflines: 0,
+            difftotal: 0,
+            error    : "",
+            insize   : 0,
+            lang     : [
+                "", "", ""
+            ],
+            outsize  : 0,
+            time     : ""
+        };
+    }
+    if (typeof process === "object" && Array.isArray(process.argv) === true && process.argv[1].replace(/\\/g, "/").replace(".js", "").split("prettydiff/prettydiff")[1] === "") {
+        return console.log("This file \u001b[31m\u001b[1mdoes not execute from the command line\u001b[0m\u001b[39m.  Use \u001b[32mapi/node-local.js\u001b[39m instead.");
+    }
+    if (typeof define === "function" && (typeof ace !== "object" || ace.prettydiffid === undefined)) {
+        define(function prettydiff_requirejs() {
+            return function prettydiff_requirejs_wrapper(x) {
+                return prettydiff(x);
+            };
+        });
+    } else if (typeof module === "object" && typeof module.parent === "object") {
+        //commonjs and nodejs support
+        module.exports         = function commonjs_prettydiff(x) {
+            return prettydiff(x);
+        };
+        module.exports.edition = global.prettydiff.edition;
+        module.exports.meta    = global.prettydiff.meta;
+        if (typeof require === "function" && (typeof ace !== "object" || ace.prettydiffid === undefined)) {
+            (function glib_prettydiff() {
+                var localPath = (
+                    typeof process === "object" && typeof process.cwd === "function" && (process.cwd() === "/" || (/^([a-z]:\\)$/).test(process.cwd()) === true) && typeof __dirname === "string"
+                )
+                    ? __dirname
+                    : ".";
+                if (global.prettydiff.language === undefined) {
+                    global.prettydiff.language = require(
+                        localPath + "/lib/language.js"
+                    );
+                }
+                if (global.prettydiff.finalFile === undefined) {
+                    global.prettydiff.finalFile = require(
+                        localPath + "/lib/finalFile.js"
+                    );
+                }
+                if (global.prettydiff.csspretty === undefined) {
+                    global.prettydiff.csspretty = require(
+                        localPath + "/lib/csspretty.js"
+                    );
+                }
+                if (global.prettydiff.csvpretty === undefined) {
+                    global.prettydiff.csvpretty = require(
+                        localPath + "/lib/csvpretty.js"
+                    );
+                }
+                if (global.prettydiff.diffview === undefined) {
+                    global.prettydiff.diffview = require(
+                        localPath + "/lib/diffview.js"
+                    );
+                }
+                if (global.prettydiff.jspretty === undefined) {
+                    global.prettydiff.jspretty = require(
+                        localPath + "/lib/jspretty.js"
+                    );
+                }
+                if (global.prettydiff.options === undefined) {
+                    global.prettydiff.options = require(
+                        localPath + "/lib/options.js"
+                    );
+                }
+                if (global.prettydiff.safeSort === undefined) {
+                    global.prettydiff.safeSort = require(
+                        localPath + "/lib/safeSort.js"
+                    );
+                }
+                if (global.prettydiff.markuppretty === undefined) {
+                    global.prettydiff.markuppretty = require(
+                        localPath + "/lib/markuppretty.js"
+                    );
+                }
+            }());
+        }
+    } else {
+        global.prettydiff.prettydiff = prettydiff;
+    }
+    global.prettydiff.edition        = {
+        addon        : {
+            ace: 160307
+        },
+        api          : {
+            dom      : 170521, //dom.js
+            nodeLocal: 170521 //node-local.js
+        },
+        css          : 170521, //css files
+        csspretty    : 170521, //csspretty lib
+        csvpretty    : 170514, //csvpretty lib
+        diffview     : 170521, //diffview lib
+        documentation: 170521, //documentation.xhtml and various guide pages
+        finalFile    : 170514, //HTML report generator
+        jspretty     : 170521, //jspretty lib
+        language     : 170514, //language lib
+        latest       : 0,
+        lint         : 170521, //unit test and lint automation as test/lint.js
+        markuppretty : 170521, //markuppretty lib
+        options      : 170521, //options management
+        prettydiff   : 170521, //this file
+        safeSort     : 170514, //safeSort lib
+        version      : "2.2.1", //version number
+        webtool      : 170521
+    };
+    global.prettydiff.edition.latest = (function edition_latest() {
+        return Math.max(
+            global.prettydiff.edition.css,
+            global.prettydiff.edition.csspretty,
+            global.prettydiff.edition.csvpretty,
+            global.prettydiff.edition.diffview,
+            global.prettydiff.edition.documentation,
+            global.prettydiff.edition.finalFile,
+            global.prettydiff.edition.jspretty,
+            global.prettydiff.edition.language,
+            global.prettydiff.edition.markuppretty,
+            global.prettydiff.edition.options,
+            global.prettydiff.edition.prettydiff,
+            global.prettydiff.edition.webtool,
+            global.prettydiff.edition.api.dom,
+            global.prettydiff.edition.api.nodeLocal
+        );
+    }());
+}());

--- a/package.json
+++ b/package.json
@@ -167,7 +167,6 @@
     "node-dir": "^0.1.16",
     "node-uuid": "^1.4.3",
     "open": "0.0.5",
-    "prettydiff": "^1.16.27",
     "pug-beautify": "^0.1.1",
     "remark": "^6.0.1",
     "season": "^5.3.0",

--- a/src/beautifiers/prettydiff.coffee
+++ b/src/beautifiers/prettydiff.coffee
@@ -127,8 +127,7 @@ module.exports = class PrettyDiff extends Beautifier
 
       # Beautify
       @verbose('prettydiff', options)
-      output = prettydiff.api(options)
-      result = output[0]
+      result = prettydiff(options)
 
       # Return beautified text
       resolve(result)

--- a/src/beautifiers/vue-beautifier.coffee
+++ b/src/beautifiers/vue-beautifier.coffee
@@ -37,14 +37,14 @@ module.exports = class VueBeautifier extends Beautifier
                   lang: "scss"
                   mode: "beautify"
                 )
-                prettydiff.api(options)[0]
+                prettydiff(options)
               when "less"
                 options = _.merge(options,
                   source: text
                   lang: "less"
                   mode: "beautify"
                 )
-                prettydiff.api(options)[0]
+                prettydiff(options)
               when undefined
                 require("js-beautify").css(text, options)
               else


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Brings Pretty Diff updates to Atom Beautify
...

### Does this close any currently open issues?
fixes #881
...

### Any other comments?
Pretty Diff is directly embedded.  It does not require any second or third party distribution.  The way to update Pretty Diff is to install over it from http://prettydiff.com/downloads/prettydiff/prettydiff_cli_latest.zip using biddle or manually.

When biddle version 2 is released the source will change from the Pretty Diff domain URI to a IPFS hash managed through the Pretty Diff domain.
...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
      * I did this, but seemed to generate faulty output by removing the final curly brace from package.json and changing the default value of YAML padding property, in options.json, to null
- [x] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
