### PR TITLE
fix: fill callback function into clang-format beautifier

### DIFF
--- a/src/beautifiers/clang-format.coffee
+++ b/src/beautifiers/clang-format.coffee
@@ -81,6 +81,6 @@ module.exports = class ClangFormat extends Beautifier
         @dumpToFile(dumpFile, text)
         ["--style=file"]
         ]).finally( ->
-          fs.unlink(dumpFile)
+          fs.unlink(dumpFile, ->)
         )
     )


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
* This fixes an error happens when executing `clang-format.coffee`, which is caused by missing the second parameter of `fs.unlink` at line 84.
* It fill an empty function into the parameter list, where should put a callback function.

### Does this close any currently open issues?
* This is related to issue #2290, which is closed by the stale bot. However, the bug still exists.

### Any other comments?
* Nope

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
