### PR TITLE
Fix Docker Executable with optional Executable, PHP-CS-Fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Next
+
+# v0.32.3 (2018-05-14)
 - Issue [#448](https://github.com/Glavin001/atom-beautify/issues/448) Add support for Laravel Blade templates (beta)
+- Fix Docker Executable with optional Executable, PHP-CS-Fixer ([#2129](https://github.com/Glavin001/atom-beautify/pull/2129))
 
 # v0.32.2 (2018-03-10)
 - Revert fix package.json repository field (#2062)

--- a/src/beautifiers/php-cs-fixer.coffee
+++ b/src/beautifiers/php-cs-fixer.coffee
@@ -105,7 +105,7 @@ module.exports = class PHPCSFixer extends Beautifier
       isPhpScript = (finalPhpCsFixerPath.indexOf(".phar") isnt -1) or (finalPhpCsFixerPath.indexOf(".php") isnt -1)
       @verbose('isPhpScript', isPhpScript)
 
-      if finalPhpCsFixerPath and isPhpScript
+      if not phpCsFixer.isInstalled and finalPhpCsFixerPath and isPhpScript
         php.run([finalPhpCsFixerPath, phpCsFixerOptions, tempFile], runOptions)
           .then(=>
             @readFile(tempFile)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

- Optional Executables do not attempt to use Docker when not installed.
- PHP-CS-Fixer does not work with Docker Executable

### Does this close any currently open issues?

No, I do not think so.

### Any other comments?

See #1707.

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [x] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
