### PR TITLE
Fallback to global eslint and add errors_only option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Next
-- ...
+- FIX [#1739](https://github.com/Glavin001/atom-beautify/issues/1739) Fallback to included eslint
+- Add option to only fix errors with eslint
 
 # v0.32.0 (2018-03-02)
 - See [#2026](https://github.com/Glavin001/atom-beautify/issues/2026) Add Vue support to ESLint Fixer beautifier. Should be used with [eslint-plugin-vue](https://github.com/vuejs/eslint-plugin-vue).

--- a/docs/options.md
+++ b/docs/options.md
@@ -2126,6 +2126,7 @@ Path to uncrustify config file. i.e. uncrustify.cfg (Supported by Uncrustify)
 | `end_of_line` | :white_check_mark: | :x: |
 | `end_with_comma` | :white_check_mark: | :white_check_mark: |
 | `end_with_newline` | :white_check_mark: | :x: |
+| `errors_only` | :white_check_mark: | :x: |
 | `eval_code` | :white_check_mark: | :x: |
 | `extra_liners` | :white_check_mark: | :x: |
 | `indent_char` | :white_check_mark: | :white_check_mark: |
@@ -2332,6 +2333,30 @@ End output with newline (Supported by JS Beautify)
 {
     "html": {
         "end_with_newline": false
+    }
+}
+```
+
+#####  [Errors only](#errors-only) 
+
+**Namespace**: `js`
+
+**Key**: `errors_only`
+
+**Type**: `boolean`
+
+**Supported Beautifiers**:  [`JS Beautify`](#js-beautify) 
+
+**Description**:
+
+Fix errors but leave warnings (Supported by JS Beautify)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "js": {
+        "errors_only": false
     }
 }
 ```
@@ -5219,6 +5244,7 @@ Path to uncrustify config file. i.e. uncrustify.cfg (Supported by Uncrustify)
 | `end_of_line` | :x: | :white_check_mark: | :x: | :x: | :x: |
 | `end_with_comma` | :x: | :white_check_mark: | :x: | :x: | :white_check_mark: |
 | `end_with_newline` | :x: | :white_check_mark: | :x: | :x: | :x: |
+| `errors_only` | :white_check_mark: | :white_check_mark: | :x: | :x: | :x: |
 | `eval_code` | :x: | :white_check_mark: | :x: | :x: | :x: |
 | `indent_char` | :x: | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: |
 | `indent_level` | :x: | :white_check_mark: | :x: | :x: | :x: |
@@ -5419,6 +5445,30 @@ End output with newline (Supported by JS Beautify)
 {
     "js": {
         "end_with_newline": false
+    }
+}
+```
+
+#####  [Errors only](#errors-only) 
+
+**Namespace**: `js`
+
+**Key**: `errors_only`
+
+**Type**: `boolean`
+
+**Supported Beautifiers**:  [`JS Beautify`](#js-beautify)  [`ESLint Fixer`](#eslint-fixer) 
+
+**Description**:
+
+Fix errors but leave warnings (Supported by JS Beautify, ESLint Fixer)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "js": {
+        "errors_only": false
     }
 }
 ```
@@ -5831,6 +5881,7 @@ Wrap lines at next opportunity after N characters (Supported by JS Beautify, Pre
 | `end_of_line` | :white_check_mark: | :x: | :x: |
 | `end_with_comma` | :white_check_mark: | :x: | :white_check_mark: |
 | `end_with_newline` | :white_check_mark: | :x: | :x: |
+| `errors_only` | :white_check_mark: | :x: | :x: |
 | `eval_code` | :white_check_mark: | :x: | :x: |
 | `indent_char` | :white_check_mark: | :x: | :white_check_mark: |
 | `indent_level` | :white_check_mark: | :x: | :x: |
@@ -6031,6 +6082,30 @@ End output with newline (Supported by JS Beautify)
 {
     "js": {
         "end_with_newline": false
+    }
+}
+```
+
+#####  [Errors only](#errors-only) 
+
+**Namespace**: `js`
+
+**Key**: `errors_only`
+
+**Type**: `boolean`
+
+**Supported Beautifiers**:  [`JS Beautify`](#js-beautify) 
+
+**Description**:
+
+Fix errors but leave warnings (Supported by JS Beautify)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "js": {
+        "errors_only": false
     }
 }
 ```
@@ -6444,6 +6519,7 @@ Wrap lines at next opportunity after N characters (Supported by JS Beautify, Pre
 | `end_of_line` | :white_check_mark: | :x: |
 | `end_with_comma` | :white_check_mark: | :white_check_mark: |
 | `end_with_newline` | :white_check_mark: | :x: |
+| `errors_only` | :white_check_mark: | :x: |
 | `eval_code` | :white_check_mark: | :x: |
 | `indent_char` | :white_check_mark: | :white_check_mark: |
 | `indent_level` | :white_check_mark: | :x: |
@@ -6670,6 +6746,30 @@ End output with newline (Supported by JS Beautify)
 {
     "js": {
         "end_with_newline": false
+    }
+}
+```
+
+#####  [Errors only](#errors-only) 
+
+**Namespace**: `js`
+
+**Key**: `errors_only`
+
+**Type**: `boolean`
+
+**Supported Beautifiers**:  [`JS Beautify`](#js-beautify) 
+
+**Description**:
+
+Fix errors but leave warnings (Supported by JS Beautify)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "js": {
+        "errors_only": false
     }
 }
 ```
@@ -13669,6 +13769,7 @@ Maximum characters per line (0 disables) (Supported by Pretty Diff)
 | `end_of_line` | :x: | :x: | :white_check_mark: |
 | `end_with_comma` | :x: | :x: | :white_check_mark: |
 | `end_with_newline` | :x: | :x: | :white_check_mark: |
+| `errors_only` | :x: | :x: | :white_check_mark: |
 | `eval_code` | :x: | :x: | :white_check_mark: |
 | `extra_liners` | :x: | :x: | :white_check_mark: |
 | `indent_char` | :x: | :x: | :white_check_mark: |
@@ -13875,6 +13976,30 @@ End output with newline (Supported by Vue Beautifier)
 {
     "html": {
         "end_with_newline": false
+    }
+}
+```
+
+#####  [Errors only](#errors-only) 
+
+**Namespace**: `js`
+
+**Key**: `errors_only`
+
+**Type**: `boolean`
+
+**Supported Beautifiers**:  [`Vue Beautifier`](#vue-beautifier) 
+
+**Description**:
+
+Fix errors but leave warnings (Supported by Vue Beautifier)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "js": {
+        "errors_only": false
     }
 }
 ```
@@ -15334,6 +15459,33 @@ Used if neither a project or custom config file exists. (Supported by CSScomb)
 ```
 
 
+### ESLint Fixer
+
+#####  [Errors only](#errors-only) 
+
+**Namespace**: `js`
+
+**Key**: `errors_only`
+
+**Type**: `boolean`
+
+**Supported Beautifiers**:  [`JS Beautify`](#js-beautify)  [`ESLint Fixer`](#eslint-fixer) 
+
+**Description**:
+
+Fix errors but leave warnings (Supported by JS Beautify, ESLint Fixer)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "js": {
+        "errors_only": false
+    }
+}
+```
+
+
 ### Emacs Verilog Mode
 
 #####  [Emacs script path](#emacs-script-path) 
@@ -16068,6 +16220,30 @@ Insert spaces between brackets in object literals (Supported by JS Beautify)
 {
     "js": {
         "object_curly_spacing": false
+    }
+}
+```
+
+#####  [Errors only](#errors-only) 
+
+**Namespace**: `js`
+
+**Key**: `errors_only`
+
+**Type**: `boolean`
+
+**Supported Beautifiers**:  [`JS Beautify`](#js-beautify) 
+
+**Description**:
+
+Fix errors but leave warnings (Supported by JS Beautify)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "js": {
+        "errors_only": false
     }
 }
 ```
@@ -18786,6 +18962,30 @@ Insert spaces between brackets in object literals (Supported by Vue Beautifier)
 {
     "js": {
         "object_curly_spacing": false
+    }
+}
+```
+
+#####  [Errors only](#errors-only) 
+
+**Namespace**: `js`
+
+**Key**: `errors_only`
+
+**Type**: `boolean`
+
+**Supported Beautifiers**:  [`Vue Beautifier`](#vue-beautifier) 
+
+**Description**:
+
+Fix errors but leave warnings (Supported by Vue Beautifier)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "js": {
+        "errors_only": false
     }
 }
 ```

--- a/src/beautifiers/eslint.coffee
+++ b/src/beautifiers/eslint.coffee
@@ -9,7 +9,8 @@ module.exports = class ESLintFixer extends Beautifier
   link: "https://github.com/eslint/eslint"
 
   options: {
-    JavaScript: false
+    JavaScript:
+      errors_only: true
     Vue: false
   }
 
@@ -23,9 +24,16 @@ module.exports = class ESLintFixer extends Beautifier
       allowUnsafeNewFunction ->
         importPath = Path.join(projectPath, 'node_modules', 'eslint')
         try
-          CLIEngine = require(importPath).CLIEngine
+          try
+            eslint = require(importPath)
+          catch
+            eslint = require('eslint')
 
-          cli = new CLIEngine(fix: true, cwd: projectPath)
+          fix = true
+          if options.errors_only
+            fix = (rule) -> rule.severity is 2
+
+          cli = new eslint.CLIEngine(fix: fix, cwd: projectPath)
           result = cli.executeOnText(text).results[0]
 
           resolve result.output

--- a/src/beautifiers/eslint.coffee
+++ b/src/beautifiers/eslint.coffee
@@ -18,26 +18,41 @@ module.exports = class ESLintFixer extends Beautifier
     return new @Promise((resolve, reject) ->
       editor = atom.workspace.getActiveTextEditor()
       filePath = editor.getPath()
-      dir = path.dirname(filePath)
-      projectPath = atom.project.relativizePath(filePath)[0]
+
+      if filePath
+        dir = path.dirname(filePath)
+        projectPath = atom.project.relativizePath(filePath)[0]
+      else
+        dir = atom.getConfigDirPath()
+        projectPath = atom.project.getPaths()[0]
 
       result = null
+      importPath = Path.join(projectPath or dir, 'node_modules', 'eslint')
+      try
+        eslint = require(importPath)
+      catch
+        eslint = require('eslint')
+
+      fix = true
+      if options.errors_only
+        fix = (rule) -> rule.severity is 2
+
+      eslintExecute = (cwd) ->
+        cli = new eslint.CLIEngine(fix: fix, cwd: cwd)
+        result = cli.executeOnText(text).results[0]
+        result.output
+
       allowUnsafeNewFunction ->
-        importPath = Path.join(projectPath or dir, 'node_modules', 'eslint')
         try
-          try
-            eslint = require(importPath)
-          catch
-            eslint = require('eslint')
-
-          fix = true
-          if options.errors_only
-            fix = (rule) -> rule.severity is 2
-
-          cli = new eslint.CLIEngine(fix: fix, cwd: projectPath or dir)
-          result = cli.executeOnText(text).results[0]
-
-          resolve result.output
+          resolve eslintExecute(projectPath or dir)
         catch err
-          reject(err)
+
+          # check for default config
+          if err.message is 'No ESLint configuration found.' and (filePath or projectPath)
+            try
+              resolve eslintExecute(atom.getConfigDirPath())
+            catch
+              reject(err)
+          else
+            reject(err)
     )

--- a/src/beautifiers/eslint.coffee
+++ b/src/beautifiers/eslint.coffee
@@ -18,11 +18,12 @@ module.exports = class ESLintFixer extends Beautifier
     return new @Promise((resolve, reject) ->
       editor = atom.workspace.getActiveTextEditor()
       filePath = editor.getPath()
+      dir = path.dirname(filePath)
       projectPath = atom.project.relativizePath(filePath)[0]
 
       result = null
       allowUnsafeNewFunction ->
-        importPath = Path.join(projectPath, 'node_modules', 'eslint')
+        importPath = Path.join(projectPath or dir, 'node_modules', 'eslint')
         try
           try
             eslint = require(importPath)
@@ -33,7 +34,7 @@ module.exports = class ESLintFixer extends Beautifier
           if options.errors_only
             fix = (rule) -> rule.severity is 2
 
-          cli = new eslint.CLIEngine(fix: fix, cwd: projectPath)
+          cli = new eslint.CLIEngine(fix: fix, cwd: projectPath or dir)
           result = cli.executeOnText(text).results[0]
 
           resolve result.output

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -112,5 +112,9 @@ module.exports = {
       type: 'boolean'
       default: false
       description: "Insert spaces between brackets in object literals"
+    errors_only:
+      type: 'boolean'
+      default: false
+      description: "Fix errors but leave warnings"
 
 }

--- a/src/options.json
+++ b/src/options.json
@@ -1340,6 +1340,20 @@
           "namespace": "js"
         }
       },
+      "errors_only": {
+        "type": "boolean",
+        "default": false,
+        "description": "Fix errors but leave warnings (Supported by JS Beautify)",
+        "title": "Errors only",
+        "beautifiers": [
+          "JS Beautify"
+        ],
+        "key": "errors_only",
+        "language": {
+          "name": "JavaScript",
+          "namespace": "js"
+        }
+      },
       "indent_inner_html": {
         "type": "boolean",
         "default": false,
@@ -3292,6 +3306,21 @@
           "namespace": "js"
         }
       },
+      "errors_only": {
+        "type": "boolean",
+        "default": false,
+        "description": "Fix errors but leave warnings (Supported by JS Beautify, ESLint Fixer)",
+        "title": "Errors only",
+        "beautifiers": [
+          "JS Beautify",
+          "ESLint Fixer"
+        ],
+        "key": "errors_only",
+        "language": {
+          "name": "JavaScript",
+          "namespace": "js"
+        }
+      },
       "disabled": {
         "title": "Disable Beautifying Language",
         "order": -3,
@@ -3650,6 +3679,20 @@
           "JS Beautify"
         ],
         "key": "object_curly_spacing",
+        "language": {
+          "name": "JavaScript",
+          "namespace": "js"
+        }
+      },
+      "errors_only": {
+        "type": "boolean",
+        "default": false,
+        "description": "Fix errors but leave warnings (Supported by JS Beautify)",
+        "title": "Errors only",
+        "beautifiers": [
+          "JS Beautify"
+        ],
+        "key": "errors_only",
         "language": {
           "name": "JavaScript",
           "namespace": "js"
@@ -4028,6 +4071,20 @@
           "JS Beautify"
         ],
         "key": "object_curly_spacing",
+        "language": {
+          "name": "JavaScript",
+          "namespace": "js"
+        }
+      },
+      "errors_only": {
+        "type": "boolean",
+        "default": false,
+        "description": "Fix errors but leave warnings (Supported by JS Beautify)",
+        "title": "Errors only",
+        "beautifiers": [
+          "JS Beautify"
+        ],
+        "key": "errors_only",
         "language": {
           "name": "JavaScript",
           "namespace": "js"
@@ -8071,6 +8128,20 @@
           "Vue Beautifier"
         ],
         "key": "object_curly_spacing",
+        "language": {
+          "name": "JavaScript",
+          "namespace": "js"
+        }
+      },
+      "errors_only": {
+        "type": "boolean",
+        "default": false,
+        "description": "Fix errors but leave warnings (Supported by Vue Beautifier)",
+        "title": "Errors only",
+        "beautifiers": [
+          "Vue Beautifier"
+        ],
+        "key": "errors_only",
         "language": {
           "name": "JavaScript",
           "namespace": "js"


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

checks for a local eslint but falls back to the global eslint

```
importPath = Path.join(projectPath, 'node_modules', 'eslint')
try
  eslint = require(importPath)
catch
  eslint = require('eslint')
```

Adds an option to only fix errors and leave warnings alone.


### Does this close any currently open issues?

fixes #1739

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [x] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [x] Travis CI passes (Mac support)
- [x] AppVeyor passes (Windows support)
