### PR TITLE
adds javascript comma first option to documentation

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -2854,6 +2854,45 @@ Break chained method calls across subsequent lines (Supported by JS Beautify, Pr
     }
 }
 ```
+#####  [Comma First](#comma-first) 
+
+**Namespace**: `js`
+
+**Key**: `comma_first`
+
+**Type**: `boolean`
+
+**Supported Beautifiers**:  [`JS Beautify`](#js-beautify)
+
+**Description**:
+
+Allow comma first formatting (Supported by JS Beautify, Pretty Diff)
+
+**Example `.jsbeautifyrc` Configuration**
+
+```json
+{
+    "js": {
+        "comma_first": true
+    }
+}
+```
+
+```javascript
+// will transform this:
+const obj = {
+    foo: 1,
+    bar: 2
+}
+
+// into this:
+const obj = {
+	foo: 1
+	, bar: 2
+}
+
+```
+
 
 #####  [Content unformatted](#content-unformatted) 
 


### PR DESCRIPTION
See my other [pull request](https://github.com/Glavin001/atom-beautify/pull/2569); js-beautify has an option for comma first formatting; so I added it to the readme and also here so people know about it :-)

### What does this implement/fix? Explain your changes.
It literally just updates a readme to reflect a feature that js-beautify supports out of the box.
...

### Does this close any currently open issues?
No. But it would have if I had made an open issue- which I was going to do before I just did this myself.
...

### Any other comments?
pretty simple. literally just added to the readme and options
...

### Checklist

Check all those that are applicable and complete.

- [ x] Merged with latest `master` branch
- [ x] Regenerate documentation with `npm run docs`
- [ x] Add change details to `CHANGELOG.md` under "Next" section
- [ x] Added examples for testing to [examples/ directory](examples/)
- [ x] Travis CI passes (Mac support)
- [ x] AppVeyor passes (Windows support)
