### PR TITLE
terraform v0.12 requires filename with a `.tf` extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+- Fix [#2348](https://github.com/Glavin001/atom-beautify/issues/2348) Terraform Fmt failing on .tf files
+
 # v0.33.4 (2018-09-28)
 
 - Fix [#2204](https://github.com/Glavin001/atom-beautify/issues/2204). Auto-remove docker containers after run.

--- a/package.json
+++ b/package.json
@@ -176,6 +176,10 @@
     {
       "name": "Liam Newman",
       "url": "https://github.com/bitwiseman"
+    },
+    {
+      "name": "Mithun Ayachit",
+      "url": "https://github.com/mithun"
     }
   ],
   "engines": {

--- a/src/beautifiers/terraformfmt.coffee
+++ b/src/beautifiers/terraformfmt.coffee
@@ -31,7 +31,7 @@ module.exports = class Terraformfmt extends Beautifier
   beautify: (text, language, options) ->
     @exe("terraform").run([
       "fmt"
-      tempFile = @tempFile("input", text)
+      tempFile = @tempFile("input", text, ".tf")
       ])
       .then(=>
         @readFile(tempFile)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Fixes beautification for terraform 0.12. Starting with v0.12.0 `terraform fmt` expects file names to use the `.tf` extension.

### Does this close any currently open issues?

Yes. #2348 

### Any other comments?

No

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [x] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
