### PR TITLE
Added VHDL Support via Emacs

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -13748,6 +13748,125 @@ Path to uncrustify config file. i.e. uncrustify.cfg (Supported by Uncrustify)
 }
 ```
 
+####  [Vhdl](#vhdl) 
+
+**Supported Beautifiers**:  [`Vhdl Beautifier`](#vhdl-beautifier) 
+
+| Option | Vhdl Beautifier |
+| --- | --- |
+| `disabled` | :white_check_mark: |
+| `default_beautifier` | :white_check_mark: |
+| `beautify_on_save` | :white_check_mark: |
+| `emacs_path` | :white_check_mark: |
+| `emacs_script_path` | :white_check_mark: |
+
+**Description**:
+
+Options for language Vhdl
+
+#####  [Disable Beautifying Language](#disable-beautifying-language) 
+
+**Important**: This option is only configurable from within Atom Beautify's setting panel.
+
+**Type**: `boolean`
+
+**Description**:
+
+Disable Vhdl Beautification
+
+**How to Configure**
+
+1. You can open the [Settings View](https://github.com/atom/settings-view) by navigating to
+*Edit > Preferences (Linux)*, *Atom > Preferences (OS X)*, or *File > Preferences (Windows)*.
+2. Go into *Packages* and search for "*Atom Beautify*" package.
+3. Find the option "*Disable Beautifying Language*" and change it to your desired configuration.
+
+#####  [Default Beautifier](#default-beautifier) 
+
+**Important**: This option is only configurable from within Atom Beautify's setting panel.
+
+**Default**: `Vhdl Beautifier`
+
+**Type**: `string`
+
+**Enum**:  `Vhdl Beautifier` 
+
+**Description**:
+
+Default Beautifier to be used for Vhdl
+
+**How to Configure**
+
+1. You can open the [Settings View](https://github.com/atom/settings-view) by navigating to
+*Edit > Preferences (Linux)*, *Atom > Preferences (OS X)*, or *File > Preferences (Windows)*.
+2. Go into *Packages* and search for "*Atom Beautify*" package.
+3. Find the option "*Default Beautifier*" and change it to your desired configuration.
+
+#####  [Beautify On Save](#beautify-on-save) 
+
+**Important**: This option is only configurable from within Atom Beautify's setting panel.
+
+**Type**: `boolean`
+
+**Description**:
+
+Automatically beautify Vhdl files on save
+
+**How to Configure**
+
+1. You can open the [Settings View](https://github.com/atom/settings-view) by navigating to
+*Edit > Preferences (Linux)*, *Atom > Preferences (OS X)*, or *File > Preferences (Windows)*.
+2. Go into *Packages* and search for "*Atom Beautify*" package.
+3. Find the option "*Beautify On Save*" and change it to your desired configuration.
+
+#####  [Emacs path](#emacs-path) 
+
+**Namespace**: `vhdl`
+
+**Key**: `emacs_path`
+
+**Type**: `string`
+
+**Supported Beautifiers**:  [`Vhdl Beautifier`](#vhdl-beautifier) 
+
+**Description**:
+
+Path to the `emacs` executable (Supported by Vhdl Beautifier)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "vhdl": {
+        "emacs_path": ""
+    }
+}
+```
+
+#####  [Emacs script path](#emacs-script-path) 
+
+**Namespace**: `vhdl`
+
+**Key**: `emacs_script_path`
+
+**Type**: `string`
+
+**Supported Beautifiers**:  [`Vhdl Beautifier`](#vhdl-beautifier) 
+
+**Description**:
+
+Path to the emacs script (Supported by Vhdl Beautifier)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "vhdl": {
+        "emacs_script_path": ""
+    }
+}
+```
+
 ####  [Visualforce](#visualforce) 
 
 **Supported Beautifiers**:  [`Pretty Diff`](#pretty-diff) 
@@ -19220,6 +19339,57 @@ Path to uncrustify config file. i.e. uncrustify.cfg (Supported by Uncrustify)
 {
     "vala": {
         "configPath": ""
+    }
+}
+```
+
+
+### Vhdl Beautifier
+
+#####  [Emacs path](#emacs-path) 
+
+**Namespace**: `vhdl`
+
+**Key**: `emacs_path`
+
+**Type**: `string`
+
+**Supported Beautifiers**:  [`Vhdl Beautifier`](#vhdl-beautifier) 
+
+**Description**:
+
+Path to the `emacs` executable (Supported by Vhdl Beautifier)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "vhdl": {
+        "emacs_path": ""
+    }
+}
+```
+
+#####  [Emacs script path](#emacs-script-path) 
+
+**Namespace**: `vhdl`
+
+**Key**: `emacs_script_path`
+
+**Type**: `string`
+
+**Supported Beautifiers**:  [`Vhdl Beautifier`](#vhdl-beautifier) 
+
+**Description**:
+
+Path to the emacs script (Supported by Vhdl Beautifier)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "vhdl": {
+        "emacs_script_path": ""
     }
 }
 ```

