### PR TITLE
Fix for #1721

### DIFF
--- a/src/beautify.coffee
+++ b/src/beautify.coffee
@@ -542,9 +542,10 @@ handleSaveEvent = ->
             # It will add a newline and keep the file from converging on a beautified form
             # and saving without emitting onDidSave event, because there were no changes.
             pendingPaths[filePath] = true
-            editor.save()
-            delete pendingPaths[filePath]
-            logger.verbose('Saved TextEditor.')
+            Promise.resolve(editor.save()).then(() ->
+              delete pendingPaths[filePath]
+              logger.verbose('Saved TextEditor.')
+            )
         )
         .catch((error) ->
           return showError(error)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Fix to handle the async save operation of editor.save() released in Atom 1.19. Resolves promise from editor.save before deleting pendingPaths and logging it.

### Does this close any currently open issues?
https://github.com/Glavin001/atom-beautify/issues/1721 and https://github.com/Glavin001/atom-beautify/issues/1801

### Any other comments?
First pull request ever on GitHub, please provide any feedback on improvements.

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
