### PR TITLE
Allow 0 for minor and patch versions of docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Next
 - See [#881](https://github.com/Glavin001/atom-beautify/issues/881). Update to Prettydiff version 2!
+- Fix for [#1888](https://github.com/Glavin001/atom-beautify/issues/1888). Allow 0 for minor and patch versions of Docker
 - ...
 
 # v0.30.5 (2017-08-11)

--- a/package.json
+++ b/package.json
@@ -146,6 +146,10 @@
     {
       "name": "Kamontat Chantrachirathumrong",
       "url": "https://github.com/kamontat"
+    },
+    {
+      "name": "Steven Zeck",
+      "url": "https://github.com/szeck87"
     }
   ],
   "engines": {

--- a/src/beautifiers/executable.coffee
+++ b/src/beautifiers/executable.coffee
@@ -379,7 +379,7 @@ class HybridExecutable extends Executable
         homepage: "https://www.docker.com/"
         installation: "https://www.docker.com/get-docker"
         version: {
-          parse: (text) -> text.match(/version [0]*([1-9]\d*).[0]*([1-9]\d*).[0]*([1-9]\d*)/).slice(1).join('.')
+          parse: (text) -> text.match(/version [0]*([1-9]\d*).[0]*([0-9]\d*).[0]*([0-9]\d*)/).slice(1).join('.')
         }
       })
     return @docker


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Docker for Mac's current version is:  `Docker version 17.09.0-ce, build afdb6d4`.  Atom Beautify is failing to run Docker images because the regex expects a number between 1-9 for the major, minor, and patch versions of semver.  So when the above is run against match on https://github.com/Glavin001/atom-beautify/blob/master/src/beautifiers/executable.coffee#L382, it fails because of the `.0`.

This fix allows 0 for both the minor and patch versions.  I don't expect the major version number for Docker to ever be 0, so no change there.
...

### Does this close any currently open issues?
#1888 
...

### Any other comments?
...

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [X] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [X] Travis CI passes (Mac support)
- [X] AppVeyor passes (Windows support)
