### PR TITLE
Fix beautysh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+- Fixes [#2378](https://github.com/Glavin001/atom-beautify/issues/2378). beautysh arguments usage has changed since version 5.0.0
+
 # v0.33.4 (2018-09-28)
 
 - Fix [#2204](https://github.com/Glavin001/atom-beautify/issues/2204). Auto-remove docker containers after run.

--- a/src/beautifiers/beautysh.coffee
+++ b/src/beautifiers/beautysh.coffee
@@ -32,8 +32,8 @@ module.exports = class BashBeautify extends Beautifier
     file = @tempFile("input", text)
     tabs = options.indent_with_tabs
     if tabs is true
-      beautysh.run([ '-t', '-f', file ])
+      beautysh.run([ '-t', file ])
         .then(=> @readFile file)
     else
-      beautysh.run([ '-i', options.indent_size, '-f', file ])
+      beautysh.run([ '-i', options.indent_size, file ])
         .then(=> @readFile file)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
This removes the -f flag from the beautysh call
-f flag was removed in major release version 5.0.0

### Does this close any currently open issues?
Fixes issue #2378 

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [x] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
   - all old tests are still valid
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
