### PR TITLE
[vue] Fix default langs not being beautified

### DIFF
--- a/src/beautifiers/vue-beautifier.coffee
+++ b/src/beautifiers/vue-beautifier.coffee
@@ -23,7 +23,7 @@ module.exports = class VueBeautifier extends Beautifier
             switch lang
               when "pug", "jade"
                 require("pug-beautify")(text, options)
-              when undefined
+              when "html", undefined
                 require("js-beautify").html(text, options)
               else
                 undefined
@@ -45,7 +45,7 @@ module.exports = class VueBeautifier extends Beautifier
                   mode: "beautify"
                 )
                 prettydiff(options)
-              when undefined
+              when "css", undefined
                 require("js-beautify").css(text, options)
               else
                 undefined


### PR DESCRIPTION
Currently `<template lang="html">` and `<style lang="css">` are not being beautified.

### What does this implement/fix? Explain your changes.
Fixes #2374 

### Does this close any currently open issues?

Yes

### Any other comments?
This is a super quick and easy fix

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
