### PR TITLE
MINOR: Enabled isort after black formatting for python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ You can clean up old Docker containers by running:
 docker ps --all | grep "unibeautify/" | awk '{ print $1 }' | xargs docker rm
 ```
 
+# Next
+- Added support for `sort imports` when using the `black` as the Python beautifier.
+
 # v0.33.2 (2018-09-26)
 - (BREAKING CHANGE) Added `inline` and `content_unformatted` options from `js-beautify` html settings and cleared `unformatted`.  Breaking change but generally improves the behavior to more accurately beautify html. ([#2210](https://github.com/Glavin001/atom-beautify/issues/2210), [#2215](https://github.com/Glavin001/atom-beautify/pull/2215), [js-beautify#1407](https://github.com/beautify-web/js-beautify/pull/1407))
 - ocamlformat formatter added for OCaml [#2207](https://github.com/Glavin001/atom-beautify/pull/2207)

--- a/package.json
+++ b/package.json
@@ -176,6 +176,10 @@
     {
       "name": "Liam Newman",
       "url": "https://github.com/bitwiseman"
+    },
+    {
+      "name": "Stephen J. Bush",
+      "url": "https://github.com/muppetjones"
     }
   ],
   "engines": {

--- a/src/beautifiers/black.coffee
+++ b/src/beautifiers/black.coffee
@@ -23,17 +23,32 @@ module.exports = class Black extends Beautifier
             text.match(/black, version (\d+\.\d+)/)[1] + ".0"
       }
     }
+    {
+      name: "isort"
+      cmd: "isort"
+      optional: true
+      homepage: "https://github.com/timothycrosley/isort"
+      installation: "https://github.com/timothycrosley/isort#installing-isort"
+      version: {
+        parse: (text) -> text.match(/VERSION (\d+\.\d+\.\d+)/)[1]
+      }
+    }
   ]
 
   options: {
-    Python: false
+    Python: true
   }
 
   beautify: (text, language, options, context) ->
-    cwd = context.filePath and path.dirname context.filePath
-    # `-` as filename reads from stdin
-    @exe("black").run(["-"], {
-      cwd: cwd
-      onStdin: (stdin) ->
-        stdin.end text
-    })
+    @exe("black").run([
+        tempFile = @tempFile("input", text)
+    ])
+    .then(=>
+        console.log tempFile
+        if options.sort_imports
+          console.log "sort imports"
+          filePath = context.filePath
+          projectPath = atom?.project.relativizePath(filePath)[0]
+          @exe("isort").run(["-sp", projectPath, tempFile])
+      )
+    .then(=> @readFile(tempFile))


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

The `black` beautifier did not honor the `sort imports` option. This update will allow `isort` to run after `black` if the option is selected.

### Does this close any currently open issues?

No.

### Any other comments?

* `black` and `isort` don't always play nicely, but a solution seems to [be in the works](https://github.com/ambv/black/issues/333)
* There are not any tests or docs for `black`, so neither were updated.

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [x] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
