### PR TITLE
Add Vue support to ESLint Fixer beautifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 - Fix [#1862](https://github.com/Glavin001/atom-beautify/issues/1862) Add support for ocp-indent as an executable
 - See [#601](https://github.com/Glavin001/atom-beautify/issues/1862) Add support for tsx files
+- See [#2026](https://github.com/Glavin001/atom-beautify/issues/2026) Add Vue support to ESLint Fixer beautifier
 
 # v0.30.9 (2017-11-22)
 - Fix [#1949](https://github.com/Glavin001/atom-beautify/issues/1949): Fix beautify on save when text has not changed.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ See [all supported options in the documentation at  `docs/options.md`](docs/opti
 | UX Markup | `UX` |`.ux` | **[`Pretty Diff`](https://github.com/prettydiff/prettydiff)** |
 | Vala | `Vala` |`.vala`, `.vapi` | **[`Uncrustify`](https://github.com/uncrustify/uncrustify)** |
 | Visualforce | `Visualforce` |`.page` | **[`Pretty Diff`](https://github.com/prettydiff/prettydiff)** |
-| Vue | `Vue Component` |`.vue` | **[`Vue Beautifier`](https://github.com/Glavin001/atom-beautify/blob/master/src/beautifiers/vue-beautifier.coffee)** |
+| Vue | `Vue Component` |`.vue` | **[`Vue Beautifier`](https://github.com/Glavin001/atom-beautify/blob/master/src/beautifiers/vue-beautifier.coffee)**, [`ESLint Fixer`](https://github.com/eslint/eslint) |
 | XML | `SLD`, `XML`, `XHTML`, `XSD`, `XSL`, `JSP`, `GSP` |`.sld`, `.xml`, `.xhtml`, `.xsd`, `.xsl`, `.jsp`, `.gsp`, `.plist`, `.recipe`, `.config` | **[`Pretty Diff`](https://github.com/prettydiff/prettydiff)**, [`JS Beautify`](https://github.com/beautify-web/js-beautify) |
 | XTemplate | `XTemplate` |`.xtemplate` | **[`Pretty Diff`](https://github.com/prettydiff/prettydiff)** |
 | YAML | `YAML` |`.yml`, `.yaml` | **[`align-yaml`](https://github.com/jonschlinkert/align-yaml)** |

--- a/docs/options.md
+++ b/docs/options.md
@@ -14030,39 +14030,39 @@ Maximum characters per line (0 disables) (Supported by Pretty Diff)
 
 ####  [Vue](#vue) 
 
-**Supported Beautifiers**:  [`Vue Beautifier`](#vue-beautifier) 
+**Supported Beautifiers**:  [`ESLint Fixer`](#eslint-fixer)  [`Vue Beautifier`](#vue-beautifier) 
 
-| Option | Vue Beautifier |
-| --- | --- |
-| `disabled` | :white_check_mark: |
-| `default_beautifier` | :white_check_mark: |
-| `beautify_on_save` | :white_check_mark: |
-| `brace_style` | :white_check_mark: |
-| `break_chained_methods` | :white_check_mark: |
-| `end_of_line` | :white_check_mark: |
-| `end_with_comma` | :white_check_mark: |
-| `end_with_newline` | :white_check_mark: |
-| `eval_code` | :white_check_mark: |
-| `extra_liners` | :white_check_mark: |
-| `indent_char` | :white_check_mark: |
-| `indent_inner_html` | :white_check_mark: |
-| `indent_level` | :white_check_mark: |
-| `indent_scripts` | :white_check_mark: |
-| `indent_size` | :white_check_mark: |
-| `indent_with_tabs` | :white_check_mark: |
-| `jslint_happy` | :white_check_mark: |
-| `keep_array_indentation` | :white_check_mark: |
-| `keep_function_indentation` | :white_check_mark: |
-| `max_preserve_newlines` | :white_check_mark: |
-| `preserve_newlines` | :white_check_mark: |
-| `space_after_anon_function` | :white_check_mark: |
-| `space_before_conditional` | :white_check_mark: |
-| `space_in_paren` | :white_check_mark: |
-| `unescape_strings` | :white_check_mark: |
-| `unformatted` | :white_check_mark: |
-| `wrap_attributes` | :white_check_mark: |
-| `wrap_attributes_indent_size` | :white_check_mark: |
-| `wrap_line_length` | :white_check_mark: |
+| Option | ESLint Fixer | Vue Beautifier |
+| --- | --- | --- |
+| `disabled` | :white_check_mark: | :white_check_mark: |
+| `default_beautifier` | :white_check_mark: | :white_check_mark: |
+| `beautify_on_save` | :white_check_mark: | :white_check_mark: |
+| `brace_style` | :x: | :white_check_mark: |
+| `break_chained_methods` | :x: | :white_check_mark: |
+| `end_of_line` | :x: | :white_check_mark: |
+| `end_with_comma` | :x: | :white_check_mark: |
+| `end_with_newline` | :x: | :white_check_mark: |
+| `eval_code` | :x: | :white_check_mark: |
+| `extra_liners` | :x: | :white_check_mark: |
+| `indent_char` | :x: | :white_check_mark: |
+| `indent_inner_html` | :x: | :white_check_mark: |
+| `indent_level` | :x: | :white_check_mark: |
+| `indent_scripts` | :x: | :white_check_mark: |
+| `indent_size` | :x: | :white_check_mark: |
+| `indent_with_tabs` | :x: | :white_check_mark: |
+| `jslint_happy` | :x: | :white_check_mark: |
+| `keep_array_indentation` | :x: | :white_check_mark: |
+| `keep_function_indentation` | :x: | :white_check_mark: |
+| `max_preserve_newlines` | :x: | :white_check_mark: |
+| `preserve_newlines` | :x: | :white_check_mark: |
+| `space_after_anon_function` | :x: | :white_check_mark: |
+| `space_before_conditional` | :x: | :white_check_mark: |
+| `space_in_paren` | :x: | :white_check_mark: |
+| `unescape_strings` | :x: | :white_check_mark: |
+| `unformatted` | :x: | :white_check_mark: |
+| `wrap_attributes` | :x: | :white_check_mark: |
+| `wrap_attributes_indent_size` | :x: | :white_check_mark: |
+| `wrap_line_length` | :x: | :white_check_mark: |
 
 **Description**:
 
@@ -14093,7 +14093,7 @@ Disable Vue Beautification
 
 **Type**: `string`
 
-**Enum**:  `Vue Beautifier` 
+**Enum**:  `ESLint Fixer`  `Vue Beautifier` 
 
 **Description**:
 

--- a/package.json
+++ b/package.json
@@ -150,6 +150,10 @@
     {
       "name": "Steven Zeck",
       "url": "https://github.com/szeck87"
+    },
+    {
+      "name": "Kohei Hiraga",
+      "url": "https://github.com/range3"
     }
   ],
   "engines": {

--- a/src/beautifiers/eslint.coffee
+++ b/src/beautifiers/eslint.coffee
@@ -10,6 +10,7 @@ module.exports = class ESLintFixer extends Beautifier
 
   options: {
     JavaScript: false
+    Vue: false
   }
 
   beautify: (text, language, options) ->

--- a/src/options.json
+++ b/src/options.json
@@ -8068,6 +8068,7 @@
     "description": "Options for language Vue",
     "collapsed": true,
     "beautifiers": [
+      "ESLint Fixer",
       "Vue Beautifier"
     ],
     "grammars": [
@@ -8559,6 +8560,7 @@
         "default": "Vue Beautifier",
         "description": "Default Beautifier to be used for Vue",
         "enum": [
+          "ESLint Fixer",
           "Vue Beautifier"
         ]
       },


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
just add an Eslint Fixer beautifier option to support Vue language.

...

### Does this close any currently open issues?
#2026 
...

### Any other comments?
Eslint can not only support *.js files but also *.vue files using plugins such as [eslint-plugin-vue](https://github.com/vuejs/eslint-plugin-vue).
The users can use Eslint Fixer beautifier for vue by setting eslint can handle vue files.

...

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [x] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
