### PR TITLE
Fix #2597. Regex expected different version string than it received.

### DIFF
--- a/src/beautifiers/black.coffee
+++ b/src/beautifiers/black.coffee
@@ -20,7 +20,10 @@ module.exports = class Black extends Beautifier
           try
             text.match(/black, version (\d+\.\d+)/)[1] + "." + text.match(/b(\d+)$/)[1]
           catch
-            text.match(/black, version (\d+\.\d+)/)[1] + ".0"
+            try
+              text.match(/black, version (\d+\.\d+)/)[1] + ".0"
+            catch
+              text.match(/black, (\d+\.\d+\.\d+)/)[1]
       }
     }
   ]


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Adds support for recent versions of Python formatter Black.

### Does this close any currently open issues?
Fixes #2597

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
