### PR TITLE
Add goimports beautifier for Go language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+- Add goimports beautifier for Go language
 - ...
 
 # v0.30.1 (2017-06-19)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Some of the supported beautifiers are developed for Node.js and are automaticall
 | Fortran Beautifier | :warning: 1 executable | :x: No Docker support | :bookmark_tabs: Manually:<br/>1. Install [Emacs (`emacs`)](https://www.gnu.org/software/emacs/) by following https://www.gnu.org/software/emacs/<br/> |
 | Gherkin formatter | :white_check_mark: | :ok_hand: Not necessary | :smiley: Nothing! |
 | gofmt | :warning: Manual installation | :construction: Not an executable | :page_facing_up: Go to https://golang.org/cmd/gofmt/ and follow the instructions. |
+| goimports | :warning: 1 executable | :x: No Docker support | :bookmark_tabs: Manually:<br/>1. Install [goimports (`goimports`)](https://godoc.org/golang.org/x/tools/cmd/goimports) by following https://godoc.org/golang.org/x/tools/cmd/goimports<br/> |
 | hh_format | :warning: Manual installation | :construction: Not an executable | :page_facing_up: Go to http://hhvm.com/ and follow the instructions. |
 | HTML Beautifier | :warning: Manual installation | :construction: Not an executable | :page_facing_up: Go to https://github.com/threedaymonk/htmlbeautifier and follow the instructions. |
 | JS Beautify | :white_check_mark: | :ok_hand: Not necessary | :smiley: Nothing! |
@@ -142,7 +143,7 @@ See [all supported options in the documentation at  `docs/options.md`](docs/opti
 | Fortran | `Fortran - Modern` |`.f90`, `.F90`, `.f95`, `.F95`, `.f03`, `.F03`, `.f08`, `.F08` | **[`Fortran Beautifier`](https://www.gnu.org/software/emacs/)** |
 | gherkin | `Gherkin` |`.feature` | **[`Gherkin formatter`](https://github.com/Glavin001/atom-beautify/blob/master/src/beautifiers/gherkin.coffee)** |
 | GLSL | `C`, `opencl`, `GLSL` |`.vert`, `.frag` | **[`clang-format`](https://clang.llvm.org/docs/ClangFormat.html)** |
-| Go | `Go` |`.go` | **[`gofmt`](https://golang.org/cmd/gofmt/)** |
+| Go | `Go` |`.go` | **[`gofmt`](https://golang.org/cmd/gofmt/)**, [`goimports`](https://godoc.org/golang.org/x/tools/cmd/goimports) |
 | Golang Template | `HTML (Go)`, `Go Template` |`.gohtml` | **[`Pretty Diff`](https://github.com/prettydiff/prettydiff)** |
 | Handlebars | `Handlebars`, `HTML (Handlebars)` |`.hbs`, `.handlebars` | **[`JS Beautify`](https://github.com/beautify-web/js-beautify)**, [`Pretty Diff`](https://github.com/prettydiff/prettydiff) |
 | Haskell | `Haskell` |`.hs` | **[`stylish-haskell`](https://github.com/jaspervdj/stylish-haskell)** |

--- a/docs/options.md
+++ b/docs/options.md
@@ -249,6 +249,23 @@ Options for Emacs executable.
 2. Go into *Packages* and search for "*Atom Beautify*" package.
 3. Find the option "*Emacs*" and change it to your desired configuration.
 
+#####  [goimports](#goimports) 
+
+**Important**: This option is only configurable from within Atom Beautify's setting panel.
+
+**Type**: `object`
+
+**Description**:
+
+Options for goimports executable.
+
+**How to Configure**
+
+1. You can open the [Settings View](https://github.com/atom/settings-view) by navigating to
+*Edit > Preferences (Linux)*, *Atom > Preferences (OS X)*, or *File > Preferences (Windows)*.
+2. Go into *Packages* and search for "*Atom Beautify*" package.
+3. Find the option "*goimports*" and change it to your desired configuration.
+
 #####  [isort](#isort) 
 
 **Important**: This option is only configurable from within Atom Beautify's setting panel.
@@ -3920,13 +3937,13 @@ Path to clang-format config file. i.e. clang-format.cfg (Supported by clang-form
 
 ####  [Go](#go) 
 
-**Supported Beautifiers**:  [`gofmt`](#gofmt) 
+**Supported Beautifiers**:  [`gofmt`](#gofmt)  [`goimports`](#goimports) 
 
-| Option | gofmt |
-| --- | --- |
-| `disabled` | :white_check_mark: |
-| `default_beautifier` | :white_check_mark: |
-| `beautify_on_save` | :white_check_mark: |
+| Option | gofmt | goimports |
+| --- | --- | --- |
+| `disabled` | :white_check_mark: | :white_check_mark: |
+| `default_beautifier` | :white_check_mark: | :white_check_mark: |
+| `beautify_on_save` | :white_check_mark: | :white_check_mark: |
 
 **Description**:
 
@@ -3957,7 +3974,7 @@ Disable Go Beautification
 
 **Type**: `string`
 
-**Enum**:  `gofmt` 
+**Enum**:  `gofmt`  `goimports` 
 
 **Description**:
 

--- a/package.json
+++ b/package.json
@@ -396,7 +396,8 @@
     "nginx",
     "nginx beautify",
     "golang template",
-    "align-yaml"
+    "align-yaml",
+    "goimports"
   ],
   "devDependencies": {
     "coffeelint": "1.16.0"

--- a/src/beautifiers/goimports.coffee
+++ b/src/beautifiers/goimports.coffee
@@ -1,0 +1,36 @@
+###
+Requires https://godoc.org/golang.org/x/tools/cmd/goimports
+###
+
+"use strict"
+Beautifier = require('./beautifier')
+
+module.exports = class Goimports extends Beautifier
+  name: "goimports"
+  link: "https://godoc.org/golang.org/x/tools/cmd/goimports"
+  executables: [
+    {
+      name: "goimports"
+      cmd: "goimports"
+      homepage: "https://godoc.org/golang.org/x/tools/cmd/goimports"
+      installation: "https://godoc.org/golang.org/x/tools/cmd/goimports"
+      version: {
+        # Does not display version
+        args: ['--help'],
+        parse: (text) -> text.indexOf("usage: goimports") isnt -1 and "0.0.0",
+        runOptions: {
+          ignoreReturnCode: true,
+          returnStderr: true
+        }
+      }
+    }
+  ]
+
+  options: {
+    Go: false
+  }
+
+  beautify: (text, language, options) ->
+    @exe("goimports").run([
+      @tempFile("input", text)
+      ])

--- a/src/beautifiers/index.coffee
+++ b/src/beautifiers/index.coffee
@@ -49,6 +49,7 @@ module.exports = class Beautifiers extends EventEmitter
     'csscomb'
     'gherkin'
     'gofmt'
+    'goimports'
     'latex-beautify'
     'fortran-beautifier'
     'js-beautify'

--- a/src/options.json
+++ b/src/options.json
@@ -2085,7 +2085,8 @@
     "description": "Options for language Go",
     "collapsed": true,
     "beautifiers": [
-      "gofmt"
+      "gofmt",
+      "goimports"
     ],
     "grammars": [
       "Go"
@@ -2108,7 +2109,8 @@
         "default": "gofmt",
         "description": "Default Beautifier to be used for Go",
         "enum": [
-          "gofmt"
+          "gofmt",
+          "goimports"
         ]
       },
       "beautify_on_save": {
@@ -9241,6 +9243,22 @@
             "type": "string",
             "default": "",
             "description": "Absolute path to the \"elm-format\" executable's binary/script."
+          }
+        }
+      },
+      "goimports": {
+        "key": "goimports",
+        "title": "goimports",
+        "type": "object",
+        "collapsed": true,
+        "description": "Options for goimports executable.",
+        "properties": {
+          "path": {
+            "key": "path",
+            "title": "Binary/Script Path",
+            "type": "string",
+            "default": "",
+            "description": "Absolute path to the \"goimports\" executable's binary/script."
           }
         }
       },


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
This adds goimports beautifier for Go language.

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [x] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [x] Travis CI passes (Mac support)
- [x] AppVeyor passes (Windows support)
