### PR TITLE
Switch to remark-cli to support .remarkrc and unlock remark version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+- Switch to external [`Remark CLI`](https://github.com/remarkjs/remark/tree/master/packages/remark-cli) and thus allow for user-defined config with `remarkrc` ([#965](https://github.com/Glavin001/atom-beautify/issues/965))
 - Fix [#1862](https://github.com/Glavin001/atom-beautify/issues/1862) Add support for ocp-indent as an executable
 
 # v0.30.9 (2017-11-22)

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Some of the supported beautifiers are developed for Node.js and are automaticall
 | Pug Beautify | :white_check_mark: | :ok_hand: Not necessary | :smiley: Nothing! |
 | puppet-lint | :warning: 1 executable | :white_check_mark: :100:% of executables | :whale: With [Docker](https://www.docker.com/):<br/>1. Install [puppet-lint (`puppet-lint`)](http://puppet-lint.com/) with `docker pull unibeautify/puppet-lint`<br/><br/>:bookmark_tabs: Manually:<br/>1. Install [puppet-lint (`puppet-lint`)](http://puppet-lint.com/) by following http://puppet-lint.com/<br/> |
 | pybeautifier | :warning: Manual installation | :construction: Not an executable | :page_facing_up: Go to https://github.com/guyskk/pybeautifier and follow the instructions. |
-| Remark | :white_check_mark: | :ok_hand: Not necessary | :smiley: Nothing! |
+| Remark | :warning: 1 executable | :x: No Docker support | :bookmark_tabs: Manually:<br/>1. Install [Remark CLI (`remark`)](https://github.com/remarkjs/remark) by following https://github.com/remarkjs/remark/tree/master/packages/remark-cli#installation<br/> |
 | Rubocop | :warning: Manual installation | :construction: Not an executable | :page_facing_up: Go to https://github.com/bbatsov/rubocop and follow the instructions. |
 | Ruby Beautify | :warning: Manual installation | :construction: Not an executable | :page_facing_up: Go to https://github.com/erniebrodeur/ruby-beautify and follow the instructions. |
 | rustfmt | :warning: Manual installation | :construction: Not an executable | :page_facing_up: Go to https://github.com/rust-lang-nursery/rustfmt and follow the instructions. |
@@ -173,7 +173,7 @@ See [all supported options in the documentation at  `docs/options.md`](docs/opti
 | LaTeX | `BibTeX`, `LaTeX`, `TeX` |`.bib`, `.tex`, `.sty`, `.cls`, `.dtx`, `.ins`, `.bbx`, `.cbx` | **[`Latex Beautify`](https://github.com/cmhughes/latexindent.pl)** |
 | LESS | `LESS` |`.less` | **[`Pretty Diff`](https://github.com/prettydiff/prettydiff)**, [`CSScomb`](https://github.com/csscomb/csscomb.js) |
 | Lua | `Lua` |`.lua`, `.ttslua` | **[`Lua beautifier`](https://github.com/Glavin001/atom-beautify/blob/master/src/beautifiers/lua-beautifier/beautifier.coffee)** |
-| Markdown | `GitHub Markdown` |`.markdown`, `.md` | **[`Tidy Markdown`](https://github.com/slang800/tidy-markdown)**, [`Remark`](https://github.com/wooorm/remark) |
+| Markdown | `GitHub Markdown` |`.markdown`, `.md` | **[`Tidy Markdown`](https://github.com/slang800/tidy-markdown)**, [`Remark`](https://github.com/remarkjs/remark) |
 | Marko | `Marko` |`.marko` | **[`Marko Beautifier`](https://github.com/marko-js/marko-prettyprint)** |
 | Mustache | `HTML (Mustache)` |`.mustache` | **[`JS Beautify`](https://github.com/beautify-web/js-beautify)**, [`Pretty Diff`](https://github.com/prettydiff/prettydiff) |
 | Nginx | `nginx` |`.conf` | **[`Nginx Beautify`](https://github.com/denysvitali/nginxbeautify)** |

--- a/docs/options.md
+++ b/docs/options.md
@@ -368,6 +368,23 @@ Options for puppet-lint executable.
 2. Go into *Packages* and search for "*Atom Beautify*" package.
 3. Find the option "*puppet-lint*" and change it to your desired configuration.
 
+#####  [Remark CLI](#remark-cli) 
+
+**Important**: This option is only configurable from within Atom Beautify's setting panel.
+
+**Type**: `object`
+
+**Description**:
+
+Options for Remark CLI executable.
+
+**How to Configure**
+
+1. You can open the [Settings View](https://github.com/atom/settings-view) by navigating to
+*Edit > Preferences (Linux)*, *Atom > Preferences (OS X)*, or *File > Preferences (Windows)*.
+2. Go into *Packages* and search for "*Atom Beautify*" package.
+3. Find the option "*Remark CLI*" and change it to your desired configuration.
+
 #####  [Rscript](#rscript) 
 
 **Important**: This option is only configurable from within Atom Beautify's setting panel.
@@ -8045,6 +8062,7 @@ Override EOL from line-ending-selector (Supported by Lua beautifier)
 | `beautify_on_save` | :white_check_mark: | :white_check_mark: |
 | `commonmark` | :white_check_mark: | :x: |
 | `gfm` | :white_check_mark: | :x: |
+| `search_for_configuration` | :white_check_mark: | :x: |
 | `yaml` | :white_check_mark: | :x: |
 
 **Description**:
@@ -8152,6 +8170,30 @@ GitHub Flavoured Markdown (Supported by Remark)
 {
     "markdown": {
         "gfm": true
+    }
+}
+```
+
+#####  [Search for configuration](#search-for-configuration) 
+
+**Namespace**: `markdown`
+
+**Key**: `search_for_configuration`
+
+**Type**: `boolean`
+
+**Supported Beautifiers**:  [`Remark`](#remark) 
+
+**Description**:
+
+Searches for `remarkrc` file and respects rules in it. If set, **Commonmark**, **Gfm** and **Yaml** options are ignored (Supported by Remark)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "markdown": {
+        "search_for_configuration": false
     }
 }
 ```
@@ -18616,6 +18658,30 @@ Allows and disallows several constructs. (Supported by Remark)
 {
     "markdown": {
         "commonmark": false
+    }
+}
+```
+
+#####  [Search for configuration](#search-for-configuration) 
+
+**Namespace**: `markdown`
+
+**Key**: `search_for_configuration`
+
+**Type**: `boolean`
+
+**Supported Beautifiers**:  [`Remark`](#remark) 
+
+**Description**:
+
+Searches for `remarkrc` file and respects rules in it. If set, **Commonmark**, **Gfm** and **Yaml** options are ignored (Supported by Remark)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "markdown": {
+        "search_for_configuration": false
     }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -185,7 +185,6 @@
     "open": "0.0.5",
     "prettydiff2": "^2.2.7",
     "pug-beautify": "^0.1.1",
-    "remark": "6.0.1",
     "season": "6.0.0",
     "semver": "^5.3.0",
     "shell-env": "^0.3.0",

--- a/src/beautifiers/remark.coffee
+++ b/src/beautifiers/remark.coffee
@@ -1,44 +1,62 @@
+###
+Requires https://github.com/remarkjs/remark
+###
 "use strict"
 Beautifier = require('./beautifier')
 
 module.exports = class Remark extends Beautifier
   name: "Remark"
-  link: "https://github.com/wooorm/remark"
+  link: "https://github.com/remarkjs/remark"
   options: {
     _: {
       gfm: true
       yaml: true
       commonmark: true
-      footnotes: true
-      pedantic: true
-      breaks: true
-      entities: true
-      setext: true
-      closeAtx: true
-      looseTable: true
-      spacedTable: true
-      fence: true
-      fences: true
-      bullet: true
-      listItemIndent: true
-      incrementListMarker: true
-      rule: true
-      ruleRepetition: true
-      ruleSpaces: true
-      strong: true
-      emphasis: true
-      position: true
+      search_for_configuration: true
     }
     Markdown: true
   }
 
-  beautify: (text, language, options) ->
-    return new @Promise((resolve, reject) ->
-      try
-        remark = require 'remark'
-        cleanMarkdown = remark().process(text, options).toString()
-        resolve cleanMarkdown
-      catch err
-        @error("Remark error: #{err}")
-        reject(err)
+  executables: [
+    {
+      name: "Remark CLI"
+      cmd: "remark"
+      homepage: "https://github.com/remarkjs/remark"
+      installation: "https://github.com/remarkjs/remark/tree/master/packages/remark-cli#installation"
+      version: {
+        parse: (text) ->
+          return text.match(/remark: (\d+\.\d+\.\d+)/)[1]
+        runOptions: {
+          returnStderr: true
+        }
+      }
+    }
+  ]
+
+  beautify: (text, language, options, context) ->
+    cwd = context.filePath and path.dirname context.filePath
+    remarkArgs = [
+      '--no-color'
+      '--no-ignore'
+      '--file-path'
+      context.filePath
+    ]
+    remarkOptions = {}
+
+    if (!options.search_for_configuration)
+      settings = Object.assign({}, options)
+      delete settings.search_for_configuration
+      serializedSettings = JSON.stringify(settings).slice(1, -1)
+      remarkArgs.push('--no-config', '--setting', serializedSettings)
+
+    return new Promise((resolve, reject) =>
+      @exe("remark")
+        .run(remarkArgs, {
+          cwd
+          onStdin: (stdin) ->
+            stdin.end text
+        })
+        .then (output) ->
+          resolve(output)
+        .catch(reject)
     )

--- a/src/languages/markdown.coffee
+++ b/src/languages/markdown.coffee
@@ -33,4 +33,8 @@ module.exports = {
       type: 'boolean'
       default: false
       description: 'Allows and disallows several constructs.'
+    search_for_configuration:
+      type: 'boolean'
+      default: false
+      description: 'Searches for `remarkrc` file and respects rules in it. If set, **Commonmark**, **Gfm** and **Yaml** options are ignored'
 }

--- a/src/options.json
+++ b/src/options.json
@@ -4686,6 +4686,20 @@
           "namespace": "markdown"
         }
       },
+      "search_for_configuration": {
+        "type": "boolean",
+        "default": false,
+        "description": "Searches for `remarkrc` file and respects rules in it. If set, **Commonmark**, **Gfm** and **Yaml** options are ignored (Supported by Remark)",
+        "title": "Search for configuration",
+        "beautifiers": [
+          "Remark"
+        ],
+        "key": "search_for_configuration",
+        "language": {
+          "name": "Markdown",
+          "namespace": "markdown"
+        }
+      },
       "disabled": {
         "title": "Disable Beautifying Language",
         "order": -3,
@@ -9397,6 +9411,22 @@
             "type": "string",
             "default": "",
             "description": "Absolute path to the \"puppet-lint\" executable's binary/script."
+          }
+        }
+      },
+      "remark": {
+        "key": "remark",
+        "title": "Remark CLI",
+        "type": "object",
+        "collapsed": true,
+        "description": "Options for Remark CLI executable.",
+        "properties": {
+          "path": {
+            "key": "path",
+            "title": "Binary/Script Path",
+            "type": "string",
+            "default": "",
+            "description": "Absolute path to the \"remark\" executable's binary/script."
           }
         }
       },


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

I've been trying to add `.remarkrc` support to fix #965 and was [suggested](https://github.com/Glavin001/atom-beautify/issues/965#issuecomment-356340663) by @wooorm to have a look at `remark-cli`. As a result, I re-implemented remark beautifier to use `remark` as an external tool.

The benefit of this approach is not only a local `.remarkrc` file can be found and loaded, but also that there is no more version lock-in for `remark` (it used to be v6, which is 2 versions behind the latest).

I don't pretend that this PR is perfect and will be happy to revise it with someone's help.

### Does this close any currently open issues?

Closes https://github.com/Glavin001/atom-beautify/issues/965. Related to https://github.com/Glavin001/atom-beautify/pull/2004.

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [x] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
