### PR TITLE
Add lib to gitignore, src to npmignore, package.json & tsconfig updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.js
 *.js.map
 src/*.d.ts
+lib/
 
 ### https://raw.github.com/github/gitignore/77e29837cf03b59fc4d885ea011bbd683caaaf85/node.gitignore
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.js
 *.js.map
 src/*.d.ts
-lib/
+dist/
 
 ### https://raw.github.com/github/gitignore/77e29837cf03b59fc4d885ea011bbd683caaaf85/node.gitignore
 

--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,4 @@ examples/
 .travis.yml
 appveyor.yml
 *.md
+src/

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Or Settings/Preferences ➔ Packages ➔ Search for `atom-beautify`
 
 ## Contribute
 1. Clone the repository
-1. `cd 'atom-beautify'`
-1. Run `npm install`
-1. Run `apm link` (if necessary)
-1. Install [atom-typescript](https://atom.io/packages/atom-typescript) (if using Atom)
-1. Typescript files in `/src` will be compiled to Javascript and saved in `/lib` whenever a file is saved
+2. `cd 'atom-beautify'`
+3. Run `npm install`
+4. Run `apm link` (if necessary)
+5. Install [atom-typescript](https://atom.io/packages/atom-typescript) (if using Atom)
+6. Typescript files in `/src` will be compiled to Javascript and saved in `/lib` whenever a file is saved

--- a/README.md
+++ b/README.md
@@ -26,3 +26,11 @@ apm install atom-beautify
 ```
 
 Or Settings/Preferences ➔ Packages ➔ Search for `atom-beautify`
+
+## Contribute
+1. Clone the repository
+1. `cd 'atom-beautify'`
+1. Run `npm install`
+1. Run `apm link` (if necessary)
+1. Install [atom-typescript](https://atom.io/packages/atom-typescript) (if using Atom)
+1. Typescript files in `/src` will be compiled to Javascript and saved in `/lib` whenever a file is saved

--- a/menus/atom-beautify.json
+++ b/menus/atom-beautify.json
@@ -1,0 +1,34 @@
+{
+  "context-menu": {
+    "atom-text-editor": [
+      {
+        "label": "Beautify editor contents",
+        "command": "atom-beautify:beautify-editor"
+      },
+      {
+        "label": "Debug Atom Beautify",
+        "command": "atom-beautify:help-debug-editor"
+      }
+    ]
+  },
+  "menu": [
+    {
+      "label": "Packages",
+      "submenu": [
+        {
+          "label": "Atom Beautify",
+          "submenu": [
+            {
+              "label": "Beautify editor contents",
+              "command": "atom-beautify:beautify-editor"
+            },
+            {
+              "label": "Debug Atom Beautify",
+              "command": "atom-beautify:help-debug-editor"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atom-beautify",
-  "main": "./src/index.js",
+  "main": "./dist/index.js",
   "version": "0.29.11",
   "private": true,
   "description": "Beautifier for Atom powered by Unibeautify",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.6",
-    "typescript": "^2.0.3",
+    "typescript": "^2.5.3",
     "unibeautify": "^0.1.5"
   },
   "activationCommands": {
@@ -139,8 +139,9 @@
     "@types/event-kit": "^1.2.29",
     "@types/lodash": "^4.14.36",
     "@types/node": "^6.0.41",
+    "@types/atom": "^1.21.4",
     "tslint": "^3.15.1",
-    "typescript": "^2.0.3"
+    "typescript": "^2.5.3"
   },
   "scripts": {
     "start": "tsc --watch"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+    "compileOnSave": true,
     "compilerOptions": {
         "module": "commonjs",
         "noImplicitAny": true,
@@ -7,13 +8,15 @@
         "sourceMap": true,
         "target": "ES6",
         "declaration": true,
-        "moduleResolution": "node"
+        "moduleResolution": "node",
+        "outDir": "lib"
     },
     "include": [
         "./declarations.d.ts",
         "./src/**/*.ts",
         "./script/**/*.ts",
-        "./test/**/*.ts"
+        "./test/**/*.ts",
+        "src"
     ],
     "exclude": [
         "./node_modules"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,14 +9,13 @@
         "target": "ES6",
         "declaration": true,
         "moduleResolution": "node",
-        "outDir": "lib"
+        "outDir": "dist"
     },
     "include": [
         "./declarations.d.ts",
         "./src/**/*.ts",
         "./script/**/*.ts",
-        "./test/**/*.ts",
-        "src"
+        "./test/**/*.ts"
     ],
     "exclude": [
         "./node_modules"


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
- Updates Typescript dependency
- If using Atom and the atom-typescript package, saving .ts files in src will compile them into .js files in lib (from change in tsconfig.json)
- Ignore lib directory in git
- Ignore src directory in npm
- Add Atom Beautify to the top menu
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
