### PR TITLE
Appveyor - Ruby 2.4-x64, gem update --system

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,9 @@ install:
   - pip install -r requirements.txt
 
   # Gemfile Install
+  - set PATH=C:\Ruby24-x64\bin;%PATH%
+  - ruby -v
+  - gem update --system
   - bundle install
 
   # PHP


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Appveyor Failures.

1. Used Ruby 2.4 64 bit.  Appveyor defaults to 1.9.3.  Why, I don't know.  I suggest 2.5, but pre-compiled gems may be limited.
2. Updated RubyGems.  The RubyGems/Bundler issue should be fixed in the next release, this gets it passing until then.

### Does this close any currently open issues?

Haven't looked

### Any other comments?

I ended up here due to an open issue in another repo.  I just got the tests to pass, haven't even read the README page.

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [X] AppVeyor passes (Windows support)