--- a/examples/nested-jsbeautifyrc/vhdl/expected/test.vhd
+++ b/examples/nested-jsbeautifyrc/vhdl/expected/test.vhd
@@ -1,0 +1,17 @@
+library ieee;
+use ieee.std_logic_1164.all;
+entity test is
+  port(
+    clk : in  std_logic;
+    d   : in  std_logic;
+    q   : out std_logic);
+end test;
+architecture rtl of test is
+begin
+  process (clk)
+  begin
+    if rising_edge(clk) then
+      q <= d;
+    end if;
+  end;
+end rtl;

--- a/examples/nested-jsbeautifyrc/vhdl/original/test.vhd
+++ b/examples/nested-jsbeautifyrc/vhdl/original/test.vhd
@@ -1,0 +1,17 @@
+library ieee;
+use ieee.std_logic_1164.all;
+entity test is
+port(
+clk : in std_logic;
+d : in std_logic ;
+q :out std_logic );
+end test;
+architecture rtl of test is
+    begin
+process (clk)
+     begin
+        if rising_edge(clk) then
+q <= d;
+        end if;
+    end;
+end rtl;

--- a/package.json
+++ b/package.json
@@ -277,7 +277,8 @@
       "atom-beautify:beautify-language-xml",
       "atom-beautify:beautify-language-xtemplate",
       "atom-beautify:beautify-language-yaml",
-      "atom-beautify:beautify-language-terraform"
+      "atom-beautify:beautify-language-terraform",
+      "atom-beautify:beautify-language-vhdl"
     ],
     ".tree-view .file .name": [
       "atom-beautify:beautify-file"
@@ -412,7 +413,9 @@
     "align-yaml",
     "goimports",
     "terraform",
-    "terraformfmt"
+    "terraformfmt",
+    "vhdl",
+    "vhdl beautifier"
   ],
   "devDependencies": {
     "coffeelint": "1.16.0"

--- a/src/beautifiers/index.coffee
+++ b/src/beautifiers/index.coffee
@@ -52,6 +52,7 @@ module.exports = class Beautifiers extends EventEmitter
     'goimports'
     'latex-beautify'
     'fortran-beautifier'
+    'vhdl-beautifier'
     'js-beautify'
     'jscs'
     'eslint'

--- a/src/beautifiers/vhdl-beautifier/emacs-vhdl-formating-script.lisp
+++ b/src/beautifiers/vhdl-beautifier/emacs-vhdl-formating-script.lisp
@@ -1,0 +1,45 @@
+(defun vhdl-batch-indent-region ()
+  "Run `f90-batch-beatify-region' on the specified filename.
+Use this from the command line, with `-batch';
+it won't work in an interactive Emacs.
+For example, invoke \"emacs -batch -l ~/.emacs-batch-vhdl-indent -f vhdl-batch-indent-region file.f\""
+  (if (not noninteractive)
+      (error "`vhdl-batch-indent-region' is to be used only with -batch"))
+  (let  ((make-backup-files nil)
+        (version-control nil)
+        (auto-save-default nil)
+        (find-file-run-dired nil)
+        (kept-old-versions 259259)
+        (kept-new-versions 259259))
+  (let ((error 0)
+        file
+        (files ()))
+      (while command-line-args-left
+        (setq file (expand-file-name (car command-line-args-left)))
+        (cond ((not (file-exists-p file))
+               (message ">> %s does not exist!" file)
+               (setq error 1
+                     command-line-args-left (cdr command-line-args-left)))
+              ((file-directory-p file)
+               (setq command-line-args-left
+                     (nconc (directory-files file)
+                            (cdr command-line-args-left))))
+              (t
+               (setq files (cons file files)
+                     command-line-args-left (cdr command-line-args-left)))))
+      (while files
+        (setq file (car files)
+              files (cdr files))
+        (condition-case err
+            (progn
+              (if buffer-file-name (kill-buffer (current-buffer)))
+              (find-file file)
+              (buffer-disable-undo (current-buffer))
+              (set-buffer-modified-p nil)
+              (vhdl-mode)
+              (message (file-name-nondirectory buffer-file-name))
+                                        ; compute indentation of first
+                                        ; line
+              (vhdl-beautify-buffer)
+              (save-buffer)
+))))))

--- a/src/beautifiers/vhdl-beautifier/index.coffee
+++ b/src/beautifiers/vhdl-beautifier/index.coffee
@@ -1,0 +1,59 @@
+###
+Requires https://www.gnu.org/software/emacs/
+###
+
+"use strict"
+Beautifier = require('../beautifier')
+path = require("path")
+
+module.exports = class VhdlBeautifier extends Beautifier
+  name: "Vhdl Beautifier"
+  link: "https://www.gnu.org/software/emacs/"
+  executables: [
+    {
+      name: "Emacs"
+      cmd: "emacs"
+      homepage: "https://www.gnu.org/software/emacs/"
+      installation: "https://www.gnu.org/software/emacs/"
+      version: {
+        parse: (text) -> text.match(/Emacs (\d+\.\d+\.\d+)/)[1]
+      }
+    }
+  ]
+
+  options: {
+    Vhdl: true
+  }
+
+  beautify: (text, language, options) ->
+    @debug('vhdl-beautifier', options)
+    emacs = @exe("emacs")
+
+    emacs_path = options.emacs_path
+    emacs_script_path = options.emacs_script_path
+
+    if not emacs_script_path
+      emacs_script_path = path.resolve(__dirname, "emacs-vhdl-formating-script.lisp")
+
+    @debug('vhdl-beautifier', 'emacs script path: ' + emacs_script_path)
+
+    args = [
+      '--batch'
+      '-l'
+      emacs_script_path
+      '-f'
+      'vhdl-batch-indent-region'
+      tempFile = @tempFile("temp", text)
+      ]
+
+    if emacs_path
+      @deprecateOptionForExecutable("Emacs", "emacs_path", "Path")
+      @run(emacs_path, args, {ignoreReturnCode: false})
+        .then(=>
+          @readFile(tempFile)
+        )
+    else
+      emacs.run(args, {ignoreReturnCode: false})
+        .then(=>
+          @readFile(tempFile)
+        )

--- a/src/languages/index.coffee
+++ b/src/languages/index.coffee
@@ -73,6 +73,7 @@ module.exports = class Languages
     "ux_markup"
     "vala"
     "vue"
+    "vhdl"
     "visualforce"
     "xml"
     "xtemplate"

--- a/src/languages/vhdl.coffee
+++ b/src/languages/vhdl.coffee
@@ -1,0 +1,35 @@
+module.exports = {
+
+  name: "Vhdl"
+  namespace: "vhdl"
+
+  ###
+  Supported Grammars
+  ###
+  grammars: [
+    "VHDL 2008"
+  ]
+
+  ###
+  Supported extensions
+  ###
+  extensions: [
+    "vhd"
+    "VHD"
+  ]
+
+  ###
+
+  ###
+  options:
+    # JavaScript
+    emacs_path:
+      type: 'string'
+      default: ""
+      description: "Path to the `emacs` executable"
+    emacs_script_path:
+      type: 'string'
+      default: ""
+      description: "Path to the emacs script"
+
+}

--- a/src/options.json
+++ b/src/options.json
@@ -8530,6 +8530,76 @@
       }
     }
   },
