### PR TITLE
Fix bugs for blade language

### DIFF
--- a/examples/simple-jsbeautifyrc/blade/expected/test.blade.php
+++ b/examples/simple-jsbeautifyrc/blade/expected/test.blade.php
@@ -4,7 +4,7 @@
   <title>App Name - @yield('title')</title>
 </head>
 <script type="text/javascript">
-  document.write("@" );
+  document.write("<blade " / > );
 </script>
 
 <body>
@@ -15,8 +15,7 @@
   <div class="container">
     @yield('content')
   </div>
-  <p><span>
-      @lang('Hi')</span></p>
+  <p><span>@lang('Hi')</span></p>
 
   @component('alert')
   @slot('title')

--- a/examples/simple-jsbeautifyrc/blade/expected/test.blade.php
+++ b/examples/simple-jsbeautifyrc/blade/expected/test.blade.php
@@ -1,7 +1,38 @@
-<script>
-  @foreach ($users as $user) {
-      {
-        $user - > name
-      }
-    } @endforeach
+<html>
+
+<head>
+  <title>App Name - @yield('title')</title>
+</head>
+<script type="text/javascript">
+  document.write("@" );
 </script>
+
+<body>
+  @section('sidebar')
+  This is the {{ $mater }} sidebar.
+  @show
+
+  <div class="container">
+    @yield('content')
+  </div>
+  <p><span>@lang('Hi')</span></p>
+
+  @component('alert')
+  @slot('title')
+  Forbidden
+  @endslot
+  <strong>Whoops!</strong> Something went wrong!
+  @endcomponent
+
+  @foreach ($users as $user)
+  @if ($user->type == 1)
+  @continue
+  @endif
+  <li>{{ $user->name }}</li>
+  @if ($user->number == 5)
+  @break
+  @endif
+  @endforeach
+</body>
+
+</html>

--- a/examples/simple-jsbeautifyrc/blade/expected/test.blade.php
+++ b/examples/simple-jsbeautifyrc/blade/expected/test.blade.php
@@ -1,38 +1,7 @@
-<html>
-
-<head>
-  <title>App Name - @yield('title')</title>
-</head>
-<script type="text/javascript">
-  document.write("<blade " / > );
+<script>
+  @foreach ($users as $user) {
+      {
+        $user - > name
+      }
+    } @endforeach
 </script>
-
-<body>
-  @section('sidebar')
-  This is the {{ $mater }} sidebar.
-  @show
-
-  <div class="container">
-    @yield('content')
-  </div>
-  <p><span>@lang('Hi')</span></p>
-
-  @component('alert')
-  @slot('title')
-  Forbidden
-  @endslot
-  <strong>Whoops!</strong> Something went wrong!
-  @endcomponent
-
-  @foreach ($users as $user)
-  @if ($user->type == 1)
-  @continue
-  @endif
-  <li>{{ $user->name }}</li>
-  @if ($user->number == 5)
-  @break
-  @endif
-  @endforeach
-</body>
-
-</html>

--- a/examples/simple-jsbeautifyrc/blade/expected/test.blade.php
+++ b/examples/simple-jsbeautifyrc/blade/expected/test.blade.php
@@ -3,6 +3,9 @@
 <head>
   <title>App Name - @yield('title')</title>
 </head>
+<script type="text/javascript">
+  document.write("@" );
+</script>
 
 <body>
   @section('sidebar')
@@ -12,6 +15,8 @@
   <div class="container">
     @yield('content')
   </div>
+  <p><span>
+      @lang('Hi')</span></p>
 
   @component('alert')
   @slot('title')

--- a/examples/simple-jsbeautifyrc/blade/original/test.blade.php
+++ b/examples/simple-jsbeautifyrc/blade/original/test.blade.php
@@ -2,6 +2,9 @@
 <head>
 <title>App Name - @yield('title')</title>
 </head>
+<script type="text/javascript">
+     document.write( "@" );
+</script>
 <body>
 @section('sidebar')
 This is the {{ $mater }} sidebar.
@@ -10,6 +13,7 @@ This is the {{ $mater }} sidebar.
 <div class="container">
 @yield('content')
 </div>
+<p><span>@lang('Hi')</span></p>
 
 @component('alert')
 @slot('title')
@@ -29,3 +33,4 @@ Forbidden
 @endforeach
 </body>
 </html>
