### PR TITLE
Fix for latexindent v3

### DIFF
--- a/src/beautifiers/latex-beautify.coffee
+++ b/src/beautifiers/latex-beautify.coffee
@@ -59,11 +59,11 @@ module.exports = class LatexBeautify extends Beautifier
     .then((dirPath)=>
       @setUpDir(dirPath, text, @buildConfigFile(options))
       run = @run "latexindent", [
-        "-o"            #Output to the same location as file, -w creates a backup file, whereas this does not
         "-s"            #Silent mode
         "-l"            #Tell latexindent we have a local configuration file
         "-c=" + dirPath #Tell latexindent to place the log file in this directory
         @texFile
+        "-o"            #Output to the same location as file, -w creates a backup file, whereas this does not
         @texFile
       ], help: {
         link: "https://github.com/cmhughes/latexindent.pl"


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

The new latex indent v3.2.2 has fixed the [issue #1564](https://github.com/Glavin001/atom-beautify/issues/1564#issuecomment-311768474), but it changes its flag order as mentioned by @cmhughes:
> I think I see the problem: the -o switch changed a little bit in v3.0 of latexindent.pl, and needs the output file to be specified next to the -o switch, for example:
latexindent.pl myfile.tex -o output.tex
So, if you move the -o switch in between the two @texfile statements, that might work.

### Does this close any currently open issues?

Yes, it closes [issue #1564](https://github.com/Glavin001/atom-beautify/issues/1564#issuecomment-311768474).

### Any other comments?

@cmhughes suggested to use 
```shell
latexindent.pl myfile.tex -w
```
instead of 
```shell
latexindent.pl myfile.tex -o myfile.tex
```
maybe we can consider it as an option in the settings menu.

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)