### PR TITLE
Fix deprecation warning and Travis Ubuntu build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,11 +108,11 @@ before_install:
     fi
   # Python language support
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo chmod 777 -R /opt/python; fi
-  - pip install --upgrade pip
-  - pip install --upgrade autopep8
-  - pip install --upgrade isort
+  - pip install --user --upgrade pip
+  - pip install --user --upgrade autopep8
+  - pip install --user --upgrade isort
   # SQL language support
-  - pip install --upgrade sqlparse
+  - pip install --user --upgrade sqlparse
   # Java, C, C++, C#, Objective-C, D, Pawn, Vala
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew install uncrustify;
@@ -167,4 +167,4 @@ before_install:
   # Crystal
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install crystal-lang; fi
   # Bash
-  - pip install beautysh
+  - pip install --user beautysh

--- a/package.json
+++ b/package.json
@@ -146,6 +146,10 @@
     {
       "name": "Kamontat Chantrachirathumrong",
       "url": "https://github.com/kamontat"
+    },
+    {
+      "name": "Steven Zeck",
+      "url": "https://github.com/szeck87"
     }
   ],
   "engines": {

--- a/src/beautifiers/executable.coffee
+++ b/src/beautifiers/executable.coffee
@@ -133,7 +133,7 @@ class Executable
     @debug("Run: ", @cmd, args, options)
     { cmd, cwd, ignoreReturnCode, help, onStdin, returnStderr, returnStdoutOrStderr } = options
     exeName = cmd or @cmd
-    cwd ?= os.tmpDir()
+    cwd ?= os.tmpdir()
     help ?= {
       program: @cmd
       link: @installation or @homepage
@@ -213,7 +213,7 @@ class Executable
     Promise.all(args)
 
   relativizePaths: (args) ->
-    tmpDir = os.tmpDir()
+    tmpDir = os.tmpdir()
     newArgs = args.map((arg) ->
       isTmpFile = (typeof arg is 'string' and not arg.includes(':') and \
         path.isAbsolute(arg) and path.dirname(arg).startsWith(tmpDir))
@@ -410,7 +410,7 @@ class HybridExecutable extends Executable
     this.resolveArgs(args)
       .then((args) =>
         { cwd } = options
-        tmpDir = os.tmpDir()
+        tmpDir = os.tmpdir()
         pwd = fs.realpathSync(cwd or tmpDir)
         image = @dockerOptions.image
         workingDir = @dockerOptions.workingDir


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Fix for #1833 and #1844
...

### Does this close any currently open issues?
#1833 and #1844 
...

### Any other comments?
The Mac build is still failing due to an issue with ocp-indent and topkg, but this fixes the Linux/Ubuntu build. Solution taken from this comment:  https://github.com/travis-ci/travis-ci/issues/8378#issuecomment-328484987
...

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [X] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
