### PR TITLE
autopep8: add option to respect user config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 - See [#881](https://github.com/Glavin001/atom-beautify/issues/881). Update to Prettydiff version 2!
 - Fix for [#1888](https://github.com/Glavin001/atom-beautify/issues/1888). Allow 0 for minor and patch versions of Docker
+- See [#1897](https://github.com/Glavin001/atom-beautify/issues/1897). Add an option that allows autopep8 to use the user config file in `.config/pep8` than rather always overriding it with the CLI arguments.
 - ...
 
 # v0.30.5 (2017-08-11)

--- a/docs/options.md
+++ b/docs/options.md
@@ -10262,6 +10262,7 @@ Automatically beautify Puppet files on save
 | `disabled` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `default_beautifier` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `beautify_on_save` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `cli_options` | :white_check_mark: | :white_check_mark: | :x: |
 | `formater` | :white_check_mark: | :white_check_mark: | :x: |
 | `ignore` | :white_check_mark: | :white_check_mark: | :x: |
 | `indent_size` | :white_check_mark: | :white_check_mark: | :x: |
@@ -10328,6 +10329,32 @@ Automatically beautify Python files on save
 *Edit > Preferences (Linux)*, *Atom > Preferences (OS X)*, or *File > Preferences (Windows)*.
 2. Go into *Packages* and search for "*Atom Beautify*" package.
 3. Find the option "*Beautify On Save*" and change it to your desired configuration.
+
+#####  [Cli options](#cli-options) 
+
+**Namespace**: `python`
+
+**Key**: `cli_options`
+
+**Default**: `true`
+
+**Type**: `boolean`
+
+**Supported Beautifiers**:  [`autopep8`](#autopep8)  [`pybeautifier`](#pybeautifier) 
+
+**Description**:
+
+Override autopep8 config with CLI options (Supported by autopep8, pybeautifier)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "python": {
+        "cli_options": true
+    }
+}
+```
 
 #####  [Formater](#formater) 
 
@@ -19902,6 +19929,32 @@ The amount of padding to add next to each line. (Supported by align-yaml)
 
 ### autopep8
 
+#####  [Cli options](#cli-options) 
+
+**Namespace**: `python`
+
+**Key**: `cli_options`
+
+**Default**: `true`
+
+**Type**: `boolean`
+
+**Supported Beautifiers**:  [`autopep8`](#autopep8)  [`pybeautifier`](#pybeautifier) 
+
+**Description**:
+
+Override autopep8 config with CLI options (Supported by autopep8, pybeautifier)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "python": {
+        "cli_options": true
+    }
+}
+```
+
 #####  [Max line length](#max-line-length) 
 
 **Namespace**: `python`
@@ -20254,6 +20307,32 @@ Indentation size/length (Supported by formatR)
 
 
 ### pybeautifier
+
+#####  [Cli options](#cli-options) 
+
+**Namespace**: `python`
+
+**Key**: `cli_options`
+
+**Default**: `true`
+
+**Type**: `boolean`
+
+**Supported Beautifiers**:  [`autopep8`](#autopep8)  [`pybeautifier`](#pybeautifier) 
+
+**Description**:
+
+Override autopep8 config with CLI options (Supported by autopep8, pybeautifier)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "python": {
+        "cli_options": true
+    }
+}
+```
 
 #####  [Max line length](#max-line-length) 
 

--- a/src/beautifiers/autopep8.coffee
+++ b/src/beautifiers/autopep8.coffee
@@ -49,9 +49,9 @@ module.exports = class Autopep8 extends Beautifier
     @exe("autopep8").run([
         tempFile = @tempFile("input", text)
         "-i"
-        ["--max-line-length", "#{options.max_line_length}"] if options.max_line_length?
-        ["--indent-size","#{options.indent_size}"] if options.indent_size?
-        ["--ignore","#{options.ignore.join(',')}"] if options.ignore?
+        ["--max-line-length", "#{options.max_line_length}"] if (options.max_line_length? && options.cli_options)
+        ["--indent-size","#{options.indent_size}"] if (options.indent_size? && options.cli_options)
+        ["--ignore","#{options.ignore.join(',')}"] if (options.ignore? && options.cli_options)
       ])
       .then(=>
         if options.sort_imports

--- a/src/languages/python.coffee
+++ b/src/languages/python.coffee
@@ -19,6 +19,10 @@ module.exports = {
   ]
 
   options:
+    cli_options:
+      type: 'boolean'
+      default: true
+      description: "Override autopep8 config with CLI options"
     max_line_length:
       type: 'integer'
       default: 79

--- a/src/options.json
+++ b/src/options.json
@@ -6057,6 +6057,21 @@
       "py"
     ],
     "properties": {
+      "cli_options": {
+        "type": "boolean",
+        "default": true,
+        "description": "Override autopep8 config with CLI options (Supported by autopep8, pybeautifier)",
+        "title": "Cli options",
+        "beautifiers": [
+          "autopep8",
+          "pybeautifier"
+        ],
+        "key": "cli_options",
+        "language": {
+          "name": "Python",
+          "namespace": "python"
+        }
+      },
       "max_line_length": {
         "type": "integer",
         "default": 79,


### PR DESCRIPTION
Apparently for autopep8 CLI options and user config file (`.config/pep8`) are mutually exclusive. This means that the current behaviour of the package is that the package defaults will override the user defaults.

When `cli_options` is set to false, no style options are passed to the CLI so that autopep8 will respect the user config. Even though for this would make sense as the default behaviour, I left it to true by default so that backward compat is preserved.
Open questions:
* For now I went KISS, but it would be possible for the user to provide a custom pep8 config file via `--global-config`
* I don't know how to specify to which beautifier the option applies (only autopep8), so for now the option is labeled as applying to autopep8 and pybeautifier (but not yapf, I don't know why). This should be fixed before merging.