### PR TITLE
Adds comma_first as an option for javascript

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,8 @@ See [examples/simple-jsbeautifyrc/.jsbeautifyrc](examples/simple-jsbeautifyrc/.j
   "preserve_newlines": true,
   "max_preserve_newlines": 2,
   "jslint_happy": true,
-  "indent_handlebars": true
+  "indent_handlebars": true,
+  "comma_first": true
 }
 ```
 
@@ -344,7 +345,8 @@ See [examples/nested-jsbeautifyrc/.jsbeautifyrc](examples/nested-jsbeautifyrc/.j
     "indent_with_tabs": false,
     "preserve_newlines": true,
     "max_preserve_newlines": 2,
-    "jslint_happy": true
+    "jslint_happy": true,
+    "comma_first": true
   },
   "sql": {
     "indent_size": 4,


### PR DESCRIPTION
because after digging thru js-beautify's code:   
```atom-beautify/node-modules/js-beautify/js/lib/beautifier.js    ```
on approximately line 1213 inside the Beautifier.prototype.handle_comma function, you can see on line 1227:

```
} else if  (this._options.comma_first){ // <--------
```
so the option "comma_first" both exists, and is usable and works as expected if you specify the option in your .jsbeautifyrc 
:-)

### What does this implement/fix? Explain your changes.

js-beautify has an option for comma first style. it exists in their code. i just added to the readme so people know it exists

### Does this close any currently open issues?

had i made one rather than solving the problem directly, yeah

### Any other comments?

ezpz. relates to [my other pull request](https://github.com/Glavin001/atom-beautify/pull/2570) which just adds the example to the options.md

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `master` branch
- [x] Regenerate documentation with `npm run docs`
- [x] Add change details to `CHANGELOG.md` under "Next" section
- [x] Added examples for testing to [examples/ directory](examples/)
- [x] Travis CI passes (Mac support)
- [x] AppVeyor passes (Windows support)
