### PR TITLE
Specify order of files when running spec tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ matrix:
     - os: osx
       env:
         - ATOM_CHANNEL=stable
+      rvm: 2.3.1
     # - os: osx
     #   env:
     #     - ATOM_CHANNEL=beta

--- a/build-package.sh
+++ b/build-package.sh
@@ -100,7 +100,9 @@ fi
 
 if [ -d ./spec ]; then
   echo "Running specs..."
-  "$ATOM_SCRIPT_PATH" --test spec
+  "$ATOM_SCRIPT_PATH" --test spec/atom-beautify-spec.coffee
+  "$ATOM_SCRIPT_PATH" --test spec/beautifier-php-cs-fixer-spec.coffee
+  "$ATOM_SCRIPT_PATH" --test spec/beautify-languages-spec.coffee
 else
   echo "Missing spec folder! Please consider adding a test suite in `./spec`"
   exit 1


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
A suggestion from Travis support is to specify the order in which to run the `spec` files during the build to try and fix the issues with master branch always failing.

This simply specifies the name of each file in the desired order when running the specs, versus just the folder itself.
...

### Does this close any currently open issues?

...

### Any other comments?
If this doesn't work we can revert this change.  If it does, we'll need to update the build file for any spec files added in the future.
...

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [X] Travis CI passes (Mac support)
- [X] AppVeyor passes (Windows support)
