### PR TITLE
Adding Clojure executable options

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -1642,6 +1642,7 @@ Maximum characters per line (0 disables) (Supported by Pretty Diff)
 | `disabled` | :white_check_mark: |
 | `default_beautifier` | :white_check_mark: |
 | `beautify_on_save` | :white_check_mark: |
+| `executable_path` | :white_check_mark: |
 
 **Description**:
 
@@ -1701,6 +1702,32 @@ Automatically beautify Clojure files on save
 *Edit > Preferences (Linux)*, *Atom > Preferences (OS X)*, or *File > Preferences (Windows)*.
 2. Go into *Packages* and search for "*Atom Beautify*" package.
 3. Find the option "*Beautify On Save*" and change it to your desired configuration.
+
+#####  [Executable path](#executable-path) 
+
+**Namespace**: `clj`
+
+**Key**: `executable_path`
+
+**Default**: `C:\Users\david\Documents\GitHub\node_modules\.bin\cljfmt`
+
+**Type**: `string`
+
+**Supported Beautifiers**:  [`cljfmt`](#cljfmt) 
+
+**Description**:
+
+The path to the cljfmt executable to use (Supported by cljfmt)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "clj": {
+        "executable_path": "C:\\Users\\david\\Documents\\GitHub\\node_modules\\.bin\\cljfmt"
+    }
+}
+```
 
 ####  [CoffeeScript](#coffeescript) 
 
@@ -20371,6 +20398,35 @@ Path to clang-format config file. i.e. clang-format.cfg (Supported by clang-form
 {
     "glsl": {
         "configPath": ""
+    }
+}
+```
+
+
+### cljfmt
+
+#####  [Executable path](#executable-path) 
+
+**Namespace**: `clj`
+
+**Key**: `executable_path`
+
+**Default**: `C:\Users\david\Documents\GitHub\node_modules\.bin\cljfmt`
+
+**Type**: `string`
+
+**Supported Beautifiers**:  [`cljfmt`](#cljfmt) 
+
+**Description**:
+
+The path to the cljfmt executable to use (Supported by cljfmt)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "clj": {
+        "executable_path": "C:\\Users\\david\\Documents\\GitHub\\node_modules\\.bin\\cljfmt"
     }
 }
 ```

--- a/src/beautifiers/cljfmt/index.coffee
+++ b/src/beautifiers/cljfmt/index.coffee
@@ -8,12 +8,13 @@ module.exports = class Cljfmt extends Beautifier
   link: "https://github.com/snoe/node-cljfmt"
 
   options: {
-    Clojure: false
+    Clojure:
+      executable_path: true
   }
 
   beautify: (text, language, options) ->
     formatPath = path.resolve(__dirname, "fmt.edn")
-    cljfmt = path.resolve(__dirname, "..", "..", "..", "node_modules/.bin/cljfmt")
+    cljfmt = options.executable_path
     @tempFile("input", text).then((filePath) =>
       @run(cljfmt, [
         filePath,

--- a/src/languages/clojure.coffee
+++ b/src/languages/clojure.coffee
@@ -1,3 +1,4 @@
+path = require('path')
 module.exports = {
 
   name: "Clojure"
@@ -18,4 +19,11 @@ module.exports = {
   ]
 
   defaultBeautifier: "cljfmt"
+
+  options: {
+    executable_path:
+      type: 'string'
+      default: path.resolve(__dirname, "..", "..", "..", "node_modules/.bin/cljfmt")
+      description: "The path to the cljfmt executable to use"
+  }
 }

--- a/src/options.json
+++ b/src/options.json
@@ -669,6 +669,20 @@
       "edn"
     ],
     "properties": {
+      "executable_path": {
+        "type": "string",
+        "default": "C:\\Users\\david\\Documents\\GitHub\\node_modules\\.bin\\cljfmt",
+        "description": "The path to the cljfmt executable to use (Supported by cljfmt)",
+        "title": "Executable path",
+        "beautifiers": [
+          "cljfmt"
+        ],
+        "key": "executable_path",
+        "language": {
+          "name": "Clojure",
+          "namespace": "clj"
+        }
+      },
       "disabled": {
         "title": "Disable Beautifying Language",
         "order": -3,


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Per #1488, #1544 and #2329, there is a bug where windows can't fin the `cljfmt` executable.  This update doesn't fix any of the errors there, but does allow the user to either use a globally installed `cljfmt` or to fix the path name manually in the settings.

### Does this close any currently open issues?
Yes, it should close #1488 and #2329 as well as finish the closed and abandoned PR #1544.

### Any other comments?


### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section - There was no next section
- [ ] Added examples for testing to [examples/ directory](examples/) - N/A as I didn't change any beautifying, just options.
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
