### PR TITLE
Fix to send parser to prettier API properly

### DIFF
--- a/src/beautifiers/prettier.coffee
+++ b/src/beautifiers/prettier.coffee
@@ -31,6 +31,7 @@ module.exports = class Prettier extends Beautifier
       prettierLanguage = _.find(prettier.getSupportInfo().languages, 'name': language)
       if prettierLanguage
         parser = prettierLanguage.parsers[0]
+        options.parser = parser
       else
         reject(new Error("Unknown language for Prettier"))
 
@@ -38,7 +39,7 @@ module.exports = class Prettier extends Beautifier
 
       try
         prettier.resolveConfig(filePath).then((configOptions) ->
-          result = prettier.format(text, configOptions or options, parser)
+          result = prettier.format(text, configOptions or options)
           prettier.clearConfigCache()
           resolve result
         )


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
With the implementation of prettier, I didn't pass the parser into the options properly so it can't beautify anything other than javascript.  This fixes so it works with other supported languages.
...

### Does this close any currently open issues?
Closes #2070 
...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [X] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [X] Added examples for testing to [examples/ directory](examples/)
- [X] Travis CI passes (Mac support)
- [X] AppVeyor passes (Windows support)
