### PR TITLE
Use OS EOL default for split string

### DIFF
--- a/src/beautifiers/rubocop.coffee
+++ b/src/beautifiers/rubocop.coffee
@@ -81,7 +81,7 @@ module.exports = class Rubocop extends Beautifier
         # Rubocop output an error if stdout is empty
         return text if stdout.length == 0
 
-        result = stdout.split("====================" + os.EOL)
+        result = stdout.split("====================")
         result[result.length - 1]
       )
     )

--- a/src/beautifiers/rubocop.coffee
+++ b/src/beautifiers/rubocop.coffee
@@ -5,6 +5,7 @@ Requires https://github.com/bbatsov/rubocop
 "use strict"
 Beautifier = require('./beautifier')
 path = require('path')
+os = require('os')
 
 module.exports = class Rubocop extends Beautifier
   name: "Rubocop"
@@ -80,7 +81,7 @@ module.exports = class Rubocop extends Beautifier
         # Rubocop output an error if stdout is empty
         return text if stdout.length == 0
 
-        result = stdout.split("====================\n")
+        result = stdout.split("====================" + os.EOL)
         result[result.length - 1]
       )
     )


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Uses the OS default EOL character to split the string in rubocop.coffee
...

### Does this close any currently open issues?
Closes #2092 
...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [X] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [X] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