+

--- a/examples/simple-jsbeautifyrc/blade/original/test.blade.php
+++ b/examples/simple-jsbeautifyrc/blade/original/test.blade.php
@@ -33,4 +33,3 @@ Forbidden
 @endforeach
 </body>
 </html>
-

--- a/src/beautifiers/js-beautify.coffee
+++ b/src/beautifiers/js-beautify.coffee
@@ -55,7 +55,7 @@ module.exports = class JSBeautify extends Beautifier
           when "Blade"
             beautifyHTML = require("js-beautify").html
             # pre script (Workaround)
-            text = text.replace(/\@(?!(?:yield|lang))([^\n\s\<]*)/ig, "<blade $1 />")
+            text = text.replace(/\@(?!(?:yield|lang))([^\n\s]*)/ig, "<blade $1 />")
             text = beautifyHTML(text, options)
             # post script (Workaround)
             text = text.replace(/<blade ([^\n\s]*)\s*\/\s*>/ig, "@$1")

--- a/src/beautifiers/js-beautify.coffee
+++ b/src/beautifiers/js-beautify.coffee
@@ -55,7 +55,7 @@ module.exports = class JSBeautify extends Beautifier
           when "Blade"
             beautifyHTML = require("js-beautify").html
             # pre script (Workaround)
-            text = text.replace(/\@(?!yield)([^\n\s\<]*)/ig, "<blade $1 />")
+            text = text.replace(/\@(?!(?:yield|lang))([^\n\s\<]*)/ig, "<blade $1 />")
             text = beautifyHTML(text, options)
             # post script (Workaround)
             text = text.replace(/<blade ([^\n\s]*)\s*\/\s*>/ig, "@$1")

--- a/src/beautifiers/js-beautify.coffee
+++ b/src/beautifiers/js-beautify.coffee
@@ -58,7 +58,8 @@ module.exports = class JSBeautify extends Beautifier
             text = text.replace(/\@(?!(?:yield|lang))([^\n\s]*)/ig, "<blade $1 />")
             text = beautifyHTML(text, options)
             # post script (Workaround)
-            text = text.replace(/<blade ([^\n\s]*)\s*\/\s*>/ig, "@$1")
+            # possible whitespaces are added in `script` tag
+            text = text.replace(/<\s*blade ([^\n\s]*)\s*\/\s*>/ig, "@$1")
             text = text.replace(/\(\ \'/ig, "('")
             @debug("Beautified HTML: #{text}")
             resolve text

--- a/src/beautifiers/js-beautify.coffee
+++ b/src/beautifiers/js-beautify.coffee
@@ -55,10 +55,10 @@ module.exports = class JSBeautify extends Beautifier
           when "Blade"
             beautifyHTML = require("js-beautify").html
             # pre script (Workaround)
-            text = text.replace(/\@(?!yield)([^\n\s]*)/ig, "<blade $1 />")
+            text = text.replace(/\@(?!yield)([^\n\s\<]*)/ig, "<blade $1 />")
             text = beautifyHTML(text, options)
             # post script (Workaround)
-            text = text.replace(/<blade ([^\n\s]*)\s*\/>/ig, "@$1")
+            text = text.replace(/<blade ([^\n\s]*)\s*\/\s*>/ig, "@$1")
             text = text.replace(/\(\ \'/ig, "('")
             @debug("Beautified HTML: #{text}")
             resolve text


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Beautifying blade files has currently 3 steps

1. Convert blade syntax from `@section(...)` to `<blade (..) />`
2. Beautify regular HTML
3. Convert back.

First issue:
Beautifying the regular HTML may change `<blade (..) />` to `<blade (..) / >` (add a whitespace) if its inside a `<script>` tag. This causes step 3 to fail. 

Second issue:
Its currently assumed that blade syntax will always end with a whitespace or return, except if its a `yield`tag. This exception is also necessary for `@lang` tag, otherwise there will be problems (see #2420 for example)

This commits fixes both issues. Both scenarios have been added to the test file.

### Does this close any currently open issues?

Fixes #2414
Fixes #2420

### Any other comment?

The current pre-regex is this:

    text.replace(/\@(?!(?:yield|lang))([^\n\s]*)/ig, "<blade $1 />")

But not any `@` symbol belongs to a blade modifier. Maybe its better to whitelist all blade-modifier into the regex.

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [x] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
