### PR TITLE
Fix #1682. Removed --no-patch flag from phpcbf beautifier version 3

### DIFF
--- a/src/beautifiers/phpcbf.coffee
+++ b/src/beautifiers/phpcbf.coffee
@@ -76,7 +76,7 @@ module.exports = class PHPCBF extends Beautifier
       )
     else
       @run("phpcbf", [
-        "--no-patch"
+        "--no-patch" unless options.phpcbf_version is 3
         "--standard=#{options.standard}" if options.standard
         tempFile = @tempFile("temp", text)
         ], {


### PR DESCRIPTION


### What does this implement/fix? Explain your changes.

#1643 only fixed Windows. This applies the same fix to other platforms.

### Does this close any currently open issues?

#1682

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
