### PR TITLE
Add basic Laravel Blade template support #448

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
 
 env:
   global:
-    - APM_TEST_PACKAGES="language-marko language-html-swig language-svg language-d mavensmate-atom language-lua"
+    - APM_TEST_PACKAGES="language-marko language-html-swig language-svg language-d mavensmate-atom language-lua language-blade"
     - PATH="/home/travis/gopath/bin:$HOME/.linuxbrew/bin:$PATH"
 
 addons:

--- a/examples/simple-jsbeautifyrc/blade/expected/test.blade.php
+++ b/examples/simple-jsbeautifyrc/blade/expected/test.blade.php
@@ -1,0 +1,20 @@
+<html>
+
+<head>
+  <title>App Name - @yield('title')</title>
+</head>
+
+<body>
+  @section('sidebar') This is the {{ $mater }} sidebar. @show
+
+  <div class="container">
+    @yield('content')
+  </div>
+
+  @component('alert') @slot('title') Forbidden @endslot
+  <strong>Whoops!</strong> Something went wrong! @endcomponent @foreach ($users as $user) @if ($user->type == 1) @continue @endif
+  <li>{{ $user->name }}</li>
+  @if ($user->number == 5) @break @endif @endforeach
+</body>
+
+</html>

--- a/examples/simple-jsbeautifyrc/blade/original/_test.blade.php
+++ b/examples/simple-jsbeautifyrc/blade/original/_test.blade.php
@@ -1,0 +1,31 @@
+<html>
+<head>
+<title>App Name - @yield('title')</title>
+</head>
+<body>
+@section('sidebar')
+This is the {{ $mater }} sidebar.
+@show
+
+<div class="container">
+@yield('content')
+</div>
+
+@component('alert')
+@slot('title')
+Forbidden
+@endslot
+<strong>Whoops!</strong> Something went wrong!
+@endcomponent
+
+@foreach ($users as $user)
+@if ($user->type == 1)
+@continue
+@endif
+<li>{{ $user->name }}</li>
+@if ($user->number == 5)
+@break
+@endif
+@endforeach
+</body>
+</html>

--- a/spec/beautify-languages-spec.coffee
+++ b/spec/beautify-languages-spec.coffee
@@ -49,7 +49,7 @@ describe "BeautifyLanguages", ->
     "mustache", "objective-c", "perl", "php",
     "python", "ruby", "sass", "sql", "svg",
     "xml", "csharp", "gfm", "marko",
-    "go", "html-swig", "lua"
+    "go", "html-swig", "lua", "blade"
     ]
   # All Atom packages that Atom Beautify is dependent on
   dependentPackages = [

--- a/src/beautifiers/js-beautify.coffee
+++ b/src/beautifiers/js-beautify.coffee
@@ -6,7 +6,7 @@ module.exports = class JSBeautify extends Beautifier
   link: "https://github.com/beautify-web/js-beautify"
 
   options: {
-    # Blade: true
+    Blade: true
     HTML: true
     XML: true
     Handlebars: true

--- a/src/beautifiers/js-beautify.coffee
+++ b/src/beautifiers/js-beautify.coffee
@@ -6,6 +6,7 @@ module.exports = class JSBeautify extends Beautifier
   link: "https://github.com/beautify-web/js-beautify"
 
   options: {
+    # Blade: true
     HTML: true
     XML: true
     Handlebars: true
@@ -42,7 +43,7 @@ module.exports = class JSBeautify extends Beautifier
             beautifyHTML = require("js-beautify").html
             text = beautifyHTML(text, options)
             resolve text
-          when "EJS", "HTML (Liquid)", "HTML", "XML", "Web Form/Control (C#)", "Web Handler (C#)"
+          when "Blade", "EJS", "HTML (Liquid)", "HTML", "XML", "Web Form/Control (C#)", "Web Handler (C#)"
             beautifyHTML = require("js-beautify").html
             text = beautifyHTML(text, options)
             @debug("Beautified HTML: #{text}")

--- a/src/languages/blade.coffee
+++ b/src/languages/blade.coffee
@@ -1,0 +1,22 @@
+module.exports = {
+
+  name: "Blade"
+  namespace: "blade"
+  fallback: ["html", "php"]
+
+  ###
+  Supported Grammars
+  ###
+  grammars: [
+    "Blade"
+  ]
+
+  ###
+  Supported extensions
+  ###
+  extensions: [
+    "php"
+  ]
+
+  options: []
+}

--- a/src/languages/index.coffee
+++ b/src/languages/index.coffee
@@ -15,6 +15,7 @@ module.exports = class Languages
     "apex"
     "arduino"
     "bash"
+    "blade"
     "c-sharp"
     "c"
     "clojure"


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Add basic Laravel Blade template support.
All the HTML tags in the .blade.php files are now able to be beautified.
...

### Does this close any currently open issues?
Issue #448
But Blade directives don't indent properly
...

### Any other comments?
To fix: Blade directives don't indent properly
Please advice.
...

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [X] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
