### PR TITLE
Fixes removal of comment blocks

### DIFF
--- a/src/beautifiers/rubocop.coffee
+++ b/src/beautifiers/rubocop.coffee
@@ -80,8 +80,7 @@ module.exports = class Rubocop extends Beautifier
         # Rubocop output an error if stdout is empty
         return text if stdout.length == 0
 
-        result = stdout.split("====================\n")
-        result = stdout.split("====================\r\n") if result.length == 1
+        result = stdout.split(/\r?\n====================\r?\n/)
 
         result[result.length - 1]
       )


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

The rubocop beautifier will delete partial file contents if the file includes any block comments of this style:

```
    # ===============================================
    # = This is a Ruby block comment  =
    # ===============================================
```

The reason is that we are indiscriminately splitting the debug output from the content on any sequence of 20x `=` characters.

This change will require a full-line match and ignores other occurrences of 20x`=` sequences. It also removes an unnecessary second check, as we are now using a Regex to match the split sequence.

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
