### PR TITLE
Fix to show executable error instead of Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+- Fixes an issue where Atom Beautify would display a Docker error instead of an executable error ([#2146](https://github.com/Glavin001/atom-beautify/issues/2146))
 
 # v0.32.5 (2018-05-28)
 - Fixes an issue with Rubocop not working on Windows ([#2092](https://github.com/Glavin001/atom-beautify/issues/2092))

--- a/README-template.md
+++ b/README-template.md
@@ -4,7 +4,7 @@
 [![GitHub issues](https://img.shields.io/github/issues/Glavin001/atom-beautify.svg?style=flat-square)](https://github.com/Glavin001/atom-beautify/issues)
 [![Greenkeeper badge](https://badges.greenkeeper.io/Glavin001/atom-beautify.svg)](https://greenkeeper.io/)
 
-[![Slack](https://unibeautify-slack.herokuapp.com/badge.svg)](https://unibeautify-slack.herokuapp.com/)
+[![Slack](https://unibeautify-slack.glitch.me/badge.svg)](https://unibeautify-slack.glitch.me/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/unibeautify.svg?style=social&label=Follow)](https://twitter.com/unibeautify)
 [![Gitter](https://img.shields.io/gitter/room/Glavin001/atom-beautify.svg?style=flat-square)](https://gitter.im/Glavin001/atom-beautify)
 [![Bountysource](https://img.shields.io/bountysource/team/atom-beautify/activity.svg?style=flat-square)](https://www.bountysource.com/teams/atom-beautify)

--- a/src/beautifiers/executable.coffee
+++ b/src/beautifiers/executable.coffee
@@ -394,13 +394,13 @@ class HybridExecutable extends Executable
       )
       .catch((error) =>
         return Promise.reject(error) if not @docker?
-        return @
+        return Promise.resolve(error)
       )
-      .then(() =>
+      .then((errorOrThis) =>
         shouldTryWithDocker = not @isInstalled and @docker?
         @verbose("Executable shouldTryWithDocker", shouldTryWithDocker, @isInstalled, @docker?)
         if shouldTryWithDocker
-          return @initDocker()
+          return @initDocker().catch(() => Promise.reject(errorOrThis))
         return @
       )
       .catch((error) =>
@@ -459,6 +459,5 @@ class HybridExecutable extends Executable
           Object.assign({}, options, { cmd: undefined })
         )
       )
-
 
 module.exports = HybridExecutable


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Fixes the error being shown to users running executables to be that of the executable, not Docker.
...

### Does this close any currently open issues?
Closes #2146 
...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [X] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [X] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
