### PR TITLE
Rustfmt nightly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Next
 - Fixes #1638. update type-formatter and Fixes indent size not supported
+- Add support for rustfmt-nightly
 
 # v0.30.4 (2017-07-14)
 - Fixes #1732. Improve deprecation message for old options for new Executables

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Some of the supported beautifiers are developed for Node.js and are automaticall
 | Remark | :white_check_mark: | :ok_hand: Not necessary | :smiley: Nothing! |
 | Rubocop | :warning: Manual installation | :construction: Not an executable | :page_facing_up: Go to https://github.com/bbatsov/rubocop and follow the instructions. |
 | Ruby Beautify | :warning: Manual installation | :construction: Not an executable | :page_facing_up: Go to https://github.com/erniebrodeur/ruby-beautify and follow the instructions. |
-| rustfmt | :warning: Manual installation | :construction: Not an executable | :page_facing_up: Go to https://github.com/nrc/rustfmt and follow the instructions. |
+| rustfmt | :warning: Manual installation | :construction: Not an executable | :page_facing_up: Go to https://github.com/rust-lang-nursery/rustfmt and follow the instructions. |
 | SassConvert | :warning: 1 executable | :white_check_mark: :100:% of executables | :whale: With [Docker](https://www.docker.com/):<br/>1. Install [SassConvert (`sass-convert`)](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#syntax) with `docker pull unibeautify/sass-convert`<br/><br/>:bookmark_tabs: Manually:<br/>1. Install [SassConvert (`sass-convert`)](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#syntax) by following http://sass-lang.com/documentation/file.SASS_REFERENCE.html#syntax<br/> |
 | sqlformat | :warning: Manual installation | :construction: Not an executable | :page_facing_up: Go to https://github.com/andialbrecht/sqlparse and follow the instructions. |
 | stylish-haskell | :warning: Manual installation | :construction: Not an executable | :page_facing_up: Go to https://github.com/jaspervdj/stylish-haskell and follow the instructions. |
@@ -171,7 +171,7 @@ See [all supported options in the documentation at  `docs/options.md`](docs/opti
 | R | `R` |`.r`, `.R` | **[`formatR`](https://github.com/yihui/formatR)** |
 | Riot.js | `Riot.js`, `HTML (Riot Tag)` |`.tag` | **[`Pretty Diff`](https://github.com/prettydiff/prettydiff)** |
 | Ruby | `Ruby`, `Ruby on Rails` |`.rb` | **[`Rubocop`](https://github.com/bbatsov/rubocop)**, [`Ruby Beautify`](https://github.com/erniebrodeur/ruby-beautify) |
-| Rust | `Rust` |`.rs`, `.rlib` | **[`rustfmt`](https://github.com/nrc/rustfmt)** |
+| Rust | `Rust` |`.rs`, `.rlib` | **[`rustfmt`](https://github.com/rust-lang-nursery/rustfmt)** |
 | Sass | `Sass` |`.sass` | **[`SassConvert`](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#syntax)** |
 | SCSS | `SCSS` |`.scss` | **[`Pretty Diff`](https://github.com/prettydiff/prettydiff)**, [`CSScomb`](https://github.com/csscomb/csscomb.js), [`SassConvert`](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#syntax) |
 | Spacebars | `Spacebars` | | **[`Pretty Diff`](https://github.com/prettydiff/prettydiff)** |

--- a/docs/code/class/Rustfmt.html
+++ b/docs/code/class/Rustfmt.html
@@ -54,7 +54,7 @@
     =
   </dt>
   <dd>
-    <pre><code class='coffeescript'>&quot;https:&#47;&#47;github.com&#47;nrc&#47;rustfmt&quot;</code></pre>
+    <pre><code class='coffeescript'>&quot;https:&#47;&#47;github.com&#47;rust-lang-nursery&#47;rustfmt&quot;</code></pre>
     
   </dd>
   <dt id='options-variable'>

--- a/docs/code/extra/README.md.html
+++ b/docs/code/extra/README.md.html
@@ -379,7 +379,7 @@ Thank you.</p><h2 id="language-support">Language Support</h2><p>See <a href="htt
 <td>Rust</td>
 <td><code>Rust</code></td>
 <td><code>.rs</code>, <code>.rlib</code></td>
-<td><a href="https://github.com/nrc/rustfmt"><code>rustfmt</code></a> (Default)</td>
+<td><a href="https://github.com/rust-lang-nursery/rustfmt"><code>rustfmt</code></a> (Default)</td>
 </tr>
 <tr>
 <td>Sass</td>

--- a/src/beautifiers/rustfmt.coffee
+++ b/src/beautifiers/rustfmt.coffee
@@ -1,5 +1,5 @@
 ###
-Requires https://github.com/nrc/rustfmt
+Requires https://github.com/rust-lang-nursery/rustfmt
 ###
 
 "use strict"
@@ -10,7 +10,7 @@ versionCheckState = false
 
 module.exports = class Rustfmt extends Beautifier
   name: "rustfmt"
-  link: "https://github.com/nrc/rustfmt"
+  link: "https://github.com/rust-lang-nursery/rustfmt"
   isPreInstalled: false
 
   options: {
@@ -21,7 +21,7 @@ module.exports = class Rustfmt extends Beautifier
     cwd = context.filePath and path.dirname context.filePath
     program = options.rustfmt_path or "rustfmt"
     help = {
-      link: "https://github.com/nrc/rustfmt"
+      link: "https://github.com/rust-lang-nursery/rustfmt"
       program: "rustfmt"
       pathOption: "Rust - Rustfmt Path"
     }

--- a/src/beautifiers/rustfmt.coffee
+++ b/src/beautifiers/rustfmt.coffee
@@ -34,7 +34,7 @@ module.exports = class Rustfmt extends Beautifier
     else
       @run(program, ["--version"], help: help)
         .then((stdout) ->
-          if /^0\.(?:[0-4]\.[0-9])/.test(stdout.trim())
+          if /^0\.(?:[0-4]\.[0-9])(?!-nightly)/.test(stdout.trim())
             versionCheckState = false
             throw new Error("rustfmt version 0.5.0 or newer required")
           else


### PR DESCRIPTION
This PR enables running newish rustfmt tool (known as rustfmt-nightly).
Its version numbering scheme has been restarted from 0.1.0.
To whitelist these new builds, the version regex was changed to only trigger when the version numbers are NOT followed by `-nightly` suffix.

See #358 

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [x] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [x] Travis CI passes (Mac support)
- [x] AppVeyor passes (Windows support)
