### PR TITLE
Run brew update as suggested workaround for Ruby version issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ before_install:
       git clone --depth=1 https://github.com/Linuxbrew/brew.git ~/.linuxbrew || true;
     fi
   # Update Homebrew
-  # - brew update
+  - brew update
   - brew tap homebrew/dupes
   - brew tap homebrew/versions
   # Ruby language support


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Homebrew requires Ruby 2.3 to run.  The Travis images for OSX are outdated, and the only way to get Homebrew working is to run `brew update` before doing anything else, as suggested in https://github.com/Homebrew/brew/issues/3299.
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [X] Travis CI passes (Mac support)
- [X] AppVeyor passes (Windows support)
