### PR TITLE
eslint beautifier bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Next
 
+# v0.32.5 (2018-05-28)
+- Fixes an issue with Rubocop not working on Windows ([#2092](https://github.com/Glavin001/atom-beautify/issues/2092))
+- Fixes an issue with PHPCBF not running when specifying a path to it ([#2140](https://github.com/Glavin001/atom-beautify/issues/2140))
+- Fixes the repository link to Atom Beautify within Atom's settings ([#2086](https://github.com/Glavin001/atom-beautify/pull/2086))
+
 # v0.32.4 (2018-05-15)
 - Fix php-cs-fixer not running when using `.phar` files ([#2134](https://github.com/Glavin001/atom-beautify/pull/2134))
 - Fix error `Error is not defined` ([#2134](https://github.com/Glavin001/atom-beautify/pull/2134))

--- a/package.json
+++ b/package.json
@@ -204,6 +204,7 @@
     "prettydiff2": "^2.2.7",
     "pug-beautify": "^0.1.1",
     "remark": "6.0.1",
+    "requireg": "^0.1.8",
     "season": "^6.0.2",
     "semver": "^5.5.0",
     "shell-env": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atom-beautify",
   "main": "./src/beautify",
-  "version": "0.32.4",
+  "version": "0.32.5",
   "private": true,
   "description": "Beautify HTML, CSS, JavaScript, PHP, Python, Ruby, Java, C, C++, C#, Objective-C, CoffeeScript, TypeScript, Coldfusion, SQL, and more in Atom",
   "repository": "https://github.com/Glavin001/atom-beautify.git",

--- a/src/beautifiers/eslint.coffee
+++ b/src/beautifiers/eslint.coffee
@@ -3,6 +3,7 @@
 Beautifier = require('./beautifier')
 Path = require('path')
 {allowUnsafeNewFunction} = require 'loophole'
+requireg = require('requireg');
 
 module.exports = class ESLintFixer extends Beautifier
   name: "ESLint Fixer"
@@ -24,10 +25,10 @@ module.exports = class ESLintFixer extends Beautifier
         importPath = Path.join(projectPath, 'node_modules', 'eslint')
         eslint = null
         try
-          eslint = require(importPath)
+          eslint = requireg('eslint')
         catch
           try
-            eslint = requireg('eslint')
+            eslint = require(importPath)
           catch
             try
               eslint = require('eslint')


### PR DESCRIPTION


### What does this implement/fix? Explain your changes.

Eslint beautifier should load globally eslint module which install by `npm i -g eslint` if it do installed.
And there should be some warning to users when it got some problem.

### Does this close any currently open issues?

In this project, no.
But I think there should be some individuals have this problem.

Let me know if any code or desc I commited doesn't match this project rules.
Thank you.

