### PR TITLE
Fix "Cannot read property 'split' of undefined"

### DIFF
--- a/src/beautifiers/php-cs-fixer.coffee
+++ b/src/beautifiers/php-cs-fixer.coffee
@@ -61,7 +61,7 @@ module.exports = class PHPCSFixer extends Beautifier
       options.cs_fixer_config_file = if context? and context.filePath? then @findFile(path.dirname(context.filePath), configFiles)
 
     # Try again to find a config file in the project root
-    if not options.cs_fixer_config_file
+    if not options.cs_fixer_config_file and atom.project.getPaths()[0]
       options.cs_fixer_config_file = @findFile(atom.project.getPaths()[0], configFiles)
 
     phpCsFixerOptions = [


### PR DESCRIPTION
### What does this implement/fix?

This fixes the "Cannot read property 'split' of undefined" bug when using `php-cs-fixer`.

### Does this close any currently open issues?

This bug closes [this issue](https://github.com/Glavin001/atom-beautify/issues/2044).
