### PR TITLE
Add Black beautifier for Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 - Fixes an issue where Atom Beautify would display a Docker error instead of an executable error ([#2146](https://github.com/Glavin001/atom-beautify/issues/2146))
 - Fixes Rubocop not excluding files with an exact pattern match (`db/schema.rb` vs `db/**/*`)
+- Add [Black](http://github.com/ambv/black) beautifier for Python.
 
 # v0.32.5 (2018-05-28)
 - Fixes an issue with Rubocop not working on Windows ([#2092](https://github.com/Glavin001/atom-beautify/issues/2092))

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Some of the supported beautifiers are developed for Node.js and are automaticall
 | align-yaml | :white_check_mark: | :ok_hand: Not necessary | :smiley: Nothing! |
 | autopep8 | :warning: 2 executables | :warning: Only 1 of 2 executables | :whale: With [Docker](https://www.docker.com/):<br/>1. Install [autopep8 (`autopep8`)](https://github.com/hhatto/autopep8) with `docker pull unibeautify/autopep8`<br/><br/>:bookmark_tabs: Manually:<br/>1. Install [autopep8 (`autopep8`)](https://github.com/hhatto/autopep8) by following https://github.com/hhatto/autopep8#installation<br/>2. Install [isort (`isort`)](https://github.com/timothycrosley/isort) by following https://github.com/timothycrosley/isort#installing-isort<br/> |
 | beautysh | :warning: 1 executable | :white_check_mark: :100:% of executables | :whale: With [Docker](https://www.docker.com/):<br/>1. Install [beautysh (`beautysh`)](https://github.com/bemeurer/beautysh) with `docker pull unibeautify/beautysh`<br/><br/>:bookmark_tabs: Manually:<br/>1. Install [beautysh (`beautysh`)](https://github.com/bemeurer/beautysh) by following https://github.com/bemeurer/beautysh#installation<br/> |
+| black | :warning: 1 executable | :x: No Docker support | :bookmark_tabs: Manually:<br/>1. Install [black (`black`)](https://github.com/ambv/black) by following https://github.com/ambv/black#installation<br/> |
 | brittany | :warning: Manual installation | :construction: Not an executable | :page_facing_up: Go to https://github.com/lspitzner/brittany and follow the instructions. |
 | clang-format | :warning: 1 executable | :white_check_mark: :100:% of executables | :whale: With [Docker](https://www.docker.com/):<br/>1. Install [ClangFormat (`clang-format`)](https://clang.llvm.org/docs/ClangFormat.html) with `docker pull unibeautify/clang-format`<br/><br/>:bookmark_tabs: Manually:<br/>1. Install [ClangFormat (`clang-format`)](https://clang.llvm.org/docs/ClangFormat.html) by following https://clang.llvm.org/docs/ClangFormat.html<br/> |
 | cljfmt | :white_check_mark: | :ok_hand: Not necessary | :smiley: Nothing! |
@@ -196,7 +197,7 @@ See [all supported options in the documentation at  `docs/options.md`](docs/opti
 | Perl | `Perl`, `Perl 6` |`.pl`, `.PL`, `.pm`, `.pod`, `.t` | **[`Perltidy`](http://perltidy.sourceforge.net/)** |
 | PHP | `PHP` |`.php`, `.module`, `.inc` | **[`PHP-CS-Fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer)**, [`PHPCBF`](http://php.net/manual/en/install.php), [`hh_format`](http://hhvm.com/) |
 | Puppet | `Puppet` |`.pp` | **[`puppet-lint`](http://puppet-lint.com/)** |
-| Python | `Python`, `MagicPython` |`.py` | **[`autopep8`](https://github.com/hhatto/autopep8)**, [`pybeautifier`](https://github.com/guyskk/pybeautifier), [`yapf`](https://github.com/google/yapf) |
+| Python | `Python`, `MagicPython` |`.py` | **[`autopep8`](https://github.com/hhatto/autopep8)**, [`black`](https://github.com/ambv/black), [`pybeautifier`](https://github.com/guyskk/pybeautifier), [`yapf`](https://github.com/google/yapf) |
 | R | `R` |`.r`, `.R` | **[`formatR`](https://github.com/yihui/formatR)** |
 | Riot.js | `Riot.js`, `HTML (Riot Tag)` |`.tag` | **[`Pretty Diff`](https://github.com/prettydiff/prettydiff)** |
 | Ruby | `Ruby`, `Ruby on Rails` |`.rb` | **[`Rubocop`](https://github.com/bbatsov/rubocop)**, [`Ruby Beautify`](https://github.com/erniebrodeur/ruby-beautify) |

--- a/docs/options.md
+++ b/docs/options.md
@@ -164,6 +164,23 @@ Options for beautysh executable.
 2. Go into *Packages* and search for "*Atom Beautify*" package.
 3. Find the option "*beautysh*" and change it to your desired configuration.
 
+#####  [black](#black) 
+
+**Important**: This option is only configurable from within Atom Beautify's setting panel.
+
+**Type**: `object`
+
+**Description**:
+
+Options for black executable.
+
+**How to Configure**
+
+1. You can open the [Settings View](https://github.com/atom/settings-view) by navigating to
+*Edit > Preferences (Linux)*, *Atom > Preferences (OS X)*, or *File > Preferences (Windows)*.
+2. Go into *Packages* and search for "*Atom Beautify*" package.
+3. Find the option "*black*" and change it to your desired configuration.
+
 #####  [ClangFormat](#clangformat) 
 
 **Important**: This option is only configurable from within Atom Beautify's setting panel.
@@ -10644,20 +10661,20 @@ Automatically beautify Puppet files on save
 
 ####  [Python](#python) 
 
-**Supported Beautifiers**:  [`autopep8`](#autopep8)  [`pybeautifier`](#pybeautifier)  [`yapf`](#yapf) 
+**Supported Beautifiers**:  [`autopep8`](#autopep8)  [`black`](#black)  [`pybeautifier`](#pybeautifier)  [`yapf`](#yapf) 
 
-| Option | autopep8 | pybeautifier | yapf |
-| --- | --- | --- | --- |
-| `disabled` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `default_beautifier` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `beautify_on_save` | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `formatter` | :white_check_mark: | :white_check_mark: | :x: |
-| `ignore` | :white_check_mark: | :white_check_mark: | :x: |
-| `indent_size` | :white_check_mark: | :white_check_mark: | :x: |
-| `max_line_length` | :white_check_mark: | :white_check_mark: | :x: |
-| `multi_line_output` | :white_check_mark: | :white_check_mark: | :x: |
-| `sort_imports` | :white_check_mark: | :white_check_mark: | :x: |
-| `style_config` | :white_check_mark: | :white_check_mark: | :x: |
+| Option | autopep8 | black | pybeautifier | yapf |
+| --- | --- | --- | --- | --- |
+| `disabled` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `default_beautifier` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `beautify_on_save` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `formatter` | :white_check_mark: | :x: | :white_check_mark: | :x: |
+| `ignore` | :white_check_mark: | :x: | :white_check_mark: | :x: |
+| `indent_size` | :white_check_mark: | :x: | :white_check_mark: | :x: |
+| `max_line_length` | :white_check_mark: | :x: | :white_check_mark: | :x: |
+| `multi_line_output` | :white_check_mark: | :x: | :white_check_mark: | :x: |
+| `sort_imports` | :white_check_mark: | :x: | :white_check_mark: | :x: |
+| `style_config` | :white_check_mark: | :x: | :white_check_mark: | :x: |
 
 **Description**:
 
@@ -10688,7 +10705,7 @@ Disable Python Beautification
 
 **Type**: `string`
 
-**Enum**:  `autopep8`  `pybeautifier`  `yapf` 
+**Enum**:  `autopep8`  `black`  `pybeautifier`  `yapf` 
 
 **Description**:
 

--- a/package.json
+++ b/package.json
@@ -168,6 +168,10 @@
     {
       "name": "Kohei Hiraga",
       "url": "https://github.com/range3"
+    },
+    {
+      "name": "Arlo Shallit",
+      "url": "https://github.com/arl-o"
     }
   ],
   "engines": {
@@ -446,7 +450,8 @@
     "vhdl",
     "vhdl beautifier",
     "gn",
-    "blade"
+    "blade",
+    "black"
   ],
   "devDependencies": {
     "codo": "^2.1.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ autopep8
 isort
 sqlparse
 beautysh
+black

--- a/src/beautifiers/black.coffee
+++ b/src/beautifiers/black.coffee
@@ -1,0 +1,39 @@
+###
+Requires [black](https://github.com/ambv/black)
+###
+"use strict"
+Beautifier = require('./beautifier')
+path = require('path')
+
+module.exports = class Black extends Beautifier
+  name: "black"
+  link: "https://github.com/ambv/black"
+  executables: [
+    {
+      name: "black"
+      cmd: "black"
+      homepage: "https://github.com/ambv/black"
+      installation: "https://github.com/ambv/black#installation"
+      version: {
+        parse: (text) -> 
+          # Try to read beta values, eg "black, version 18.6b4" -> 18.6.4
+          try
+            text.match(/black, version (\d+\.\d+)/)[1] + "." + text.match(/b(\d+)$/)[1]
+          catch
+            text.match(/black, version (\d+\.\d+)/)[1] + ".0"
+      }
+    }
+  ]
+
+  options: {
+    Python: false
+  }
+
+  beautify: (text, language, options, context) ->
+    cwd = context.filePath and path.dirname context.filePath
+    # `-` as filename reads from stdin
+    @exe("black").run(["-"], {
+      cwd: cwd
+      onStdin: (stdin) ->
+        stdin.end text
+    })

--- a/src/beautifiers/index.coffee
+++ b/src/beautifiers/index.coffee
@@ -43,6 +43,7 @@ module.exports = class Beautifiers extends EventEmitter
     'cljfmt'
     'clang-format'
     'crystal'
+    'black'
     'dfmt'
     'elm-format'
     'hh_format'

--- a/src/options.json
+++ b/src/options.json
@@ -6274,6 +6274,7 @@
     ],
     "beautifiers": [
       "autopep8",
+      "black",
       "pybeautifier",
       "yapf"
     ],
@@ -6424,6 +6425,7 @@
         "description": "Default Beautifier to be used for Python",
         "enum": [
           "autopep8",
+          "black",
           "pybeautifier",
           "yapf"
         ]
@@ -9436,6 +9438,22 @@
             "type": "string",
             "default": "",
             "description": "Absolute path to the \"crystal\" executable's binary/script."
+          }
+        }
+      },
+      "black": {
+        "key": "black",
+        "title": "black",
+        "type": "object",
+        "collapsed": true,
+        "description": "Options for black executable.",
+        "properties": {
+          "path": {
+            "key": "path",
+            "title": "Binary/Script Path",
+            "type": "string",
+            "default": "",
+            "description": "Absolute path to the \"black\" executable's binary/script."
           }
         }
       },


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Adds support for the [Black](http://github.com/ambv/black) python beautifier. 

### Does this close any currently open issues?

Closes #2144 

### Any other comments?

Currently does not support line length option, since Black uses a different default from autopep8 and yapf which I did not want to overwrite. (Is there a supported way to set this on an executable-basis?)

I also did not see how to set up test examples for specific beautifiers, instead of specific languages. Is there a way to do this? 

### Checklist

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [x] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
