### PR TITLE
Fix #2204. Auto-remove docker containers after run.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v0.33.3 (2018-09-28)
+
+- Fix [#2204](https://github.com/Glavin001/atom-beautify/issues/2204). Auto-remove docker containers after run.
+
+You can clean up old Docker containers by running:
+
+```bash
+docker ps --all | grep "unibeautify/" | awk '{ print $1 }' | xargs docker rm
+```
 
 # v0.33.2 (2018-09-26)
 - (BREAKING CHANGE) Added `inline` and `content_unformatted` options from `js-beautify` html settings and cleared `unformatted`.  Breaking change but generally improves the behavior to more accurately beautify html. ([#2210](https://github.com/Glavin001/atom-beautify/issues/2210), [#2215](https://github.com/Glavin001/atom-beautify/pull/2215), [js-beautify#1407](https://github.com/beautify-web/js-beautify/pull/1407))

--- a/src/beautifiers/executable.coffee
+++ b/src/beautifiers/executable.coffee
@@ -450,6 +450,7 @@ class HybridExecutable extends Executable
 
         @docker.run([
             "run",
+            "--rm",
             "--volume", "#{pwd}:#{workingDir}",
             "--volume", "#{path.resolve('/')}:#{rootPath}",
             "--workdir", workingDir,


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

![image](https://user-images.githubusercontent.com/1885333/46240002-53d82980-c377-11e8-9ca8-751680e946b7.png)

### Does this close any currently open issues?

https://github.com/Glavin001/atom-beautify/issues/2204

### Any other comments?

You can use the following to clean up:

```bash
docker ps --all | grep "unibeautify/" | awk '{ print $1 }' | xargs docker rm
```

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [x] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