+  "vhdl": {
+    "title": "Vhdl",
+    "type": "object",
+    "description": "Options for language Vhdl",
+    "collapsed": true,
+    "beautifiers": [
+      "Vhdl Beautifier"
+    ],
+    "grammars": [
+      "VHDL 2008"
+    ],
+    "extensions": [
+      "vhd",
+      "VHD"
+    ],
+    "properties": {
+      "emacs_path": {
+        "type": "string",
+        "default": "",
+        "description": "Path to the `emacs` executable (Supported by Vhdl Beautifier)",
+        "title": "Emacs path",
+        "beautifiers": [
+          "Vhdl Beautifier"
+        ],
+        "key": "emacs_path",
+        "language": {
+          "name": "Vhdl",
+          "namespace": "vhdl"
+        }
+      },
+      "emacs_script_path": {
+        "type": "string",
+        "default": "",
+        "description": "Path to the emacs script (Supported by Vhdl Beautifier)",
+        "title": "Emacs script path",
+        "beautifiers": [
+          "Vhdl Beautifier"
+        ],
+        "key": "emacs_script_path",
+        "language": {
+          "name": "Vhdl",
+          "namespace": "vhdl"
+        }
+      },
+      "disabled": {
+        "title": "Disable Beautifying Language",
+        "order": -3,
+        "type": "boolean",
+        "default": false,
+        "description": "Disable Vhdl Beautification"
+      },
+      "default_beautifier": {
+        "title": "Default Beautifier",
+        "order": -2,
+        "type": "string",
+        "default": "Vhdl Beautifier",
+        "description": "Default Beautifier to be used for Vhdl",
+        "enum": [
+          "Vhdl Beautifier"
+        ]
+      },
+      "beautify_on_save": {
+        "title": "Beautify On Save",
+        "order": -1,
+        "type": "boolean",
+        "default": false,
+        "description": "Automatically beautify Vhdl files on save"
+      }
+    }
+  },
   "visualforce": {
     "title": "Visualforce",
     "type": "object",


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Added VHDL Support via Emacs. (Analog to Fortran Support)

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [X] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [X] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
