### PR TITLE
Fix rustfmt-nightly version check.

### DIFF
--- a/src/beautifiers/rustfmt.coffee
+++ b/src/beautifiers/rustfmt.coffee
@@ -34,7 +34,7 @@ module.exports = class Rustfmt extends Beautifier
     else
       @run(program, ["--version"], help: help)
         .then((stdout) ->
-          if /^0\.(?:[0-4]\.[0-9])(?!-nightly)/.test(stdout.trim())
+          if /^0\.(?:[0-4]\.[0-9])(?![0-9]?-nightly)/.test(stdout.trim())
             versionCheckState = false
             throw new Error("rustfmt version 0.5.0 or newer required")
           else

--- a/src/beautifiers/rustfmt.coffee
+++ b/src/beautifiers/rustfmt.coffee
@@ -34,7 +34,7 @@ module.exports = class Rustfmt extends Beautifier
     else
       @run(program, ["--version"], help: help)
         .then((stdout) ->
-          if /^0\.(?:[0-4]\.[0-9])(?![0-9]?-nightly)/.test(stdout.trim())
+          if /^0\.(?:[0-4]\.[0-9])(?![0-9]*-nightly)/.test(stdout.trim())
             versionCheckState = false
             throw new Error("rustfmt version 0.5.0 or newer required")
           else


### PR DESCRIPTION
Nightly rustfmt version can contain 2 digits in PATCH field.
Current rustfmt-nightly version is: `0.2.13-nightly ( )`. And it throw the exception: "rustfmt version 0.5.0 or newer required".