### PR TITLE
Fix rubocop exact file exclude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Next
 - Fixes an issue where Atom Beautify would display a Docker error instead of an executable error ([#2146](https://github.com/Glavin001/atom-beautify/issues/2146))
+- Fixes Rubocop not excluding files with an exact pattern match (`db/schema.rb` vs `db/**/*`)
 
 # v0.32.5 (2018-05-28)
 - Fixes an issue with Rubocop not working on Windows ([#2092](https://github.com/Glavin001/atom-beautify/issues/2092))

--- a/src/beautifiers/rubocop.coffee
+++ b/src/beautifiers/rubocop.coffee
@@ -62,7 +62,7 @@ module.exports = class Rubocop extends Beautifier
       rubocopArguments = [
         "--auto-correct"
         "--force-exclusion"
-        "--stdin", "atom-beautify.rb" # filename is required but not used
+        "--stdin", fullPath or "atom-beautify.rb" # --stdin requires an argument
       ]
       exeOptions = {
         ignoreReturnCode: true,


### PR DESCRIPTION
Hello again! It's me, your friendly neighborhood Rubocop repairman, back with another fix to Rubocop's beautifier.

### What does this implement/fix? Explain your changes.

When you tried to exclude an exact filename match, Rubocop would still beautify it. Example:

```
AllCops:
  Exclude:
    - db/schema.rb 
```

### Does this close any currently open issues?

No issues

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [x] Add change details to `CHANGELOG.md` under "Next" section
- [x] ~Added examples for testing to [examples/ directory](examples/)~
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
