### PR TITLE
Use pip2 for OSX, php 7.2 for Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,15 +113,15 @@ before_install:
       pip install --user --upgrade autopep8;
       pip install --user --upgrade isort;
     else
-      pip install --upgrade pip;
-      pip install --upgrade autopep8;
-      pip install --upgrade isort;
+      pip2 install --upgrade pip2;
+      pip2 install --upgrade autopep8;
+      pip2 install --upgrade isort;
     fi
   # SQL language support
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       pip install --user --upgrade sqlparse;
     else
-      pip install --upgrade sqlparse;
+      pip2 install --upgrade sqlparse;
     fi
   # Java, C, C++, C#, Objective-C, D, Pawn, Vala
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
@@ -184,7 +184,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       pip install --user beautysh;
     else
-      pip install beautysh;
+      pip2 install beautysh;
     fi
   # terraform
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -107,8 +107,8 @@ install:
   # PHP
   - ps: Set-Service wuauserv -StartupType Manual
   - cinst php -y
-  - ps: "ls \"C:\\tools\\php71\""
-  - "SET PATH=C:\\tools\\php71;%PATH%"
+  - ps: "ls \"C:\\tools\\php72\""
+  - "SET PATH=C:\\tools\\php72;%PATH%"
   - where php
   # PHP-CS-Fixer
   - cinst curl -y # Use cURL to download file from URL


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Travis no longer includes pip in its images.  This fixes the build error to use pip2 instead.
...

### Does this close any currently open issues?
#1987 
...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [X] Regenerate documentation with `npm run docs`
- [X] Add change details to `CHANGELOG.md` under "Next" section
- [X] Added examples for testing to [examples/ directory](examples/)
- [X] Travis CI passes (Mac support)
- [X] AppVeyor passes (Windows support)

  