### PR TITLE
Fix `ocamlformat` for `.mli` files.

### DIFF
--- a/src/beautifiers/ocamlformat.coffee
+++ b/src/beautifiers/ocamlformat.coffee
@@ -28,9 +28,10 @@ module.exports = class OCamlFormat extends Beautifier
     OCaml: true
   }
 
-  beautify: (text, language, options) ->
+  beautify: (text, language, options, context) ->
+    fileExtension = context.fileExtension
     @run("ocamlformat", [
-      @tempFile("input", text)
+      @tempFile("input", text, fileExtension and ".#{fileExtension}")
       ], {
         help: {
           link: "https://github.com/ocaml-ppx/ocamlformat"


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

`ocamlformat` assumes that the input is a `.ml` file if the file doesn't have a
known extension which causes errors when beautifying `.mli` files.

This commit reuses the extension of the current file in the temp file name
which works both for `.ml` files and `.mli`.

### Does this close any currently open issues?

No.

### Any other comments?

Nope.

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
