### PR TITLE
Require path in phpcbf

### DIFF
--- a/src/beautifiers/phpcbf.coffee
+++ b/src/beautifiers/phpcbf.coffee
@@ -24,6 +24,7 @@ module.exports = class PHPCBF extends Beautifier
       cmd: "phpcbf"
       homepage: "https://github.com/squizlabs/PHP_CodeSniffer"
       installation: "https://github.com/squizlabs/PHP_CodeSniffer#installation"
+      optional: true
       version: {
         parse: (text) -> text.match(/version (\d+\.\d+\.\d+)/)[1]
       }

--- a/src/beautifiers/phpcbf.coffee
+++ b/src/beautifiers/phpcbf.coffee
@@ -4,6 +4,7 @@ Requires https://github.com/FriendsOfPHP/phpcbf
 
 "use strict"
 Beautifier = require('./beautifier')
+path = require('path')
 
 module.exports = class PHPCBF extends Beautifier
   name: "PHPCBF"


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Requires the `path` library in phpcbf.coffee as path is being used but isn't required, thus causing an error.  Also adds the `optional` flag to PHPCBF executable.
...

### Does this close any currently open issues?
Closes #2140 
...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [X] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [X] Added examples for testing to [examples/ directory](examples/)
- [x] Travis CI passes (Mac support)
- [x] AppVeyor passes (Windows support)
