### PR TITLE
Change from coffee-script to coffeescript for npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "bluebird": "^3.5.0",
     "coffee-fmt": "^0.12.0",
     "coffee-formatter": "^0.1.2",
-    "coffee-script": "^1.12.6",
+    "coffeescript": "^1.12.6",
     "csscomb": "^4.2.0",
     "diff": "^3.2.0",
     "editorconfig": "^0.13.2",

--- a/script/build-options.js
+++ b/script/build-options.js
@@ -9,7 +9,7 @@ _ = require('lodash');
 
 _plus = require('underscore-plus');
 
-require("coffee-script/register");
+require("coffeescript/register");
 
 logger = require('../src/logger')(__filename)
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Changes the package requirement of `coffee-script` to `coffeescript`.  No version change, just syntax as the former is deprecated.
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [X] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [X] Travis CI passes (Mac support)
- [X] AppVeyor passes (Windows support)
