### PR TITLE
Fix for unnecessary fat arrow warning from linter in executable beaut…

### DIFF
--- a/src/beautifiers/executable.coffee
+++ b/src/beautifiers/executable.coffee
@@ -400,7 +400,7 @@ class HybridExecutable extends Executable
         shouldTryWithDocker = not @isInstalled and @docker?
         @verbose("Executable shouldTryWithDocker", shouldTryWithDocker, @isInstalled, @docker?)
         if shouldTryWithDocker
-          return @initDocker().catch(() => Promise.reject(errorOrThis))
+          return @initDocker().catch(() -> Promise.reject(errorOrThis))
         return @
       )
       .catch((error) =>


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
`npm run lint` was throwing a warning about an unnecessary fat arrow function. This changes the function in question to use a normal arrow instead.
...

### Does this close any currently open issues?
No, just a linter warning.
...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

- [X] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
