### PR TITLE
Refactor handleSaveEvent to use onWillSave async

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     }
   ],
   "engines": {
-    "atom": ">=1.6.0 <2.0.0"
+    "atom": ">=1.21.0 <2.0.0"
   },
   "dependencies": {
     "align-yaml": "^0.1.8",

--- a/src/beautify.coffee
+++ b/src/beautify.coffee
@@ -506,20 +506,17 @@ debug = () ->
 
 handleSaveEvent = ->
   atom.workspace.observeTextEditors (editor) ->
-    pendingPaths = {}
     beautifyOnSaveHandler = ({path: filePath}) ->
-      logger.verbose('Should beautify on this save?')
-      if pendingPaths[filePath]
-        logger.verbose("Editor with file path #{filePath} already beautified!")
-        return
-      buffer = editor.getBuffer()
       path ?= require('path')
-      # Get Grammar
-      grammar = editor.getGrammar().name
       # Get file extension
       fileExtension = path.extname(filePath)
       # Remove prefix "." (period) in fileExtension
       fileExtension = fileExtension.substr(1)
+      # Set path of buffer for unsaved files
+      if editor.getPath() is undefined
+        editor.getBuffer().setPath(filePath)
+      # Get Grammar from the editor
+      grammar = editor.getGrammar().name
       # Get language
       languages = beautifier.languages.getLanguages({grammar, extension: fileExtension})
       if languages.length < 1
@@ -535,26 +532,66 @@ handleSaveEvent = ->
         beautify({editor, onSave: true})
         .then(() ->
           logger.verbose('Done beautifying file', filePath)
-          if editor.isAlive() is true
-            logger.verbose('Saving TextEditor...')
-            # Store the filePath to prevent infinite looping
-            # When Whitespace package has option "Ensure Single Trailing Newline" enabled
-            # It will add a newline and keep the file from converging on a beautified form
-            # and saving without emitting onDidSave event, because there were no changes.
-            pendingPaths[filePath] = true
-            Promise.resolve(editor.save()).then(() ->
-              delete pendingPaths[filePath]
-              logger.verbose('Saved TextEditor.')
-            )
         )
         .catch((error) ->
           return showError(error)
         )
-    disposable = editor.onDidSave(({path : filePath}) ->
-      # TODO: Implement debouncing
+    disposable = editor.getBuffer().onWillSave(({path: filePath}) ->
       beautifyOnSaveHandler({path: filePath})
     )
     plugin.subscriptions.add disposable
+
+# handleSaveEvent = ->
+#   atom.workspace.observeTextEditors (editor) ->
+#     pendingPaths = {}
+#     beautifyOnSaveHandler = ({path: filePath}) ->
+#       logger.verbose('Should beautify on this save?')
+#       if pendingPaths[filePath]
+#         logger.verbose("Editor with file path #{filePath} already beautified!")
+#         return
+#       buffer = editor.getBuffer()
+#       path ?= require('path')
+#       # Get Grammar
+#       grammar = editor.getGrammar().name
+#       # Get file extension
+#       fileExtension = path.extname(filePath)
+#       # Remove prefix "." (period) in fileExtension
+#       fileExtension = fileExtension.substr(1)
+#       # Get language
+#       languages = beautifier.languages.getLanguages({grammar, extension: fileExtension})
+#       if languages.length < 1
+#         return
+#       # TODO: select appropriate language
+#       language = languages[0]
+#       # Get language config
+#       key = "atom-beautify.#{language.namespace}.beautify_on_save"
+#       beautifyOnSave = atom.config.get(key)
+#       logger.verbose('save editor positions', key, beautifyOnSave)
+#       if beautifyOnSave
+#         logger.verbose('Beautifying file', filePath)
+#         beautify({editor, onSave: true})
+#         .then(() ->
+#           logger.verbose('Done beautifying file', filePath)
+#           if editor.isAlive() is true
+#             logger.verbose('Saving TextEditor...')
+#             # Store the filePath to prevent infinite looping
+#             # When Whitespace package has option "Ensure Single Trailing Newline" enabled
+#             # It will add a newline and keep the file from converging on a beautified form
+#             # and saving without emitting onDidSave event, because there were no changes.
+#             pendingPaths[filePath] = true
+#             Promise.resolve(editor.save()).then(() ->
+#               delete pendingPaths[filePath]
+#               logger.verbose('Saved TextEditor.')
+#             )
+#         )
+#         .catch((error) ->
+#           return showError(error)
+#         )
+#     disposable = editor.onDidSave(({path : filePath}) ->
+#       # TODO: Implement debouncing
+#       beautifyOnSaveHandler({path: filePath})
+#     )
+#     plugin.subscriptions.add disposable
 
 openSettings = ->
   atom.workspace.open('atom://config/packages/atom-beautify')

--- a/src/beautify.coffee
+++ b/src/beautify.coffee
@@ -541,58 +541,6 @@ handleSaveEvent = ->
     )
     plugin.subscriptions.add disposable
 
-# handleSaveEvent = ->
-#   atom.workspace.observeTextEditors (editor) ->
-#     pendingPaths = {}
-#     beautifyOnSaveHandler = ({path: filePath}) ->
-#       logger.verbose('Should beautify on this save?')
-#       if pendingPaths[filePath]
-#         logger.verbose("Editor with file path #{filePath} already beautified!")
-#         return
-#       buffer = editor.getBuffer()
-#       path ?= require('path')
-#       # Get Grammar
-#       grammar = editor.getGrammar().name
-#       # Get file extension
-#       fileExtension = path.extname(filePath)
-#       # Remove prefix "." (period) in fileExtension
-#       fileExtension = fileExtension.substr(1)
-#       # Get language
-#       languages = beautifier.languages.getLanguages({grammar, extension: fileExtension})
-#       if languages.length < 1
-#         return
-#       # TODO: select appropriate language
-#       language = languages[0]
-#       # Get language config
-#       key = "atom-beautify.#{language.namespace}.beautify_on_save"
-#       beautifyOnSave = atom.config.get(key)
-#       logger.verbose('save editor positions', key, beautifyOnSave)
-#       if beautifyOnSave
-#         logger.verbose('Beautifying file', filePath)
-#         beautify({editor, onSave: true})
-#         .then(() ->
-#           logger.verbose('Done beautifying file', filePath)
-#           if editor.isAlive() is true
-#             logger.verbose('Saving TextEditor...')
-#             # Store the filePath to prevent infinite looping
-#             # When Whitespace package has option "Ensure Single Trailing Newline" enabled
-#             # It will add a newline and keep the file from converging on a beautified form
-#             # and saving without emitting onDidSave event, because there were no changes.
-#             pendingPaths[filePath] = true
-#             Promise.resolve(editor.save()).then(() ->
-#               delete pendingPaths[filePath]
-#               logger.verbose('Saved TextEditor.')
-#             )
-#         )
-#         .catch((error) ->
-#           return showError(error)
-#         )
-#     disposable = editor.onDidSave(({path : filePath}) ->
-#       # TODO: Implement debouncing
-#       beautifyOnSaveHandler({path: filePath})
-#     )
-#     plugin.subscriptions.add disposable
-
 openSettings = ->
   atom.workspace.open('atom://config/packages/atom-beautify')
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Refactors the `handleSaveEvent` function in `beautify.coffee` to make use of `onWillSave` now allowing async operations.  It no longer waits for a save to complete before beautifying and then saving again, instead beautifies when the user invokes a save and afterwards the buffer saves.
...

### Does this close any currently open issues?
#1895 
...

### Any other comments?
Would like some help testing this before it's considered for merging.
...

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [X] Travis CI passes (Mac support)
- [X] AppVeyor passes (Windows support)
