### PR TITLE
Fix blade @ issue

### DIFF
--- a/examples/simple-jsbeautifyrc/blade/expected/test.blade.php
+++ b/examples/simple-jsbeautifyrc/blade/expected/test.blade.php
@@ -6,7 +6,6 @@
 <script type="text/javascript">
   document.write("@" );
 </script>
-
 <body>
   @section('sidebar')
   This is the {{ $mater }} sidebar.

--- a/examples/simple-jsbeautifyrc/blade/expected/test.blade.php
+++ b/examples/simple-jsbeautifyrc/blade/expected/test.blade.php
@@ -6,6 +6,7 @@
 <script type="text/javascript">
   document.write("@" );
 </script>
+
 <body>
   @section('sidebar')
   This is the {{ $mater }} sidebar.

--- a/examples/simple-jsbeautifyrc/blade/expected/test.blade.php
+++ b/examples/simple-jsbeautifyrc/blade/expected/test.blade.php
@@ -3,6 +3,9 @@
 <head>
   <title>App Name - @yield('title')</title>
 </head>
+<script type="text/javascript">
+  document.write("@" );
+</script>
 
 <body>
   @section('sidebar')

--- a/examples/simple-jsbeautifyrc/blade/original/test.blade.php
+++ b/examples/simple-jsbeautifyrc/blade/original/test.blade.php
@@ -2,6 +2,9 @@
 <head>
 <title>App Name - @yield('title')</title>
 </head>
+<script type="text/javascript">
+     document.write( "@" );
+</script>
 <body>
 @section('sidebar')
 This is the {{ $mater }} sidebar.

--- a/src/beautifiers/js-beautify.coffee
+++ b/src/beautifiers/js-beautify.coffee
@@ -58,7 +58,7 @@ module.exports = class JSBeautify extends Beautifier
             text = text.replace(/\@(?!yield)([^\n\s]*)/ig, "<blade $1 />")
             text = beautifyHTML(text, options)
             # post script (Workaround)
-            text = text.replace(/<blade ([^\n\s]*)\s*\/>/ig, "@$1")
+            text = text.replace(/<blade ([^\n\s]*)\s*\/\s*>/ig, "@$1")
             text = text.replace(/\(\ \'/ig, "('")
             @debug("Beautified HTML: #{text}")
             resolve text


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Current version replaces all `@***` strings to `<blade *** />`, then calls `beautifyHTML`
and then converts the blade tags back to `@***`.
The outcome of  `beautifyHTML` may add a whitespace to the blade, like this: `<blade *** / >`.
The current regex was not able to convert this back to `@***` because of the whitespace.

The regex has been modified, so that it allows whitespaces between the slash `/` and the symbol `>`.

Also added tests
...

### Does this close any currently open issues?
It closes #2414 
...

### Any other comments?
There is something removed after the `<html>` tag in the test file. I am not sure what this is. Sorry!
...

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [] Regenerate documentation with `npm run docs` 
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [x] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
