### PR TITLE
Workaround for Rubocop string split for Windows

### DIFF
--- a/src/beautifiers/rubocop.coffee
+++ b/src/beautifiers/rubocop.coffee
@@ -81,6 +81,8 @@ module.exports = class Rubocop extends Beautifier
         return text if stdout.length == 0
 
         result = stdout.split("====================\n")
+        result = stdout.split("====================\r\n") if result.length == 1
+
         result[result.length - 1]
       )
     )


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Fixes an issue with Rubocop and Windows
...

### Does this close any currently open issues?
Closes #2092 
...

### Any other comments?
This is an ugly hack, sorry.  But `os.EOL` doesn't work for all cases.
...

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [X] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [X] Added examples for testing to [examples/ directory](examples/)
- [x] Travis CI passes (Mac support)
- [x] AppVeyor passes (Windows support)
