### PR TITLE
Added the option to indent Bash scripts with tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Next
-- ...
+- Add the option to indent Bash with tabs [#1951](https://github.com/Glavin001/atom-beautify/issues/1951)
 
 # v0.30.9 (2017-11-22)
 - Fix [#1949](https://github.com/Glavin001/atom-beautify/issues/1949): Fix beautify on save when text has not changed.

--- a/src/beautifiers/beautysh.coffee
+++ b/src/beautifiers/beautysh.coffee
@@ -24,10 +24,16 @@ module.exports = class BashBeautify extends Beautifier
   options: {
     Bash:
       indent_size: true
+      use_tabs: true
   }
 
   beautify: (text, language, options) ->
     beautysh = @exe("beautysh")
     file = @tempFile("input", text)
-    beautysh.run([ '-i', options.indent_size, '-f', file ])
-      .then(=> @readFile file)
+    tabs = options.use_tabs
+    if tabs is true
+      beautysh.run([ '-t', '-f', file ])
+        .then(=> @readFile file)
+    else
+      beautysh.run([ '-i', options.indent_size, '-f', file ])
+        .then(=> @readFile file)

--- a/src/languages/bash.coffee
+++ b/src/languages/bash.coffee
@@ -27,5 +27,9 @@ module.exports = {
       default: null
       minimum: 0
       description: "Indentation size/length"
+    use_tabs:
+      type: 'boolean'
+      default: null
+      description: "Use tabs for indentation"
 
 }

--- a/src/options.json
+++ b/src/options.json
@@ -146,6 +146,20 @@
           "namespace": "bash"
         }
       },
+	    "use_tabs": {
+        "type": "boolean",
+        "default": null,
+        "description": "Use tabs instead of spaces for indentation, overrides `Indent Size` (Supported by beautysh)",
+        "title": "Indent with tabs",
+        "beautifiers": [
+          "beautysh"
+        ],
+        "key": "use_tabs",
+        "language": {
+          "name": "Bash",
+          "namespace": "bash"
+        }
+      },
       "disabled": {
         "title": "Disable Beautifying Language",
         "order": -3,


### PR DESCRIPTION
This change adds the ability to indent shell scripts with tabs. It does so by running beautysh with "-t" flag.

Closes https://github.com/Glavin001/atom-beautify/issues/1951