### PR TITLE
Add `.rb` to temp files passed to `rubocop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+- Fix [#1652](https://github.com/Glavin001/atom-beautify/issues/1652) and [#1653](https://github.com/Glavin001/atom-beautify/issues/1653). Add `.rb` to temp files passed in to the `rubocop` executable so they are not excluded.
 - ...
 
 # v0.29.26 (2017-05-28)

--- a/src/beautifiers/rubocop.coffee
+++ b/src/beautifiers/rubocop.coffee
@@ -51,7 +51,7 @@ module.exports = class Rubocop extends Beautifier
         @run(rubocopPath, [
           "--auto-correct"
           "--config", configFile
-          tempFile = @tempFile("temp", text)
+          tempFile = @tempFile("temp", text, '.rb')
           ], {ignoreReturnCode: true})
           .then(=>
             @readFile(tempFile)
@@ -60,7 +60,7 @@ module.exports = class Rubocop extends Beautifier
         @run("rubocop", [
           "--auto-correct"
           "--config", configFile
-          tempFile = @tempFile("temp", text)
+          tempFile = @tempFile("temp", text, '.rb')
           ], {ignoreReturnCode: true})
           .then(=>
             @readFile(tempFile)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Rubocop was excluding files  passed to it without a proper extension even if
they are passed as command line parameters. This adds a `.rb` to the filename
used for the temp files so they are always detected.

### Does this close any currently open issues?

#1652 and #1653 (they are duplicates).

### Any other comments?

Examples don't need to change, should be completely transparent.

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [x] Add change details to `CHANGELOG.md` under "Next" section
- [x] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
