### PR TITLE
Add `ocamlformat` formatter for OCaml.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Some of the supported beautifiers are developed for Node.js and are automaticall
 | Lua beautifier | :white_check_mark: | :ok_hand: Not necessary | :smiley: Nothing! |
 | Marko Beautifier | :white_check_mark: | :ok_hand: Not necessary | :smiley: Nothing! |
 | Nginx Beautify | :white_check_mark: | :ok_hand: Not necessary | :smiley: Nothing! |
+| ocamlformat | :warning: 1 executable | :x: No Docker support | :bookmark_tabs: Manually:<br/>1. Install [ocamlformat (`ocamlformat`)](https://github.com/ocaml-ppx/ocamlformat) by following https://github.com/ocaml-ppx/ocamlformat#installation<br/> |
 | ocp-indent | :warning: 1 executable | :white_check_mark: :100:% of executables | :whale: With [Docker](https://www.docker.com/):<br/>1. Install [ocp-indent (`ocp-indent`)](https://www.typerex.org/ocp-indent.html) with `docker pull unibeautify/ocp-indent`<br/><br/>:bookmark_tabs: Manually:<br/>1. Install [ocp-indent (`ocp-indent`)](https://www.typerex.org/ocp-indent.html) by following https://www.typerex.org/ocp-indent.html#installation<br/> |
 | Perltidy | :warning: Manual installation | :construction: Not an executable | :page_facing_up: Go to http://perltidy.sourceforge.net/ and follow the instructions. |
 | PHP-CS-Fixer | :warning: 2 executables | :warning: Only 1 of 2 executables | :whale: With [Docker](https://www.docker.com/):<br/>1. Install [PHP-CS-Fixer (`php-cs-fixer`)](https://github.com/FriendsOfPHP/PHP-CS-Fixer) with `docker pull unibeautify/php-cs-fixer`<br/><br/>:bookmark_tabs: Manually:<br/>1. Install [PHP (`php`)](http://php.net/) by following http://php.net/manual/en/install.php<br/>2. Install [PHP-CS-Fixer (`php-cs-fixer`)](https://github.com/FriendsOfPHP/PHP-CS-Fixer) by following https://github.com/FriendsOfPHP/PHP-CS-Fixer#installation<br/> |
@@ -191,7 +192,7 @@ See [all supported options in the documentation at  `docs/options.md`](docs/opti
 | Nginx | `nginx` |`.conf` | **[`Nginx Beautify`](https://github.com/denysvitali/nginxbeautify)** |
 | Nunjucks | `Nunjucks`, `Nunjucks Templates`, `HTML (Nunjucks Templates)` |`.njk`, `.nunjucks` | **[`Pretty Diff`](https://github.com/prettydiff/prettydiff)** |
 | Objective-C | `Objective-C`, `Objective-C++` |`.m`, `.mm`, `.h` | **[`Uncrustify`](https://github.com/uncrustify/uncrustify)**, [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) |
-| OCaml | `OCaml` |`.ml` | **[`ocp-indent`](https://www.typerex.org/ocp-indent.html)** |
+| OCaml | `OCaml` |`.ml` | **[`ocp-indent`](https://www.typerex.org/ocp-indent.html)**, [`ocamlformat`](https://github.com/ocaml-ppx/ocamlformat) |
 | Pawn | `Pawn` | | **[`Uncrustify`](https://github.com/uncrustify/uncrustify)** |
 | Perl | `Perl`, `Perl 6` |`.pl`, `.PL`, `.pm`, `.pod`, `.t` | **[`Perltidy`](http://perltidy.sourceforge.net/)** |
 | PHP | `PHP` |`.php`, `.module`, `.inc` | **[`PHP-CS-Fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer)**, [`PHPCBF`](http://php.net/manual/en/install.php), [`hh_format`](http://hhvm.com/) |

--- a/docs/options.md
+++ b/docs/options.md
@@ -300,6 +300,23 @@ Options for isort executable.
 2. Go into *Packages* and search for "*Atom Beautify*" package.
 3. Find the option "*isort*" and change it to your desired configuration.
 
+#####  [ocamlformat](#ocamlformat) 
+
+**Important**: This option is only configurable from within Atom Beautify's setting panel.
+
+**Type**: `object`
+
+**Description**:
+
+Options for ocamlformat executable.
+
+**How to Configure**
+
+1. You can open the [Settings View](https://github.com/atom/settings-view) by navigating to
+*Edit > Preferences (Linux)*, *Atom > Preferences (OS X)*, or *File > Preferences (Windows)*.
+2. Go into *Packages* and search for "*Atom Beautify*" package.
+3. Find the option "*ocamlformat*" and change it to your desired configuration.
+
 #####  [ocp-indent](#ocp-indent) 
 
 **Important**: This option is only configurable from within Atom Beautify's setting panel.
@@ -9985,13 +10002,13 @@ Path to uncrustify config file. i.e. uncrustify.cfg (Supported by Uncrustify)
 
 ####  [OCaml](#ocaml) 
 
-**Supported Beautifiers**:  [`ocp-indent`](#ocp-indent) 
+**Supported Beautifiers**:  [`ocp-indent`](#ocp-indent)  [`ocamlformat`](#ocamlformat) 
 
-| Option | ocp-indent |
-| --- | --- |
-| `disabled` | :white_check_mark: |
-| `default_beautifier` | :white_check_mark: |
-| `beautify_on_save` | :white_check_mark: |
+| Option | ocamlformat | ocp-indent |
+| --- | --- | --- |
+| `disabled` | :white_check_mark: | :white_check_mark: |
+| `default_beautifier` | :white_check_mark: | :white_check_mark: |
+| `beautify_on_save` | :white_check_mark: | :white_check_mark: |
 
 **Description**:
 
@@ -10022,7 +10039,7 @@ Disable OCaml Beautification
 
 **Type**: `string`
 
-**Enum**:  `ocp-indent` 
+**Enum**:  `ocp-indent`  `ocamlformat` 
 
 **Description**:
 

--- a/package.json
+++ b/package.json
@@ -446,7 +446,8 @@
     "vhdl",
     "vhdl beautifier",
     "gn",
-    "blade"
+    "blade",
+    "ocamlformat"
   ],
   "devDependencies": {
     "codo": "^2.1.2",

--- a/src/beautifiers/index.coffee
+++ b/src/beautifiers/index.coffee
@@ -87,6 +87,7 @@ module.exports = class Beautifiers extends EventEmitter
     'beautysh'
     'terraformfmt'
     'verilog-mode'
+    'ocamlformat'
   ]
 
   ###

--- a/src/beautifiers/ocamlformat.coffee
+++ b/src/beautifiers/ocamlformat.coffee
@@ -1,0 +1,38 @@
+###
+Requires https://github.com/ocaml-ppx/ocamlformat
+###
+
+"use strict"
+Beautifier = require('./beautifier')
+
+module.exports = class OCamlFormat extends Beautifier
+  name: "ocamlformat"
+  link: "https://github.com/ocaml-ppx/ocamlformat"
+  executables: [
+    {
+      name: "ocamlformat"
+      cmd: "ocamlformat"
+      homepage: "https://github.com/ocaml-ppx/ocamlformat"
+      installation: "https://github.com/ocaml-ppx/ocamlformat#installation"
+      version: {
+        parse: (text) ->
+          try
+            text.match(/(\d+\.\d+\.\d+)/)[1]
+          catch
+            text.match(/(\d+\.\d+)/)[1] + ".0"
+      }
+    }
+  ]
+
+  options: {
+    OCaml: true
+  }
+
+  beautify: (text, language, options) ->
+    @run("ocamlformat", [
+      @tempFile("input", text)
+      ], {
+        help: {
+          link: "https://github.com/ocaml-ppx/ocamlformat"
+        }
+      })

--- a/src/options.json
+++ b/src/options.json
@@ -5875,7 +5875,8 @@
     "description": "Options for language OCaml",
     "collapsed": true,
     "beautifiers": [
-      "ocp-indent"
+      "ocp-indent",
+      "ocamlformat"
     ],
     "grammars": [
       "OCaml"
@@ -5898,7 +5899,8 @@
         "default": "ocp-indent",
         "description": "Default Beautifier to be used for OCaml",
         "enum": [
-          "ocp-indent"
+          "ocp-indent",
+          "ocamlformat"
         ]
       },
       "beautify_on_save": {
@@ -9676,6 +9678,22 @@
             "type": "string",
             "default": "",
             "description": "Absolute path to the \"terraform\" executable's binary/script."
+          }
+        }
+      },
+      "ocamlformat": {
+        "key": "ocamlformat",
+        "title": "ocamlformat",
+        "type": "object",
+        "collapsed": true,
+        "description": "Options for ocamlformat executable.",
+        "properties": {
+          "path": {
+            "key": "path",
+            "title": "Binary/Script Path",
+            "type": "string",
+            "default": "",
+            "description": "Absolute path to the \"ocamlformat\" executable's binary/script."
           }
         }
       }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Adds an alternative formatter for OCaml.

### Does this close any currently open issues?

Nope.

### Any other comments?

I followed the steps [here](https://github.com/Glavin001/atom-beautify/blob/master/docs/add-languages-and-beautifiers.md) except the 4th one -- I'm not sure how to add tests for this. https://github.com/Glavin001/atom-beautify/tree/master/examples/nested-jsbeautifyrc/ocaml already includes a test case for ocp-indent and I couldn't figure out to create one for ocamlformat.

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [x] Travis CI passes (Mac support)
- [x] AppVeyor passes (Windows support)
