### PR TITLE
Fix "Reindent" option for sqlformat.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Next
-- ...
+- Fix "Reindent" option for sqlformat.
 
 # v0.32.0 (2018-03-02)
 - See [#2026](https://github.com/Glavin001/atom-beautify/issues/2026) Add Vue support to ESLint Fixer beautifier. Should be used with [eslint-plugin-vue](https://github.com/vuejs/eslint-plugin-vue).

--- a/src/beautifiers/sqlformat.coffee
+++ b/src/beautifiers/sqlformat.coffee
@@ -17,7 +17,7 @@ module.exports = class Sqlformat extends Beautifier
   beautify: (text, language, options) ->
     @run("sqlformat", [
       @tempFile("input", text)
-      "--reindent=#{options.reindent}" if options.reindent?
+      "--reindent" if (options.reindent? && options.reindent == true)
       "--indent_width=#{options.indent_size}" if options.indent_size?
       "--keywords=#{options.keywords}" if (options.keywords? && options.keywords != 'unchanged')
       "--identifiers=#{options.identifiers}" if (options.identifiers? && options.identifiers != 'unchanged')

--- a/src/beautifiers/sqlformat.coffee
+++ b/src/beautifiers/sqlformat.coffee
@@ -17,7 +17,7 @@ module.exports = class Sqlformat extends Beautifier
   beautify: (text, language, options) ->
     @run("sqlformat", [
       @tempFile("input", text)
-      "--reindent" if (options.reindent? && options.reindent == true)
+      "--reindent" if options.reindent is true
       "--indent_width=#{options.indent_size}" if options.indent_size?
       "--keywords=#{options.keywords}" if (options.keywords? && options.keywords != 'unchanged')
       "--identifiers=#{options.identifiers}" if (options.identifiers? && options.identifiers != 'unchanged')


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

For sqlparse-0.2.3 and sqlparse-0.2.4, beautifying sql will throw "sqlformat: error: argument -r/--reindent: ignored explicit argument". I remove the param asignment in the argument and change if condition.

### Does this close any currently open issues?

No.

### Any other comments?

The code works with user's config about "Reindent" in settings->atom-beautify->sql and I hava tested it in both Ubuntu and Windows.

### Checklist

Check all those that are applicable and complete.

It is the first time I use Travis CI. It passed linux and failed osx, saying "Couldn't set selectedTextBackgroundColor".

- [x] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [x] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [x] AppVeyor passes (Windows support)
