### PR TITLE
Fix Travis CI builds for Linux and MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -169,6 +169,10 @@ before_install:
       brew install opam;
     fi
   - opam init --auto-setup
+  # Init environment variables for opam
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      eval `opam config env`;
+    fi  
   - opam install --yes ocp-indent
   # Crystal
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install crystal-lang; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,10 +107,16 @@ before_install:
       docker pull unibeautify/sass-convert;
     fi
   # Python language support
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo chmod 777 -R /opt/python; fi
-  - pip install --upgrade pip
-  - pip install --user --upgrade autopep8
-  - pip install --user --upgrade isort
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      sudo chmod 777 -R /opt/python;
+      pip install --upgrade pip;
+      pip install --user --upgrade autopep8;
+      pip install --user --upgrade isort;
+    else
+      pip install --upgrade pip;
+      pip install --upgrade autopep8;
+      pip install --upgrade isort;    
+    fi
   # SQL language support
   - pip install --user --upgrade sqlparse
   # Java, C, C++, C#, Objective-C, D, Pawn, Vala

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ before_install:
     else
       pip install --upgrade pip;
       pip install --upgrade autopep8;
-      pip install --upgrade isort;    
+      pip install --upgrade isort;
     fi
   # SQL language support
   - pip install --user --upgrade sqlparse
@@ -173,4 +173,8 @@ before_install:
   # Crystal
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install crystal-lang; fi
   # Bash
-  - pip install --user beautysh
+  - if [[ "$TRAVIS_OS_NAME" == "linux"]]; then
+      pip install --user beautysh;
+    else
+      pip install beautysh;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,10 +109,10 @@ before_install:
   # Python language support
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo chmod 777 -R /opt/python; fi
   - pip install --upgrade pip
-  - pip install --upgrade autopep8
-  - pip install --upgrade isort
+  - pip install --user --upgrade autopep8
+  - pip install --user --upgrade isort
   # SQL language support
-  - pip install --upgrade sqlparse
+  - pip install --user --upgrade sqlparse
   # Java, C, C++, C#, Objective-C, D, Pawn, Vala
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew install uncrustify;
@@ -167,4 +167,4 @@ before_install:
   # Crystal
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install crystal-lang; fi
   # Bash
-  - pip install beautysh
+  - pip install --user beautysh

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,11 @@ before_install:
       pip install --upgrade isort;
     fi
   # SQL language support
-  - pip install --user --upgrade sqlparse
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      pip install --user --upgrade sqlparse;
+    else
+      pip install --upgrade sqlparse;
+    fi
   # Java, C, C++, C#, Objective-C, D, Pawn, Vala
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew install uncrustify;

--- a/package.json
+++ b/package.json
@@ -146,6 +146,10 @@
     {
       "name": "Kamontat Chantrachirathumrong",
       "url": "https://github.com/kamontat"
+    },
+    {
+      "name": "Steven Zeck",
+      "url": "https://github.com/szeck87"
     }
   ],
   "engines": {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Fixes the Ubuntu/Linux portion of the Travis CI builds due to recent Linux image changes in Travis. Also fixes MacOS Travis build with a new version of ocaml 4.05.0 causing installation issues with ocp-indent
...

### Does this close any currently open issues?
#1844 
...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [X] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [X] Travis CI passes (Mac support)
- [X] AppVeyor passes (Windows support)
