### PR TITLE
Add isort capability to black beautifier

### DIFF
--- a/src/beautifiers/black.coffee
+++ b/src/beautifiers/black.coffee
@@ -47,14 +47,15 @@ module.exports = class Black extends Beautifier
       onStdin: (stdin) ->
         stdin.end text
     })
-    .then(=>
+    .then((stdout) =>
+        console.log stdout
         if options.sort_imports
             filePath = context.filePath
             projectPath = atom?.project.relativizePath(filePath)[0]
             @exe("isort").run(["-sp", projectPath, "-"], {
                 cwd: cwd
                 onStdin: (stdin) ->
-                    stdin.end text
+                    stdin.end stdout
             })
     )
 

--- a/src/beautifiers/black.coffee
+++ b/src/beautifiers/black.coffee
@@ -23,6 +23,16 @@ module.exports = class Black extends Beautifier
             text.match(/black, version (\d+\.\d+)/)[1] + ".0"
       }
     }
+    {
+      name: "isort"
+      cmd: "isort"
+      optional: true
+      homepage: "https://github.com/timothycrosley/isort"
+      installation: "https://github.com/timothycrosley/isort#installing-isort"
+      version: {
+        parse: (text) -> text.match(/VERSION (\d+\.\d+\.\d+)/)[1]
+      }
+    }
   ]
 
   options: {
@@ -37,3 +47,14 @@ module.exports = class Black extends Beautifier
       onStdin: (stdin) ->
         stdin.end text
     })
+    .then(=>
+        if options.sort_imports
+            filePath = context.filePath
+            projectPath = atom?.project.relativizePath(filePath)[0]
+            @exe("isort").run(["-sp", projectPath, "-"], {
+                cwd: cwd
+                onStdin: (stdin) ->
+                    stdin.end text
+            })
+    )
+


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Allows the `Sort imports` option to work with the `black` beautifier.

### Does this close any currently open issues?

None that I saw.

### Any other comments?

I'll work on the checklist. 

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
