### PR TITLE
Fix regex blade bugs

### DIFF
--- a/examples/simple-jsbeautifyrc/blade/expected/test.blade.php
+++ b/examples/simple-jsbeautifyrc/blade/expected/test.blade.php
@@ -3,6 +3,9 @@
 <head>
   <title>App Name - @yield('title')</title>
 </head>
+<script type="text/javascript">
+  document.write("@" );
+</script>
 
 <body>
   @section('sidebar')
@@ -12,6 +15,8 @@
   <div class="container">
     @yield('content')
   </div>
+  <p><span>
+      @lang('Hi')</span></p>
 
   @component('alert')
   @slot('title')

--- a/examples/simple-jsbeautifyrc/blade/original/test.blade.php
+++ b/examples/simple-jsbeautifyrc/blade/original/test.blade.php
@@ -2,6 +2,9 @@
 <head>
 <title>App Name - @yield('title')</title>
 </head>
+<script type="text/javascript">
+     document.write( "@" );
+</script>
 <body>
 @section('sidebar')
 This is the {{ $mater }} sidebar.
@@ -10,6 +13,7 @@ This is the {{ $mater }} sidebar.
 <div class="container">
 @yield('content')
 </div>
+<p><span>@lang('Hi')</span></p>
 
 @component('alert')
 @slot('title')
@@ -29,3 +33,4 @@ Forbidden
 @endforeach
 </body>
 </html>
+

--- a/examples/simple-jsbeautifyrc/blade/original/test.blade.php
+++ b/examples/simple-jsbeautifyrc/blade/original/test.blade.php
@@ -33,4 +33,3 @@ Forbidden
 @endforeach
 </body>
 </html>
-

--- a/src/beautifiers/js-beautify.coffee
+++ b/src/beautifiers/js-beautify.coffee
@@ -55,10 +55,10 @@ module.exports = class JSBeautify extends Beautifier
           when "Blade"
             beautifyHTML = require("js-beautify").html
             # pre script (Workaround)
-            text = text.replace(/\@(?!yield)([^\n\s]*)/ig, "<blade $1 />")
+            text = text.replace(/\@(?!yield)([^\n\s\<]*)/ig, "<blade $1 />")
             text = beautifyHTML(text, options)
             # post script (Workaround)
-            text = text.replace(/<blade ([^\n\s]*)\s*\/>/ig, "@$1")
+            text = text.replace(/<blade ([^\n\s]*)\s*\/\s*>/ig, "@$1")
             text = text.replace(/\(\ \'/ig, "('")
             @debug("Beautified HTML: #{text}")
             resolve text


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Beautifying blade files has currently 3 steps

1. Convert blade syntax from `@section(...)` to `<blade (..) />`
2. Beautify regular HTML
3. Convert back.

First issue:
Beautifying the regular HTML may change `<blade (..) />` to `<blade (..) / >` (add a whitespace).
This causes step 3 to fail. 

Second issue:
Its currently assumed that blade syntax will always end with a whitespace. This is not always the case. It may also end by `<` as for example `<p><span>@lang('list.app_74')</span></p>`.

This commits fixes both issues. Both scenarios have been added to the test file.

### Does this close any currently open issues?

Fixes #2414
Fixes #2420

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [x] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
