### PR TITLE
Introduce internal flag `textIsNotEntireFile` inside `context` argument for `beautify()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Next
 - Fix [#1862](https://github.com/Glavin001/atom-beautify/issues/1862) Add support for ocp-indent as an executable
+- Introduce internal flag `textIsNotEntireFile` inside `context` argument for `beautify()`; this should help some beautifiers such as `elm-formatter` correctly beautify file fragments in future (e.g. avoid adding unexpected imports, extra new lines, etc.)
 
 # v0.30.9 (2017-11-22)
 - Fix [#1949](https://github.com/Glavin001/atom-beautify/issues/1949): Fix beautify on save when text has not changed.

--- a/src/beautifiers/index.coffee
+++ b/src/beautifiers/index.coffee
@@ -276,7 +276,7 @@ module.exports = class Beautifiers extends EventEmitter
       logger.error(error)
 
 
-  beautify : (text, allOptions, grammar, filePath, {onSave, language} = {}) ->
+  beautify : (text, allOptions, grammar, filePath, {onSave, language, textIsNotEntireFile} = {}) ->
     return Promise.all(allOptions)
     .then((allOptions) =>
       return new Promise((resolve, reject) =>
@@ -347,6 +347,7 @@ module.exports = class Beautifiers extends EventEmitter
             context =
               filePath: filePath
               fileExtension: fileExtension
+              textIsNotEntireFile: !!textIsNotEntireFile
 
             startTime = new Date()
             beautifier.loadExecutables()

--- a/src/beautify.coffee
+++ b/src/beautify.coffee
@@ -168,11 +168,14 @@ beautify = ({ editor, onSave, language }) ->
 
     # Get current editor's text
     text = undefined
+    textIsNotEntireFile = false
     if not forceEntireFile and isSelection
       text = editor.getSelectedText()
+      textIsNotEntireFile = editor.getSelectedText().length < editor.getText().length
     else
       text = editor.getText()
     oldText = text
+    logger.verbose('textIsNotEntireFile', textIsNotEntireFile)
 
 
     # Get Grammar
@@ -181,7 +184,7 @@ beautify = ({ editor, onSave, language }) ->
 
     # Finally, beautify!
     try
-      beautifier.beautify(text, allOptions, grammarName, editedFilePath, onSave: onSave, language: language)
+      beautifier.beautify(text, allOptions, grammarName, editedFilePath, onSave: onSave, language: language, textIsNotEntireFile: textIsNotEntireFile )
       .then(beautifyCompleted)
       .catch(beautifyCompleted)
     catch e


### PR DESCRIPTION
This should help some beautifiers such as `elm-formatter` correctly beautify file fragments in future (e.g. avoid adding unexpected imports, extra new lines, etc.)

### What does this implement/fix? Explain your changes.

When a beautifier formats something, it is not aware if the given text represents the entire file or just a fraction of it. A new flag called `textIsNotEntireFile` has been introduced to fix this. This flag is now passed to all `beautify()` methods as a part of the fourth argument (`context`). It is the beautifier's choice what to do with this (nothing needs to be done by default).

### Does this close any currently open issues?

Not sure, because I haven't done a rigorous search.

### Any other comments?

I'd like to use `textIsNotEntireFile` with Elm as soon as https://github.com/avh4/elm-format/issues/65 is fixed and so passing a flag to `elm-format` makes sense. This new `textIsNotEntireFile` flag may be also a handy addition to https://github.com/Glavin001/atom-beautify/pull/1990.

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [x] Add change details to `CHANGELOG.md` under "Next" section
- [ ] <s>Added examples for testing to [examples/ directory](examples/)</s>
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)

---

PS: Where should I document the presence of this new flag? Could not find any breakdown of what `context` argument contains.