### PR TITLE
Add settings option to menu and use Ruby 2.1.10 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ matrix:
     - os: osx
       env:
         - ATOM_CHANNEL=stable
-      rvm: 2.1.10
     # - os: osx
     #   env:
     #     - ATOM_CHANNEL=beta
@@ -98,7 +97,7 @@ before_install:
   - brew tap homebrew/versions
   # Ruby language support
   # - gem install ruby-beautify --verbose
-  - gem install rubocop
+  # - gem install rubocop
   - gem install htmlbeautifier
   - gem install puppet-lint
   # Sass language support

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ matrix:
     - os: osx
       env:
         - ATOM_CHANNEL=stable
+      rvm: 2.1.10
     # - os: osx
     #   env:
     #     - ATOM_CHANNEL=beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 - See [#881](https://github.com/Glavin001/atom-beautify/issues/881). Update to Prettydiff version 2!
 - Fix for [#1888](https://github.com/Glavin001/atom-beautify/issues/1888). Allow 0 for minor and patch versions of Docker
+- Add Settings to atom-beautify in Packages menu [#1869](https://github.com/Glavin001/atom-beautify/issues/1869)
 - ...
 
 # v0.30.5 (2017-08-11)

--- a/menus/atom-beautify.cson
+++ b/menus/atom-beautify.cson
@@ -25,6 +25,10 @@
                 'label': 'Debug'
                 'command': 'atom-beautify:help-debug-editor'
               }
+              {
+                'label': 'Settings'
+                'command': 'atom-beautify:open-settings'
+              }
           ]
       ]
   }

--- a/package.json
+++ b/package.json
@@ -208,6 +208,7 @@
     "atom-workspace": [
       "atom-beautify:help-debug-editor",
       "atom-beautify:beautify-editor",
+      "atom-beautify:open-settings",
       "atom-beautify:migrate-settings",
       "core:save",
       "core:save-as",

--- a/src/beautify.coffee
+++ b/src/beautify.coffee
@@ -556,6 +556,9 @@ handleSaveEvent = ->
     )
     plugin.subscriptions.add disposable
 
+openSettings = ->
+  atom.workspace.open('atom://config/packages/atom-beautify')
+
 getUnsupportedOptions = ->
   settings = atom.config.get('atom-beautify')
   schema = atom.config.getSchema('atom-beautify')
@@ -622,6 +625,7 @@ plugin.activate = ->
   @subscriptions.add handleSaveEvent()
   @subscriptions.add atom.commands.add "atom-workspace", "atom-beautify:beautify-editor", beautify
   @subscriptions.add atom.commands.add "atom-workspace", "atom-beautify:help-debug-editor", debug
+  @subscriptions.add atom.commands.add "atom-workspace", "atom-beautify:open-settings", openSettings
   @subscriptions.add atom.commands.add ".tree-view .file .name", "atom-beautify:beautify-file", beautifyFile
   @subscriptions.add atom.commands.add ".tree-view .directory .name", "atom-beautify:beautify-directory", beautifyDirectory
   @subscriptions.add atom.commands.add "atom-workspace", "atom-beautify:migrate-settings", plugin.migrateSettings


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
This adds an option to the Packages -> Atom Beautify submenu, Settings, that goes directly to the settings page for Atom Beautify.  This is also available in the command palette.

During the initial Travis build, Rubocop could not be installed on the OSX build because it requires Ruby 2.1 or greater.  The default is 2.0.0, thus a second change was added to use Ruby 2.1.10 so that the Travis build would pass (although it didn't fully, more on that below).
...

### Does this close any currently open issues?
#1869 
...

### Any other comments?
The OSX Travis build will still fail.  I'm getting the same errors with puppet-lint and sass as the master branch here.  I'm still working with Travis support to try and resolve them, but the builds will continue to fail for now.  Since it doesn't fail until the very end, and the Linux builds are fine, it should be safe to merge IMO.
...

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [X] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [X] AppVeyor passes (Windows support)
